### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Formatting
+        run: cargo fmt --check
+
+      - name: Lint
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --all-targets
+
+      - name: Test
+        run: cargo test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with fmt, clippy, build, and test steps on `ubuntu-latest`
- Triggers on push to `main` and PRs targeting `main`
- Includes concurrency cancellation, `Swatinem/rust-cache@v2`, and `CARGO_INCREMENTAL=0` / `RUSTFLAGS="-D warnings"`

Closes #3

## Test plan

- [ ] CI workflow runs and all 4 steps pass on this PR
- [ ] Verify stale runs are cancelled when pushing new commits