### PR TITLE
feat: add --monitor dashboard and --ttl for register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-12
+
+### Added
+- `dispatch serve --monitor <PORT>` — optional HTTP dashboard showing live team list and event stream via SSE
+- Dark-themed monitor UI embedded in the binary (no external files), auto-refreshes team every 2s
+
 ## [0.1.1] - 2026-04-11
 
 ### Fixed
@@ -29,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary integration tests for all CLI commands
 - GitHub Actions CI workflow (fmt, clippy, build, test)
 
-[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/codesoda/dispatch-cli/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,12 +313,14 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
+ "axum",
  "clap",
  "dirs",
+ "futures-util",
  "predicates",
  "reqwest",
  "semver",
@@ -361,6 +415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -479,6 +545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +563,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -769,10 +842,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1269,6 +1354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1677,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1619,6 +1716,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 
@@ -19,6 +19,8 @@ uuid = { version = "1", features = ["v4"] }
 serde_json = "1"
 dirs = "6"
 async-trait = "0.1.89"
+axum = "0.8"
+futures-util = "0.3"
 
 [profile.release]
 strip = true

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::broadcast;
 use tokio::sync::{Mutex, Notify};
 use tracing::instrument;
 
@@ -18,6 +19,15 @@ const DEFAULT_WORKER_TTL_SECS: u64 = 300;
 /// Default listen timeout in seconds.
 const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 
+/// Event emitted by the broker for the monitor dashboard.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BrokerEvent {
+    pub kind: String,
+    pub worker_id: String,
+    pub detail: String,
+    pub timestamp: u64,
+}
+
 /// Local backend that uses a Unix domain socket for IPC.
 ///
 /// The broker runs in-process with in-memory state. Clients connect
@@ -26,13 +36,15 @@ const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 pub struct LocalBackend {
     project_root: PathBuf,
     cell_id: String,
+    monitor_port: Option<u16>,
 }
 
 impl LocalBackend {
-    pub fn new(project_root: &Path, cell_id: &str) -> Self {
+    pub fn new(project_root: &Path, cell_id: &str, monitor_port: Option<u16>) -> Self {
         Self {
             project_root: project_root.to_path_buf(),
             cell_id: cell_id.to_string(),
+            monitor_port,
         }
     }
 }
@@ -42,7 +54,7 @@ impl super::Backend for LocalBackend {
     /// Start the broker server on a Unix domain socket, blocking until
     /// a shutdown signal (SIGINT/SIGTERM) is received.
     async fn serve(&self) -> Result<(), DispatchError> {
-        serve(&self.project_root, &self.cell_id).await
+        serve(&self.project_root, &self.cell_id, self.monitor_port).await
     }
 
     /// Send a request to the broker over a Unix domain socket and
@@ -121,23 +133,26 @@ impl BrokerState {
         role: String,
         description: String,
         capabilities: Vec<String>,
+        ttl_secs: Option<u64>,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
         let now = now_secs();
+        let ttl = ttl_secs.unwrap_or(DEFAULT_WORKER_TTL_SECS);
         let worker = Worker {
             id: id.clone(),
             name,
             role,
             description,
             capabilities,
-            expires_at: now + DEFAULT_WORKER_TTL_SECS,
+            expires_at: now + ttl,
         };
         self.workers.insert(id.clone(), worker);
         id
     }
 
     /// Remove workers whose TTL has expired, including their mailboxes and notifiers.
-    pub fn evict_expired(&mut self) {
+    /// Returns the IDs of workers that were evicted.
+    pub fn evict_expired(&mut self) -> Vec<String> {
         let now = now_secs();
         let expired_ids: Vec<String> = self
             .workers
@@ -150,6 +165,7 @@ impl BrokerState {
             self.mailboxes.remove(id);
             self.notifiers.remove(id);
         }
+        expired_ids
     }
 
     /// Return a list of all active (non-expired) workers.
@@ -268,7 +284,11 @@ async fn check_no_existing_broker(socket: &Path, cell_id: &str) -> Result<(), Di
 /// Listens on a Unix domain socket and handles JSON-line requests.
 /// Returns when a shutdown signal (SIGINT/SIGTERM) is received.
 #[instrument(skip_all, fields(cell_id, socket_path))]
-pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchError> {
+pub async fn serve(
+    project_root: &Path,
+    cell_id: &str,
+    monitor_port: Option<u16>,
+) -> Result<(), DispatchError> {
     let socket = socket_path(project_root, cell_id);
 
     // Ensure parent directory exists.
@@ -290,10 +310,25 @@ pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchErr
     );
 
     let state = Arc::new(Mutex::new(BrokerState::new()));
+    let (event_tx, _) = broadcast::channel::<BrokerEvent>(256);
+
+    // Optionally start the HTTP monitor dashboard.
+    if let Some(port) = monitor_port {
+        let monitor_state = super::monitor::MonitorState {
+            broker: Arc::clone(&state),
+            events: event_tx.clone(),
+        };
+        tokio::spawn(async move {
+            if let Err(e) = super::monitor::run_monitor(port, monitor_state).await {
+                tracing::error!(error = %e, "monitor server error");
+            }
+        });
+        eprintln!("dispatch serve: monitor dashboard at http://localhost:{port}");
+    }
 
     // Run until shutdown signal.
     let result = tokio::select! {
-        res = accept_loop(&listener, state) => res,
+        res = accept_loop(&listener, state, event_tx) => res,
         _ = shutdown_signal() => {
             tracing::info!("shutdown signal received");
             eprintln!("dispatch serve: shutting down");
@@ -315,12 +350,14 @@ pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchErr
 async fn accept_loop(
     listener: &UnixListener,
     state: Arc<Mutex<BrokerState>>,
+    event_tx: broadcast::Sender<BrokerEvent>,
 ) -> Result<(), DispatchError> {
     loop {
         let (stream, _addr) = listener.accept().await.map_err(DispatchError::Io)?;
         let state = Arc::clone(&state);
+        let event_tx = event_tx.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, state).await {
+            if let Err(e) = handle_connection(stream, state, event_tx).await {
                 tracing::error!(error = %e, "connection handler error");
             }
         });
@@ -332,7 +369,8 @@ async fn accept_loop(
 /// Reads one JSON line, processes it, writes one JSON line response, then closes.
 async fn handle_connection(
     stream: UnixStream,
-    _state: Arc<Mutex<BrokerState>>,
+    state: Arc<Mutex<BrokerState>>,
+    event_tx: broadcast::Sender<BrokerEvent>,
 ) -> Result<(), DispatchError> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -350,7 +388,7 @@ async fn handle_connection(
     tracing::debug!(request = %line, "received request");
 
     let response = match serde_json::from_str::<BrokerRequest>(line) {
-        Ok(request) => handle_request(request, _state).await,
+        Ok(request) => handle_request(request, state, &event_tx).await,
         Err(e) => BrokerResponse::Error {
             message: format!("invalid request: {e}"),
         },
@@ -366,18 +404,45 @@ async fn handle_connection(
     Ok(())
 }
 
+/// Emit a broker event (best-effort, ignores send failures).
+fn emit_event(tx: &broadcast::Sender<BrokerEvent>, kind: &str, worker_id: &str, detail: &str) {
+    let _ = tx.send(BrokerEvent {
+        kind: kind.to_string(),
+        worker_id: worker_id.to_string(),
+        detail: detail.to_string(),
+        timestamp: now_secs(),
+    });
+}
+
 /// Route a parsed request to the appropriate handler.
-async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) -> BrokerResponse {
+async fn handle_request(
+    request: BrokerRequest,
+    state: Arc<Mutex<BrokerState>>,
+    event_tx: &broadcast::Sender<BrokerEvent>,
+) -> BrokerResponse {
     match request {
         BrokerRequest::Register {
             name,
             role,
             description,
             capabilities,
+            ttl_secs,
         } => {
             let mut state = state.lock().await;
-            let worker_id = state.register_worker(name, role, description, capabilities);
+            let worker_id = state.register_worker(
+                name.clone(),
+                role.clone(),
+                description,
+                capabilities,
+                ttl_secs,
+            );
             tracing::info!(worker_id = %worker_id, "worker registered");
+            emit_event(
+                event_tx,
+                "register",
+                &worker_id,
+                &format!("{name} ({role})"),
+            );
             BrokerResponse::Ok {
                 payload: ResponsePayload::WorkerRegistered { worker_id },
             }
@@ -395,6 +460,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             match state.send_message(to.clone(), body, from) {
                 Some(message_id) => {
                     tracing::info!(message_id = %message_id, to = %to, "message queued");
+                    emit_event(
+                        event_tx,
+                        "send",
+                        &to,
+                        &format!("message {}", &message_id[..8]),
+                    );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::MessageAck { message_id },
                     }
@@ -417,7 +488,10 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             // Check worker exists and renew TTL; get notifier and try immediate pop.
             let (notifier, immediate_msg) = {
                 let mut s = state.lock().await;
-                s.evict_expired();
+                let expired = s.evict_expired();
+                for id in &expired {
+                    emit_event(event_tx, "expire", id, "worker expired");
+                }
                 if !s.workers.contains_key(&worker_id) {
                     return BrokerResponse::Error {
                         message: format!("worker not found or expired: {worker_id}"),
@@ -435,6 +509,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             // If a message was immediately available, return it.
             if let Some(msg) = immediate_msg {
                 tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: immediate delivery");
+                emit_event(
+                    event_tx,
+                    "deliver",
+                    &worker_id,
+                    &format!("message {}", &msg.message_id[..8]),
+                );
                 return BrokerResponse::Ok {
                     payload: ResponsePayload::Message {
                         message_id: msg.message_id,
@@ -454,6 +534,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
                 let mut s = state.lock().await;
                 if let Some(msg) = s.pop_message(&worker_id) {
                     tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: delivered after wait");
+                    emit_event(
+                        event_tx,
+                        "deliver",
+                        &worker_id,
+                        &format!("message {}", &msg.message_id[..8]),
+                    );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::Message {
                             message_id: msg.message_id,
@@ -482,6 +568,7 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             match state.heartbeat_worker(&worker_id) {
                 Some(expires_at) => {
                     tracing::info!(worker_id = %worker_id, expires_at, "heartbeat renewed");
+                    emit_event(event_tx, "heartbeat", &worker_id, "TTL renewed");
                     BrokerResponse::Ok {
                         payload: ResponsePayload::HeartbeatAck {
                             worker_id,
@@ -526,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_broker_not_running() {
         let tmp = TempDir::new().unwrap();
-        let backend = LocalBackend::new(tmp.path(), "nonexistent-cell");
+        let backend = LocalBackend::new(tmp.path(), "nonexistent-cell", None);
 
         let result = backend.send_request(&BrokerRequest::Team).await;
         assert!(result.is_err());
@@ -547,12 +634,12 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "client-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "client-test", None).await });
 
         // Wait for broker to start.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let backend = LocalBackend::new(&project_root, cell_id);
+        let backend = LocalBackend::new(&project_root, cell_id, None);
         let response = backend.send_request(&BrokerRequest::Team).await;
         assert!(response.is_ok(), "expected Ok response, got: {response:?}");
 
@@ -639,7 +726,7 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "test-cell").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "test-cell", None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -685,7 +772,7 @@ mod tests {
         });
 
         // Try to start second broker — should fail.
-        let result = serve(&project_root, cell_id).await;
+        let result = serve(&project_root, cell_id, None).await;
         assert!(result.is_err());
 
         match result.unwrap_err() {
@@ -719,7 +806,7 @@ mod tests {
 
         // Starting serve should clean up the stale socket and bind fresh.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "restart-cell").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "restart-cell", None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -743,12 +830,14 @@ mod tests {
             "planner".into(),
             "Plans things".into(),
             vec!["plan:create plans".into()],
+            None,
         );
         let id2 = state.register_worker(
             "worker-b".into(),
             "coder".into(),
             "Writes code".into(),
             vec![],
+            None,
         );
         assert_ne!(id1, id2, "each registration must produce a unique ID");
         assert_eq!(state.workers.len(), 2);
@@ -762,6 +851,7 @@ mod tests {
             "reviewer".into(),
             "Reviews pull requests".into(),
             vec!["review:code".into(), "review:docs".into()],
+            None,
         );
         let worker = state.workers.get(&id).unwrap();
         assert_eq!(worker.name, "my-worker");
@@ -778,7 +868,13 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let id = state.register_worker("ttl-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "ttl-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         let worker = state.workers.get(&id).unwrap();
         // Should expire roughly DEFAULT_WORKER_TTL_SECS from now.
         assert!(worker.expires_at >= now + DEFAULT_WORKER_TTL_SECS - 1);
@@ -788,7 +884,13 @@ mod tests {
     #[test]
     fn test_evict_expired_workers() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("soon-expired".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "soon-expired".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         // Manually set expiry to the past.
         state.workers.get_mut(&id).unwrap().expires_at = 0;
         state.evict_expired();
@@ -803,7 +905,7 @@ mod tests {
 
         // Start broker.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "reg-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "reg-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Send register request via raw socket.
@@ -849,7 +951,7 @@ mod tests {
         let project_root = tmp.path().to_path_buf();
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "cap-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "cap-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, "cap-test");
@@ -911,9 +1013,14 @@ mod tests {
     fn test_list_workers_excludes_expired() {
         let mut state = BrokerState::new();
         let active_id =
-            state.register_worker("active".into(), "coder".into(), "desc".into(), vec![]);
-        let expired_id =
-            state.register_worker("expired".into(), "coder".into(), "desc".into(), vec![]);
+            state.register_worker("active".into(), "coder".into(), "desc".into(), vec![], None);
+        let expired_id = state.register_worker(
+            "expired".into(),
+            "coder".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         // Expire one worker.
         state.workers.get_mut(&expired_id).unwrap().expires_at = 0;
 
@@ -925,7 +1032,13 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_renews_ttl() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("hb-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "hb-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         let original_expiry = state.workers.get(&id).unwrap().expires_at;
 
         // Manually lower the expiry to simulate time passing.
@@ -947,7 +1060,13 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_expired() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("exp-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "exp-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         state.workers.get_mut(&id).unwrap().expires_at = 0;
 
         assert!(
@@ -963,7 +1082,7 @@ mod tests {
         let cell_id = "team-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "team-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "team-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1002,7 +1121,7 @@ mod tests {
         let cell_id = "hb-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "hb-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1034,7 +1153,7 @@ mod tests {
         let cell_id = "hb-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "hb-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1058,7 +1177,8 @@ mod tests {
     #[test]
     fn test_send_message_queues_in_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let msg_id = state.send_message(worker_id.clone(), "hello".into(), Some("sender-1".into()));
         assert!(msg_id.is_some(), "send_message should return a message ID");
@@ -1082,8 +1202,13 @@ mod tests {
     #[test]
     fn test_send_message_expired_recipient() {
         let mut state = BrokerState::new();
-        let worker_id =
-            state.register_worker("expiring".into(), "role".into(), "desc".into(), vec![]);
+        let worker_id = state.register_worker(
+            "expiring".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         state.workers.get_mut(&worker_id).unwrap().expires_at = 0;
 
         let result = state.send_message(worker_id, "hello".into(), None);
@@ -1093,7 +1218,8 @@ mod tests {
     #[test]
     fn test_send_message_unique_ids() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let id1 = state
             .send_message(worker_id.clone(), "msg1".into(), None)
@@ -1108,7 +1234,8 @@ mod tests {
     #[test]
     fn test_send_message_without_from() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let msg_id = state
             .send_message(worker_id.clone(), "anon msg".into(), None)
@@ -1125,7 +1252,7 @@ mod tests {
         let cell_id = "send-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1166,7 +1293,7 @@ mod tests {
         let cell_id = "send-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1196,7 +1323,8 @@ mod tests {
     #[test]
     fn test_pop_message_returns_fifo_order() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         state.send_message(worker_id.clone(), "first".into(), None);
         state.send_message(worker_id.clone(), "second".into(), None);
 
@@ -1210,7 +1338,8 @@ mod tests {
     #[test]
     fn test_pop_message_empty_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         assert!(state.pop_message(&worker_id).is_none());
     }
 
@@ -1223,7 +1352,8 @@ mod tests {
     #[test]
     fn test_get_notifier_returns_same_instance() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         let n1 = state.get_notifier(&worker_id);
         let n2 = state.get_notifier(&worker_id);
         assert!(Arc::ptr_eq(&n1, &n2), "same worker should get same Notify");
@@ -1236,7 +1366,7 @@ mod tests {
         let cell_id = "listen-imm-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-imm-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-imm-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1282,7 +1412,7 @@ mod tests {
         let cell_id = "listen-to-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-to-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-to-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1321,7 +1451,7 @@ mod tests {
         let cell_id = "listen-lp-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-lp-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-lp-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1373,7 +1503,7 @@ mod tests {
         let cell_id = "listen-ttl-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-ttl-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-ttl-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1421,7 +1551,7 @@ mod tests {
         let cell_id = "listen-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1449,7 +1579,8 @@ mod tests {
         let cell_id = "listen-fifo-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-fifo-test").await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&root, "listen-fifo-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1494,7 +1625,7 @@ mod tests {
         let cell_id = "send-multi-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-multi-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-multi-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod local;
+pub mod monitor;
 
 use async_trait::async_trait;
 
@@ -27,9 +28,14 @@ pub fn create_backend(
     backend_name: Option<&str>,
     project_root: &std::path::Path,
     cell_id: &str,
+    monitor_port: Option<u16>,
 ) -> Result<Box<dyn Backend>, DispatchError> {
     match backend_name.unwrap_or("local") {
-        "local" => Ok(Box::new(local::LocalBackend::new(project_root, cell_id))),
+        "local" => Ok(Box::new(local::LocalBackend::new(
+            project_root,
+            cell_id,
+            monitor_port,
+        ))),
         other => Err(DispatchError::UnknownBackend {
             name: other.to_string(),
         }),

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dispatch Monitor</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; background: #0d1117; color: #c9d1d9; }
+  .header { padding: 12px 20px; border-bottom: 1px solid #21262d; display: flex; align-items: center; gap: 12px; }
+  .header h1 { font-size: 14px; font-weight: 600; color: #58a6ff; }
+  .header .cell { font-size: 12px; color: #8b949e; }
+  .container { display: grid; grid-template-columns: 1fr 1fr; height: calc(100vh - 45px); }
+  .pane { padding: 16px; overflow-y: auto; }
+  .pane:first-child { border-right: 1px solid #21262d; }
+  .pane h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: #8b949e; margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th { text-align: left; padding: 6px 8px; color: #8b949e; border-bottom: 1px solid #21262d; font-weight: 500; }
+  td { padding: 6px 8px; border-bottom: 1px solid #161b22; }
+  .role { color: #d2a8ff; }
+  .id { color: #8b949e; font-size: 11px; }
+  .event-log { display: flex; flex-direction: column; gap: 2px; }
+  .event { font-size: 12px; padding: 4px 8px; border-radius: 4px; display: flex; gap: 12px; }
+  .event .ts { color: #484f58; min-width: 60px; }
+  .event .kind { min-width: 72px; font-weight: 600; }
+  .event .detail { color: #8b949e; }
+  .kind-register { color: #3fb950; }
+  .kind-send { color: #d29922; }
+  .kind-deliver { color: #58a6ff; }
+  .kind-heartbeat { color: #484f58; }
+  .kind-expire { color: #f85149; }
+  .empty { color: #484f58; font-style: italic; font-size: 12px; }
+  .status-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: #3fb950; margin-right: 6px; }
+  .worker-count { color: #8b949e; font-size: 12px; font-weight: 400; }
+</style>
+</head>
+<body>
+<div class="header">
+  <span class="status-dot"></span>
+  <h1>Dispatch Monitor</h1>
+  <span class="cell" id="cell-id"></span>
+</div>
+<div class="container">
+  <div class="pane">
+    <h2>Team <span class="worker-count" id="worker-count"></span></h2>
+    <table>
+      <thead><tr><th>Name</th><th>Role</th><th>ID</th><th>TTL</th></tr></thead>
+      <tbody id="team-body"><tr><td colspan="4" class="empty">No workers registered</td></tr></tbody>
+    </table>
+  </div>
+  <div class="pane">
+    <h2>Events</h2>
+    <div class="event-log" id="event-log">
+      <div class="empty">Waiting for events...</div>
+    </div>
+  </div>
+</div>
+<script>
+async function refreshTeam() {
+  try {
+    const resp = await fetch('/api/team');
+    const workers = await resp.json();
+    const tbody = document.getElementById('team-body');
+    const count = document.getElementById('worker-count');
+    count.textContent = `(${workers.length})`;
+    if (workers.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="4" class="empty">No workers registered</td></tr>';
+      return;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    tbody.innerHTML = workers.map(w => {
+      const ttl = Math.max(0, w.expires_at - now);
+      return `<tr><td>${esc(w.name)}</td><td class="role">${esc(w.role)}</td><td class="id">${esc(w.id.slice(0,8))}...</td><td>${ttl}s</td></tr>`;
+    }).join('');
+  } catch(e) { /* ignore fetch errors */ }
+}
+setInterval(refreshTeam, 2000);
+refreshTeam();
+
+const log = document.getElementById('event-log');
+let firstEvent = true;
+const es = new EventSource('/api/events');
+es.addEventListener('broker', (e) => {
+  if (firstEvent) { log.innerHTML = ''; firstEvent = false; }
+  const ev = JSON.parse(e.data);
+  const d = new Date(ev.timestamp * 1000);
+  const ts = d.toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  const el = document.createElement('div');
+  el.className = 'event';
+  el.innerHTML = `<span class="ts">${ts}</span><span class="kind kind-${esc(ev.kind)}">${esc(ev.kind)}</span><span class="detail">${esc(ev.detail)}</span>`;
+  log.prepend(el);
+  if (log.children.length > 500) log.removeChild(log.lastChild);
+  refreshTeam();
+});
+es.onerror = () => { /* reconnect is automatic */ };
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+</script>
+</body>
+</html>

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -1,0 +1,70 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::Html;
+use axum::routing::get;
+use axum::Router;
+use futures_util::stream::Stream;
+use tokio::sync::{broadcast, Mutex};
+
+use super::local::{BrokerEvent, BrokerState};
+
+/// Shared state for the monitor HTTP server.
+#[derive(Clone)]
+pub struct MonitorState {
+    pub broker: Arc<Mutex<BrokerState>>,
+    pub events: broadcast::Sender<BrokerEvent>,
+}
+
+/// Start the HTTP monitor dashboard on the given port.
+pub async fn run_monitor(
+    port: u16,
+    state: MonitorState,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let app = Router::new()
+        .route("/", get(dashboard))
+        .route("/api/team", get(api_team))
+        .route("/api/events", get(api_events))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+    tracing::info!(port, "monitor dashboard listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Serve the embedded HTML dashboard.
+async fn dashboard() -> Html<&'static str> {
+    Html(include_str!("monitor.html"))
+}
+
+/// Return the current team as JSON.
+async fn api_team(State(state): State<MonitorState>) -> axum::Json<Vec<crate::protocol::Worker>> {
+    let mut broker = state.broker.lock().await;
+    let workers = broker.list_workers();
+    axum::Json(workers)
+}
+
+/// Stream broker events via Server-Sent Events.
+async fn api_events(
+    State(state): State<MonitorState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.events.subscribe();
+
+    let stream = futures_util::stream::unfold(rx, |mut rx| async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let sse_event = Event::default().event("broker").json_data(&event).unwrap();
+                    return Some((Ok(sse_event), rx));
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,11 @@ pub enum Commands {
     Init,
 
     /// Start the embedded broker server on a Unix domain socket
-    Serve,
+    Serve {
+        /// Start an HTTP monitor dashboard on this port
+        #[arg(long)]
+        monitor: Option<u16>,
+    },
 
     /// Register a worker with the broker
     Register {
@@ -48,6 +52,10 @@ pub enum Commands {
         /// Worker capabilities (repeatable)
         #[arg(long = "capability")]
         capabilities: Vec<String>,
+
+        /// Worker TTL in seconds (default: 300)
+        #[arg(long)]
+        ttl: Option<u64>,
     },
 
     /// List active workers in the current cell

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,30 +41,40 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
 
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
 
+    // Extract monitor port before matching (Serve consumes it).
+    let monitor_port = if let Commands::Serve { monitor } = &cli.command {
+        *monitor
+    } else {
+        None
+    };
+
     let backend = create_backend(
         config.backend.as_deref(),
         &config.project_root,
         &config.cell_id,
+        monitor_port,
     )?;
 
     match cli.command {
-        Commands::Serve => {
+        Commands::Serve { .. } => {
             backend.serve().await?;
         }
         cmd => {
             let request = match cmd {
                 Commands::Init => unreachable!(),
-                Commands::Serve => unreachable!(),
+                Commands::Serve { .. } => unreachable!(),
                 Commands::Register {
                     name,
                     role,
                     description,
                     capabilities,
+                    ttl,
                 } => BrokerRequest::Register {
                     name,
                     role,
                     description,
                     capabilities,
+                    ttl_secs: ttl,
                 },
                 Commands::Team => BrokerRequest::Team,
                 Commands::Send { to, body, from } => BrokerRequest::Send { to, body, from },

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -20,6 +20,8 @@ pub enum BrokerRequest {
         role: String,
         description: String,
         capabilities: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ttl_secs: Option<u64>,
     },
     /// List active workers.
     Team,
@@ -109,6 +111,7 @@ mod tests {
                 role: "builder".into(),
                 description: "test".into(),
                 capabilities: vec!["rust".into()],
+                ttl_secs: None,
             },
             BrokerRequest::Team,
             BrokerRequest::Send {


### PR DESCRIPTION
## Summary

Stacked on #18 (socket fix). Includes those changes plus:

- **Monitor dashboard**: `dispatch serve --monitor <PORT>` starts an HTTP dashboard with live team list (polling) and event stream (SSE). Dark-themed UI embedded in binary via `include_str!`. Events emitted for register, send, deliver, heartbeat, and worker expiry.
- **Custom TTL**: `dispatch register --ttl <SECONDS>` overrides the default 5-minute worker TTL per registration.
- New dependencies: axum 0.8, futures-util 0.3
- Version bumped to 0.2.0

## Test plan

- [ ] `cargo test --locked` — all 69 tests pass
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean
- [ ] `dispatch serve --monitor 8384` — open http://localhost:8384, see empty dashboard
- [ ] Register workers, watch them appear in team list + event stream
- [ ] `dispatch register --name x --role y --description z --ttl 60` — worker expires after 60s
- [ ] Without `--monitor` — no HTTP server, existing behaviour preserved