### PR TITLE
feat: add `dispatch init` command (#7)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,9 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Initialize a dispatch.config.toml in the current directory
+    Init,
+
     /// Start the embedded broker server on a Unix domain socket
     Serve,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,43 @@ pub fn derive_cell_id(project_root: &Path) -> String {
     format!("cell-{hash:016x}")
 }
 
+/// Config file template written by `dispatch init`.
+const CONFIG_TEMPLATE: &str = "\
+# Dispatch configuration
+# https://github.com/codesoda/dispatch-cli
+
+# Cell identity for this project.
+# If omitted, a stable ID is derived from the project directory path.
+# Override precedence: --cell-id flag > DISPATCH_CELL_ID env var > this value > derived
+# cell_id = \"my-project\"
+";
+
+/// Create a `dispatch.config.toml` in `cwd` with commented-out defaults.
+///
+/// Returns the path to the created file.
+/// Errors if the file already exists in `cwd`.
+/// Warns on stderr if a config exists in a parent directory.
+pub fn init_config(cwd: &Path) -> Result<PathBuf, DispatchError> {
+    let config_path = cwd.join("dispatch.config.toml");
+
+    if config_path.is_file() {
+        return Err(DispatchError::ConfigAlreadyExists { path: config_path });
+    }
+
+    // Check for config in a parent directory (skip cwd itself)
+    if let Some(parent) = cwd.parent() {
+        if let Some((parent_config, _)) = find_config_file(parent) {
+            eprintln!(
+                "Note: found existing config at {}, creating a new one in the current directory",
+                parent_config.display()
+            );
+        }
+    }
+
+    std::fs::write(&config_path, CONFIG_TEMPLATE)?;
+    Ok(config_path)
+}
+
 /// Resolve configuration with full precedence:
 /// CLI flag > env var > config file > derived fallback.
 pub fn resolve_config(
@@ -246,6 +283,57 @@ backend = "https://example.com"
         let resolved =
             resolve_config_inner(Some("from-cli"), Some("from-env"), tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "from-cli");
+    }
+
+    #[test]
+    fn test_init_config_creates_file() {
+        let tmp = TempDir::new().unwrap();
+        let result = init_config(tmp.path());
+        assert!(result.is_ok());
+
+        let path = result.unwrap();
+        assert_eq!(path, tmp.path().join("dispatch.config.toml"));
+        assert!(path.is_file());
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("# cell_id = \"my-project\""));
+
+        // Template must be valid TOML (all active lines are comments)
+        let parsed: Result<ConfigFile, _> = toml::from_str(&contents);
+        assert!(parsed.is_ok());
+    }
+
+    #[test]
+    fn test_init_config_already_exists() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let result = init_config(tmp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "expected 'already exists' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_init_config_with_parent_config() {
+        let tmp = TempDir::new().unwrap();
+        // Config in parent
+        let parent_config = tmp.path().join("dispatch.config.toml");
+        fs::write(&parent_config, "").unwrap();
+
+        // Init in child — should succeed despite parent config
+        let child = tmp.path().join("subdir");
+        fs::create_dir(&child).unwrap();
+
+        let result = init_config(&child);
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        assert_eq!(path, child.join("dispatch.config.toml"));
+        assert!(path.is_file());
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DispatchError {
+    #[error("dispatch.config.toml already exists at {path} -- use a text editor to modify it")]
+    ConfigAlreadyExists { path: PathBuf },
+
     #[error("config not found at {path} -- run `dispatch init` or create dispatch.config.toml")]
     ConfigNotFound { path: PathBuf },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,27 @@ async fn main() {
 
     if let Err(e) = run(cli).await {
         eprintln!("Error: {e}");
-        process::exit(1);
+        let code = match e {
+            dispatch::errors::DispatchError::ConfigAlreadyExists { .. }
+            | dispatch::errors::DispatchError::ConfigNotFound { .. }
+            | dispatch::errors::DispatchError::ConfigInvalid { .. } => 2,
+            _ => 1,
+        };
+        process::exit(code);
     }
 }
 
 async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
     let cwd = std::env::current_dir().map_err(dispatch::errors::DispatchError::Io)?;
+
+    // Handle init before config resolution — it doesn't need an existing config
+    if let Commands::Init = cli.command {
+        let path = dispatch::config::init_config(&cwd)?;
+        println!("{}", path.display());
+        eprintln!("Created dispatch.config.toml");
+        return Ok(());
+    }
+
     let config = resolve_config(cli.cell_id.as_deref(), &cwd)?;
 
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
@@ -38,6 +53,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         }
         cmd => {
             let request = match cmd {
+                Commands::Init => unreachable!(),
                 Commands::Serve => unreachable!(),
                 Commands::Register {
                     name,


### PR DESCRIPTION
## Summary
- Adds `dispatch init` subcommand that creates `dispatch.config.toml` in the current directory with commented-out options
- Errors with exit code 2 if config already exists in cwd; warns (but proceeds) if one exists in a parent directory
- Config errors (`ConfigAlreadyExists`, `ConfigNotFound`, `ConfigInvalid`) now exit with code 2 instead of 1

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 59 tests pass, including 3 new: `test_init_config_creates_file`, `test_init_config_already_exists`, `test_init_config_with_parent_config`
- [ ] Manual: `dispatch init` in a fresh dir creates the file and prints its path
- [ ] Manual: `dispatch init` again in the same dir errors with exit code 2
- [ ] `dispatch --help` lists the `init` subcommand

Closes #7