### PR TITLE
fix: move broker socket to /tmp to avoid SUN_LEN limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tasks
 scripts
 target/
-.claude
+/.claude
+dispatch.config.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-11
+
+### Fixed
+- Broker socket path moved to `/tmp/dispatch-cli/sockets/` to avoid Unix domain socket `SUN_LEN` limit (104 bytes on macOS) when project paths are deeply nested
+
+### Changed
+- Workflow example now includes simulated execution delays for a more realistic demo (~14s total pipeline)
+
 ## [0.1.0] - 2026-04-11
 
 ### Added
@@ -21,5 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary integration tests for all CLI commands
 - GitHub Actions CI workflow (fmt, clippy, build, test)
 
-[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/codesoda/dispatch-cli/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/examples/workflow.sh
+++ b/examples/workflow.sh
@@ -156,6 +156,7 @@ run_planner() {
 
   log_planner "received task: $task"
   log_planner "creating implementation plan..."
+  sleep 2
 
   # Simulate planning work
   local plan
@@ -195,6 +196,7 @@ run_implementer() {
 
   log_implementer "received plan for: $task ($steps steps)"
   log_implementer "implementing..."
+  sleep 3
 
   # Simulate implementation work
   local implementation
@@ -232,8 +234,11 @@ run_reviewer() {
   files=$(echo "$body" | jq -r '.files_changed // empty')
 
   log_reviewer "reviewing: $task (files: $files)"
+  sleep 1
   log_reviewer "checking code quality..."
+  sleep 1
   log_reviewer "checking security..."
+  sleep 1
 
   # Simulate review work
   local review
@@ -271,6 +276,7 @@ run_test_runner() {
 
   log_test "running tests for: $task (review: $verdict)"
   log_test "executing test suite..."
+  sleep 2
 
   # Simulate test execution
   local results
@@ -311,8 +317,11 @@ run_shipper() {
   coverage=$(echo "$body" | jq -r '.coverage_pct // empty')
 
   log_shipper "shipping: $task (tests: $test_result, coverage: ${coverage}%)"
+  sleep 1
   log_shipper "creating release..."
+  sleep 1
   log_shipper "deploying..."
+  sleep 1
 
   log_shipper "shipped successfully!"
 }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -228,11 +228,13 @@ fn now_secs() -> u64 {
 
 /// Derive the Unix domain socket path for a given cell identity.
 ///
-/// Socket is placed in `<project_root>/.dispatch/<cell_id>.sock`.
-fn socket_path(project_root: &Path, cell_id: &str) -> PathBuf {
-    project_root
-        .join(".dispatch")
-        .join(format!("{cell_id}.sock"))
+/// Socket is placed in `/tmp/dispatch-cli/sockets/<cell_id>.sock`.
+/// The cell_id already encodes the project identity (hashed canonical path),
+/// so no additional path components are needed. Using `/tmp` avoids the
+/// Unix domain socket `SUN_LEN` limit (104 bytes on macOS) that triggers
+/// when project paths are deeply nested.
+fn socket_path(_project_root: &Path, cell_id: &str) -> PathBuf {
+    PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"))
 }
 
 /// Check whether a broker is already running for this cell by testing
@@ -573,7 +575,7 @@ mod tests {
         let path = socket_path(Path::new("/home/user/project"), "cell-abc123");
         assert_eq!(
             path,
-            PathBuf::from("/home/user/project/.dispatch/cell-abc123.sock")
+            PathBuf::from("/tmp/dispatch-cli/sockets/cell-abc123.sock")
         );
     }
 
@@ -710,6 +712,9 @@ mod tests {
 
         // Create socket directory and a stale socket file.
         std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
+        // Remove any leftover real socket from a previous run before
+        // creating a fake stale file.
+        let _ = std::fs::remove_file(&sock);
         std::fs::write(&sock, "stale").unwrap();
 
         // Starting serve should clean up the stale socket and bind fresh.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,6 +8,12 @@ use tempfile::TempDir;
 /// Start a `dispatch serve` broker as a background process in the given
 /// temp directory with the given cell ID. Returns the child process handle.
 fn start_broker(dir: &TempDir, cell_id: &str) -> Child {
+    // Remove any stale socket from a previous test run so the broker
+    // can bind cleanly.
+    let socket =
+        std::path::PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"));
+    let _ = std::fs::remove_file(&socket);
+
     let mut child = Command::cargo_bin("dispatch")
         .unwrap()
         .arg("--cell-id")
@@ -18,9 +24,6 @@ fn start_broker(dir: &TempDir, cell_id: &str) -> Child {
         .stderr(std::process::Stdio::null())
         .spawn()
         .expect("failed to start broker");
-
-    // Wait for the socket to appear.
-    let socket = dir.path().join(".dispatch").join(format!("{cell_id}.sock"));
     for _ in 0..50 {
         if socket.exists() {
             return child;
@@ -66,7 +69,8 @@ fn serve_creates_socket_file() {
     let cell_id = "test-serve-socket";
 
     let mut broker = start_broker(&dir, cell_id);
-    let socket = dir.path().join(".dispatch").join(format!("{cell_id}.sock"));
+    let socket =
+        std::path::PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"));
     assert!(
         socket.exists(),
         "socket file should exist while broker runs"


### PR DESCRIPTION
## Summary

Closes a bug where deeply nested project paths (e.g. git worktrees) exceeded the 104-byte Unix domain socket path limit on macOS, crashing the broker.

- Socket now lives at `/tmp/dispatch-cli/sockets/<cell_id>.sock` — the cell_id already encodes the project identity via path hash, so no additional path components are needed
- Bumps version to 0.1.1 with CHANGELOG entry
- Adds simulated execution delays to the workflow example (~14s pipeline)
- Updates `.gitignore` to ignore generated `dispatch.config.toml` and scopes `/.claude` ignore to repo root only

## Test plan

- [ ] `cargo test --locked` — all 69 tests pass (unit + integration)
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean
- [ ] Run `dispatch serve` from a deeply nested path (e.g. a git worktree) — no SUN_LEN error
- [ ] Run `./examples/workflow.sh` — pipeline completes in ~14s with visible pauses