### PR TITLE
Add binary integration tests for CLI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +116,17 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -201,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,9 +263,11 @@ dependencies = [
 name = "dispatch"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "async-trait",
  "clap",
  "dirs",
+ "predicates",
  "reqwest",
  "semver",
  "serde",
@@ -280,6 +320,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -737,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +805,15 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -826,6 +890,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -970,6 +1064,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1291,6 +1397,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1638,6 +1750,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,6 @@ strip = true
 lto = true
 
 [dev-dependencies]
+assert_cmd = "2.2.0"
+predicates = "3.1.4"
 tempfile = "3.27.0"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,391 @@
+use std::process::{Child, Command};
+use std::thread;
+use std::time::Duration;
+
+use assert_cmd::cargo::CommandCargoExt;
+use tempfile::TempDir;
+
+/// Start a `dispatch serve` broker as a background process in the given
+/// temp directory with the given cell ID. Returns the child process handle.
+fn start_broker(dir: &TempDir, cell_id: &str) -> Child {
+    let mut child = Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("--cell-id")
+        .arg(cell_id)
+        .arg("serve")
+        .current_dir(dir.path())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start broker");
+
+    // Wait for the socket to appear.
+    let socket = dir.path().join(".dispatch").join(format!("{cell_id}.sock"));
+    for _ in 0..50 {
+        if socket.exists() {
+            return child;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    child.kill().ok();
+    child.wait().ok();
+    panic!("broker socket did not appear within 2.5s");
+}
+
+/// Build an `assert_cmd::Command` for `dispatch` that runs in the given
+/// temp directory with the given cell ID.
+fn dispatch_cmd(dir: &TempDir, cell_id: &str) -> assert_cmd::Command {
+    let mut cmd = assert_cmd::Command::cargo_bin("dispatch").unwrap();
+    cmd.current_dir(dir.path()).arg("--cell-id").arg(cell_id);
+    cmd
+}
+
+// ── Help & arg-parsing tests ──────────────────────────────────────────
+
+#[test]
+fn help_exits_zero_and_shows_usage() {
+    let mut cmd = assert_cmd::Command::cargo_bin("dispatch").unwrap();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Usage"))
+        .stdout(predicates::str::contains("dispatch"));
+}
+
+#[test]
+fn no_args_exits_non_zero() {
+    let mut cmd = assert_cmd::Command::cargo_bin("dispatch").unwrap();
+    cmd.assert().failure();
+}
+
+// ── Broker lifecycle tests ────────────────────────────────────────────
+
+#[test]
+fn serve_creates_socket_file() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-serve-socket";
+
+    let mut broker = start_broker(&dir, cell_id);
+    let socket = dir.path().join(".dispatch").join(format!("{cell_id}.sock"));
+    assert!(
+        socket.exists(),
+        "socket file should exist while broker runs"
+    );
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── Register + Team round-trip ────────────────────────────────────────
+
+#[test]
+fn register_returns_worker_id() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-register";
+    let mut broker = start_broker(&dir, cell_id);
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "builder",
+            "--description",
+            "test worker",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output).expect("stdout should be valid JSON");
+    assert_eq!(json["status"], "ok");
+    assert!(
+        json["worker_id"].is_string(),
+        "response should contain worker_id"
+    );
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+#[test]
+fn team_lists_registered_workers() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-team";
+    let mut broker = start_broker(&dir, cell_id);
+
+    // Register a worker first.
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "bob",
+            "--role",
+            "tester",
+            "--description",
+            "test worker",
+            "--capability",
+            "rust",
+        ])
+        .assert()
+        .success();
+
+    // Team should list the worker.
+    let output = dispatch_cmd(&dir, cell_id)
+        .arg("team")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output).expect("stdout should be valid JSON");
+    assert_eq!(json["status"], "ok");
+    let workers = json["workers"]
+        .as_array()
+        .expect("workers should be an array");
+    assert_eq!(workers.len(), 1);
+    assert_eq!(workers[0]["name"], "bob");
+    assert_eq!(workers[0]["role"], "tester");
+    assert_eq!(workers[0]["capabilities"][0], "rust");
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── Send + Listen round-trip ──────────────────────────────────────────
+
+#[test]
+fn send_and_listen_round_trip() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-send-listen";
+    let mut broker = start_broker(&dir, cell_id);
+
+    // Register a worker.
+    let reg_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "carol",
+            "--role",
+            "runner",
+            "--description",
+            "receives messages",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let reg: serde_json::Value = serde_json::from_slice(&reg_out).unwrap();
+    let worker_id = reg["worker_id"].as_str().unwrap().to_string();
+
+    // Send a message to the worker.
+    let send_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "send",
+            "--to",
+            &worker_id,
+            "--body",
+            "hello from test",
+            "--from",
+            "test-harness",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let send_json: serde_json::Value = serde_json::from_slice(&send_out).unwrap();
+    assert_eq!(send_json["status"], "ok");
+    assert!(send_json["message_id"].is_string());
+
+    // Listen should return the message immediately.
+    let listen_out = dispatch_cmd(&dir, cell_id)
+        .args(["listen", "--worker-id", &worker_id, "--timeout", "5"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let listen_json: serde_json::Value = serde_json::from_slice(&listen_out).unwrap();
+    assert_eq!(listen_json["status"], "ok");
+    assert_eq!(listen_json["body"], "hello from test");
+    assert_eq!(listen_json["from"], "test-harness");
+    assert_eq!(listen_json["to"], worker_id);
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── Error cases ───────────────────────────────────────────────────────
+
+#[test]
+fn send_to_invalid_worker_returns_error_response() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-send-invalid";
+    let mut broker = start_broker(&dir, cell_id);
+
+    // The broker returns a JSON error response (exit 0) when the
+    // recipient worker does not exist. The CLI only exits non-zero
+    // for transport-level failures, not broker-level errors.
+    let output = dispatch_cmd(&dir, cell_id)
+        .args([
+            "send",
+            "--to",
+            "nonexistent-worker",
+            "--body",
+            "should fail",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output).expect("stdout should be valid JSON");
+    assert_eq!(json["status"], "error");
+    assert!(
+        json["message"]
+            .as_str()
+            .unwrap()
+            .contains("nonexistent-worker"),
+        "error message should mention the missing worker"
+    );
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── Heartbeat ─────────────────────────────────────────────────────────
+
+#[test]
+fn heartbeat_renews_worker_ttl() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-heartbeat";
+    let mut broker = start_broker(&dir, cell_id);
+
+    // Register a worker.
+    let reg_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "dave",
+            "--role",
+            "worker",
+            "--description",
+            "heartbeat test",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let reg: serde_json::Value = serde_json::from_slice(&reg_out).unwrap();
+    let worker_id = reg["worker_id"].as_str().unwrap().to_string();
+
+    // Heartbeat should succeed and return an updated expires_at.
+    let hb_out = dispatch_cmd(&dir, cell_id)
+        .args(["heartbeat", "--worker-id", &worker_id])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let hb_json: serde_json::Value = serde_json::from_slice(&hb_out).unwrap();
+    assert_eq!(hb_json["status"], "ok");
+    assert_eq!(hb_json["worker_id"], worker_id);
+    assert!(
+        hb_json["expires_at"].is_number(),
+        "should return expires_at timestamp"
+    );
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── Listen timeout ────────────────────────────────────────────────────
+
+#[test]
+fn listen_times_out_with_no_messages() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-listen-timeout";
+    let mut broker = start_broker(&dir, cell_id);
+
+    // Register a worker.
+    let reg_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "eve",
+            "--role",
+            "idle",
+            "--description",
+            "timeout test",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let reg: serde_json::Value = serde_json::from_slice(&reg_out).unwrap();
+    let worker_id = reg["worker_id"].as_str().unwrap().to_string();
+
+    // Listen with a very short timeout — no messages are queued.
+    let listen_out = dispatch_cmd(&dir, cell_id)
+        .args(["listen", "--worker-id", &worker_id, "--timeout", "1"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&listen_out).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["worker_id"], worker_id);
+
+    broker.kill().ok();
+    broker.wait().ok();
+}
+
+// ── stdout/stderr separation ──────────────────────────────────────────
+
+#[test]
+fn stdout_is_json_stderr_is_empty_on_success() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-stdio-sep";
+    let mut broker = start_broker(&dir, cell_id);
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .arg("team")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    // stdout must be valid JSON.
+    let _: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    // stderr should be empty (no status messages on success).
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.is_empty(),
+        "stderr should be empty on success, got: {stderr}"
+    );
+
+    broker.kill().ok();
+    broker.wait().ok();
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -355,6 +355,19 @@ fn listen_times_out_with_no_messages() {
     let json: serde_json::Value = serde_json::from_slice(&listen_out).unwrap();
     assert_eq!(json["status"], "ok");
     assert_eq!(json["worker_id"], worker_id);
+    // Confirm this is a timeout response, not a message or heartbeat ack.
+    assert!(
+        json.get("body").is_none(),
+        "timeout should not contain body"
+    );
+    assert!(
+        json.get("message_id").is_none(),
+        "timeout should not contain message_id"
+    );
+    assert!(
+        json.get("expires_at").is_none(),
+        "timeout should not contain expires_at"
+    );
 
     broker.kill().ok();
     broker.wait().ok();


### PR DESCRIPTION
## Summary
- Adds `assert_cmd` and `predicates` as dev-dependencies
- Creates `tests/cli.rs` with 10 binary integration tests exercising the compiled `dispatch` binary end-to-end
- Each test is fully isolated: own `TempDir`, own broker process, own `--cell-id`

## Tests added

| Test | What it verifies |
|------|-----------------|
| `help_exits_zero_and_shows_usage` | `--help` exits 0, prints usage text |
| `no_args_exits_non_zero` | No args exits non-zero (`arg_required_else_help`) |
| `serve_creates_socket_file` | Broker creates `.dispatch/<cell_id>.sock` |
| `register_returns_worker_id` | Registration returns JSON with `worker_id` |
| `team_lists_registered_workers` | Team lists registered workers with correct fields |
| `send_and_listen_round_trip` | Send + listen delivers message end-to-end |
| `send_to_invalid_worker_returns_error_response` | Error JSON for missing recipient |
| `heartbeat_renews_worker_ttl` | Heartbeat returns updated `expires_at` |
| `listen_times_out_with_no_messages` | Listen timeout returns timeout response |
| `stdout_is_json_stderr_is_empty_on_success` | stdout is clean JSON, stderr empty on success |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (66 total: 56 existing + 10 new)
- [x] New tests don't conflict with existing unit/integration tests

Closes #5