### PR TITLE
feat: add tag-driven release workflow with changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  check:
+    name: CI checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Rust checks
+        run: cargo fmt --check && cargo clippy -- -D warnings && cargo build --locked && cargo test --locked
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          name="dispatch-${tag}-${{ matrix.target }}"
+          mkdir -p "dist/${name}"
+          cp "target/${{ matrix.target }}/release/dispatch" "dist/${name}/"
+          cd dist
+          tar czf "${name}.tar.gz" "${name}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dispatch-${{ matrix.target }}
+          path: dist/*.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.tar.gz > checksums-sha256.txt
+
+      - name: Extract changelog for release
+        id: changelog
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          # Extract the section between this version's heading and the next heading
+          notes=$(awk -v ver="$version" '
+            /^## \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") found=1; next
+            }
+            found { print }
+          ' CHANGELOG.md)
+          # Fail if we got nothing — forces you to update CHANGELOG.md before tagging
+          if [ -z "$notes" ]; then
+            echo "::error::No CHANGELOG.md entry found for version ${version}"
+            exit 1
+          fi
+          # Write to file to avoid quoting issues
+          echo "$notes" > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "${tag}" \
+            --title "${tag}" \
+            --notes-file release-notes.md \
+            --draft \
+            artifacts/*.tar.gz \
+            artifacts/checksums-sha256.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Rust checks
-        run: cargo fmt --check && cargo clippy -- -D warnings && cargo build --locked && cargo test --locked
+        run: cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo build --all-targets --locked && cargo test --locked
 
   build:
     name: Build ${{ matrix.target }}
@@ -86,7 +86,6 @@ jobs:
           sha256sum *.tar.gz > checksums-sha256.txt
 
       - name: Extract changelog for release
-        id: changelog
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           version="${tag#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-11
+
+### Added
+- CLI skeleton with Clap derive API (`dispatch --help`, `--version`)
+- Configuration resolution with `dispatch init` to scaffold `dispatch.toml`
+- Embedded local broker server with `dispatch serve`
+- Worker registration, team listing, and heartbeat monitoring
+- Direct message sending between workers
+- Long-poll listen loop for receiving messages
+- Stale worker detection and refresh control messages
+- Trait-based backend module with local implementation
+- Binary integration tests for all CLI commands
+- GitHub Actions CI workflow (fmt, clippy, build, test)
+
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/codesoda/dispatch-cli/releases/tag/v0.1.0


### PR DESCRIPTION
Closes #11

## Summary
- Add `CHANGELOG.md` in Keep a Changelog format with the 0.1.0 entry covering all features to date
- Add `.github/workflows/release.yml` — a three-job pipeline (check → build → release) triggered on `v*` tags
- Builds `aarch64-apple-darwin` binary, packages as `dispatch-{tag}-{target}.tar.gz`
- Generates SHA256 checksums, extracts release notes from CHANGELOG.md, and creates a **draft** GitHub release
- Workflow fails if no matching changelog entry exists for the tagged version

## Test plan
- [ ] Verify `release.yml` syntax is valid (CI will check via `actionlint` or manual review)
- [ ] After merge, test by tagging `v0.1.0` and confirming the workflow creates a draft release with the correct artifacts
- [ ] Verify the changelog extraction works by checking the release notes match the `## [0.1.0]` section