### PR TITLE
feat: agent orchestration, monitor dashboard, and heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-12
+
+### Added
+- `dispatch serve --monitor <PORT>` — optional HTTP dashboard showing live team list and event stream via SSE
+- Dark-themed monitor UI embedded in the binary (no external files), auto-refreshes team every 2s
+
 ## [0.1.1] - 2026-04-11
 
 ### Fixed
@@ -29,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary integration tests for all CLI commands
 - GitHub Actions CI workflow (fmt, clippy, build, test)
 
-[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/codesoda/dispatch-cli/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-13
+
+### Added
+- Declarative agent orchestration via `[[agents]]` in `dispatch.config.toml` — agents auto-launch on `dispatch serve`
+- `[main_agent]` config section — prints a ready-to-paste command for the interactive main session
+- `[monitor]` config section — configure the dashboard port in config instead of only via CLI flag
+- `dispatch register --ttl <SECONDS>` — override the default 5-minute worker TTL per registration
+- `--from <WORKER_ID>` global CLI flag — identifies the calling worker and renews TTL on every command
+- Scheduled heartbeats via `[[heartbeats]]` in config — run commands on a timer with optional `after` delay
+- `name` field in config — human-readable project name shown in the monitor dashboard title
+- Monitor dashboard redesigned: sidebar navigation, dashboard stats, agent detail view, event volume sparkline
+- `GET /api/health` — returns server timestamps, uptime, message/request stats, version
+- `GET /api/agents` — returns configured agent definitions, main agent, and heartbeat configs
+- `POST /api/shutdown` — stop the server from the monitor UI (with confirmation)
+- Stop Server button in monitor header with connection state indicator
+- Event payloads now include full structured data (from, to, body) visible in console and web UI
+- Console output during `dispatch serve` shows timestamped event log for all broker activity
+- Broker tracks `messages_sent`, `messages_delivered`, `requests_handled` counters
+- Agent subprocesses receive `DISPATCH_CELL_ID`, `DISPATCH_SOCKET_PATH`, `DISPATCH_MONITOR_URL`, `DISPATCH_AGENT_NAME`, `DISPATCH_AGENT_ROLE` env vars
+- Embedded dispatch-comms instructions auto-prepended to LLM agent prompts
+
+### Changed
+- Agent processes spawn in their own process group for reliable cleanup of entire process trees
+- Shutdown kills process groups (SIGTERM then SIGKILL) and reaps children to prevent zombies
+- Integration tests use RAII drop guard for broker cleanup (no more orphaned test processes)
+- Monitor UI sends absolute UTC timestamps; client ticks uptime/TTL locally every second
+- TTL renewed on `team`, `send`, and `listen` commands when `--from` is provided
+
 ## [0.2.0] - 2026-04-12
 
 ### Added
@@ -35,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary integration tests for all CLI commands
 - GitHub Actions CI workflow (fmt, clippy, build, test)
 
-[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/codesoda/dispatch-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/codesoda/dispatch-cli/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,12 +313,14 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
+ "axum",
  "clap",
  "dirs",
+ "futures-util",
  "predicates",
  "reqwest",
  "semver",
@@ -361,6 +415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -479,6 +545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +563,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -769,10 +842,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1269,6 +1354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1677,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1619,6 +1716,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -321,6 +321,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "libc",
  "predicates",
  "reqwest",
  "semver",
@@ -762,9 +763,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1104,9 +1105,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1277,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1893,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1906,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1916,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1926,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1939,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1982,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 
@@ -21,6 +21,7 @@ dirs = "6"
 async-trait = "0.1.89"
 axum = "0.8"
 futures-util = "0.3"
+libc = "0.2"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 
@@ -19,6 +19,8 @@ uuid = { version = "1", features = ["v4"] }
 serde_json = "1"
 dirs = "6"
 async-trait = "0.1.89"
+axum = "0.8"
+futures-util = "0.3"
 
 [profile.release]
 strip = true

--- a/src/backend/comms.md
+++ b/src/backend/comms.md
@@ -1,0 +1,34 @@
+You are a worker in a dispatch cell — a group of agents coordinating on one machine through the `dispatch` CLI. The dispatch CLI is already installed and the broker is already running. Do NOT build anything. Just use the dispatch commands below directly.
+
+## Register yourself
+
+Before you can send or receive messages, register with the broker:
+
+```bash
+dispatch register --name <YOUR_NAME> --role <YOUR_ROLE> --description "<what you do>" --capability <skill>
+```
+
+This returns JSON with your `worker_id`. Save it — you need it for all communication.
+
+## Find other workers
+
+```bash
+dispatch team
+```
+
+## Send a message
+
+```bash
+dispatch send --to <RECIPIENT_WORKER_ID> --from <YOUR_WORKER_ID> \
+  --body "$(jq -cn --arg key value '{type:"message_type", key:$key}')"
+```
+
+Always use `jq -cn` to build JSON bodies — never hand-assemble JSON strings.
+
+## Listen for messages
+
+```bash
+dispatch listen --worker-id <YOUR_WORKER_ID> --timeout 120
+```
+
+Listening automatically renews your TTL — no separate heartbeat needed. If you get `"status":"timeout"`, just listen again.

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -242,7 +242,7 @@ impl BrokerState {
 // ---------------------------------------------------------------------------
 
 /// Get current Unix timestamp in seconds.
-fn now_secs() -> u64 {
+pub fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock before UNIX epoch")

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::broadcast;
 use tokio::sync::{Mutex, Notify};
 use tracing::instrument;
 
@@ -18,6 +19,15 @@ const DEFAULT_WORKER_TTL_SECS: u64 = 300;
 /// Default listen timeout in seconds.
 const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 
+/// Event emitted by the broker for the monitor dashboard.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BrokerEvent {
+    pub kind: String,
+    pub worker_id: String,
+    pub detail: String,
+    pub timestamp: u64,
+}
+
 /// Local backend that uses a Unix domain socket for IPC.
 ///
 /// The broker runs in-process with in-memory state. Clients connect
@@ -26,13 +36,15 @@ const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 pub struct LocalBackend {
     project_root: PathBuf,
     cell_id: String,
+    monitor_port: Option<u16>,
 }
 
 impl LocalBackend {
-    pub fn new(project_root: &Path, cell_id: &str) -> Self {
+    pub fn new(project_root: &Path, cell_id: &str, monitor_port: Option<u16>) -> Self {
         Self {
             project_root: project_root.to_path_buf(),
             cell_id: cell_id.to_string(),
+            monitor_port,
         }
     }
 }
@@ -42,7 +54,7 @@ impl super::Backend for LocalBackend {
     /// Start the broker server on a Unix domain socket, blocking until
     /// a shutdown signal (SIGINT/SIGTERM) is received.
     async fn serve(&self) -> Result<(), DispatchError> {
-        serve(&self.project_root, &self.cell_id).await
+        serve(&self.project_root, &self.cell_id, self.monitor_port).await
     }
 
     /// Send a request to the broker over a Unix domain socket and
@@ -121,23 +133,26 @@ impl BrokerState {
         role: String,
         description: String,
         capabilities: Vec<String>,
+        ttl_secs: Option<u64>,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
         let now = now_secs();
+        let ttl = ttl_secs.unwrap_or(DEFAULT_WORKER_TTL_SECS);
         let worker = Worker {
             id: id.clone(),
             name,
             role,
             description,
             capabilities,
-            expires_at: now + DEFAULT_WORKER_TTL_SECS,
+            expires_at: now + ttl,
         };
         self.workers.insert(id.clone(), worker);
         id
     }
 
     /// Remove workers whose TTL has expired, including their mailboxes and notifiers.
-    pub fn evict_expired(&mut self) {
+    /// Returns the IDs of workers that were evicted.
+    pub fn evict_expired(&mut self) -> Vec<String> {
         let now = now_secs();
         let expired_ids: Vec<String> = self
             .workers
@@ -150,6 +165,7 @@ impl BrokerState {
             self.mailboxes.remove(id);
             self.notifiers.remove(id);
         }
+        expired_ids
     }
 
     /// Return a list of all active (non-expired) workers.
@@ -268,7 +284,11 @@ async fn check_no_existing_broker(socket: &Path, cell_id: &str) -> Result<(), Di
 /// Listens on a Unix domain socket and handles JSON-line requests.
 /// Returns when a shutdown signal (SIGINT/SIGTERM) is received.
 #[instrument(skip_all, fields(cell_id, socket_path))]
-pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchError> {
+pub async fn serve(
+    project_root: &Path,
+    cell_id: &str,
+    monitor_port: Option<u16>,
+) -> Result<(), DispatchError> {
     let socket = socket_path(project_root, cell_id);
 
     // Ensure parent directory exists.
@@ -290,10 +310,25 @@ pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchErr
     );
 
     let state = Arc::new(Mutex::new(BrokerState::new()));
+    let (event_tx, _) = broadcast::channel::<BrokerEvent>(256);
+
+    // Optionally start the HTTP monitor dashboard.
+    if let Some(port) = monitor_port {
+        let monitor_state = super::monitor::MonitorState {
+            broker: Arc::clone(&state),
+            events: event_tx.clone(),
+        };
+        tokio::spawn(async move {
+            if let Err(e) = super::monitor::run_monitor(port, monitor_state).await {
+                tracing::error!(error = %e, "monitor server error");
+            }
+        });
+        eprintln!("dispatch serve: monitor dashboard at http://localhost:{port}");
+    }
 
     // Run until shutdown signal.
     let result = tokio::select! {
-        res = accept_loop(&listener, state) => res,
+        res = accept_loop(&listener, state, event_tx) => res,
         _ = shutdown_signal() => {
             tracing::info!("shutdown signal received");
             eprintln!("dispatch serve: shutting down");
@@ -315,12 +350,14 @@ pub async fn serve(project_root: &Path, cell_id: &str) -> Result<(), DispatchErr
 async fn accept_loop(
     listener: &UnixListener,
     state: Arc<Mutex<BrokerState>>,
+    event_tx: broadcast::Sender<BrokerEvent>,
 ) -> Result<(), DispatchError> {
     loop {
         let (stream, _addr) = listener.accept().await.map_err(DispatchError::Io)?;
         let state = Arc::clone(&state);
+        let event_tx = event_tx.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, state).await {
+            if let Err(e) = handle_connection(stream, state, event_tx).await {
                 tracing::error!(error = %e, "connection handler error");
             }
         });
@@ -332,7 +369,8 @@ async fn accept_loop(
 /// Reads one JSON line, processes it, writes one JSON line response, then closes.
 async fn handle_connection(
     stream: UnixStream,
-    _state: Arc<Mutex<BrokerState>>,
+    state: Arc<Mutex<BrokerState>>,
+    event_tx: broadcast::Sender<BrokerEvent>,
 ) -> Result<(), DispatchError> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -350,7 +388,7 @@ async fn handle_connection(
     tracing::debug!(request = %line, "received request");
 
     let response = match serde_json::from_str::<BrokerRequest>(line) {
-        Ok(request) => handle_request(request, _state).await,
+        Ok(request) => handle_request(request, state, &event_tx).await,
         Err(e) => BrokerResponse::Error {
             message: format!("invalid request: {e}"),
         },
@@ -366,18 +404,45 @@ async fn handle_connection(
     Ok(())
 }
 
+/// Emit a broker event (best-effort, ignores send failures).
+fn emit_event(tx: &broadcast::Sender<BrokerEvent>, kind: &str, worker_id: &str, detail: &str) {
+    let _ = tx.send(BrokerEvent {
+        kind: kind.to_string(),
+        worker_id: worker_id.to_string(),
+        detail: detail.to_string(),
+        timestamp: now_secs(),
+    });
+}
+
 /// Route a parsed request to the appropriate handler.
-async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) -> BrokerResponse {
+async fn handle_request(
+    request: BrokerRequest,
+    state: Arc<Mutex<BrokerState>>,
+    event_tx: &broadcast::Sender<BrokerEvent>,
+) -> BrokerResponse {
     match request {
         BrokerRequest::Register {
             name,
             role,
             description,
             capabilities,
+            ttl_secs,
         } => {
             let mut state = state.lock().await;
-            let worker_id = state.register_worker(name, role, description, capabilities);
+            let worker_id = state.register_worker(
+                name.clone(),
+                role.clone(),
+                description,
+                capabilities,
+                ttl_secs,
+            );
             tracing::info!(worker_id = %worker_id, "worker registered");
+            emit_event(
+                event_tx,
+                "register",
+                &worker_id,
+                &format!("{name} ({role})"),
+            );
             BrokerResponse::Ok {
                 payload: ResponsePayload::WorkerRegistered { worker_id },
             }
@@ -395,6 +460,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             match state.send_message(to.clone(), body, from) {
                 Some(message_id) => {
                     tracing::info!(message_id = %message_id, to = %to, "message queued");
+                    emit_event(
+                        event_tx,
+                        "send",
+                        &to,
+                        &format!("message {}", &message_id[..8]),
+                    );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::MessageAck { message_id },
                     }
@@ -417,7 +488,10 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             // Check worker exists and renew TTL; get notifier and try immediate pop.
             let (notifier, immediate_msg) = {
                 let mut s = state.lock().await;
-                s.evict_expired();
+                let expired = s.evict_expired();
+                for id in &expired {
+                    emit_event(event_tx, "expire", id, "worker expired");
+                }
                 if !s.workers.contains_key(&worker_id) {
                     return BrokerResponse::Error {
                         message: format!("worker not found or expired: {worker_id}"),
@@ -435,6 +509,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             // If a message was immediately available, return it.
             if let Some(msg) = immediate_msg {
                 tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: immediate delivery");
+                emit_event(
+                    event_tx,
+                    "deliver",
+                    &worker_id,
+                    &format!("message {}", &msg.message_id[..8]),
+                );
                 return BrokerResponse::Ok {
                     payload: ResponsePayload::Message {
                         message_id: msg.message_id,
@@ -454,6 +534,12 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
                 let mut s = state.lock().await;
                 if let Some(msg) = s.pop_message(&worker_id) {
                     tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: delivered after wait");
+                    emit_event(
+                        event_tx,
+                        "deliver",
+                        &worker_id,
+                        &format!("message {}", &msg.message_id[..8]),
+                    );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::Message {
                             message_id: msg.message_id,
@@ -482,6 +568,7 @@ async fn handle_request(request: BrokerRequest, state: Arc<Mutex<BrokerState>>) 
             match state.heartbeat_worker(&worker_id) {
                 Some(expires_at) => {
                     tracing::info!(worker_id = %worker_id, expires_at, "heartbeat renewed");
+                    emit_event(event_tx, "heartbeat", &worker_id, "TTL renewed");
                     BrokerResponse::Ok {
                         payload: ResponsePayload::HeartbeatAck {
                             worker_id,
@@ -526,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_broker_not_running() {
         let tmp = TempDir::new().unwrap();
-        let backend = LocalBackend::new(tmp.path(), "nonexistent-cell");
+        let backend = LocalBackend::new(tmp.path(), "nonexistent-cell", None);
 
         let result = backend.send_request(&BrokerRequest::Team).await;
         assert!(result.is_err());
@@ -547,12 +634,12 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "client-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "client-test", None).await });
 
         // Wait for broker to start.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let backend = LocalBackend::new(&project_root, cell_id);
+        let backend = LocalBackend::new(&project_root, cell_id, None);
         let response = backend.send_request(&BrokerRequest::Team).await;
         assert!(response.is_ok(), "expected Ok response, got: {response:?}");
 
@@ -639,7 +726,7 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "test-cell").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "test-cell", None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -685,7 +772,7 @@ mod tests {
         });
 
         // Try to start second broker — should fail.
-        let result = serve(&project_root, cell_id).await;
+        let result = serve(&project_root, cell_id, None).await;
         assert!(result.is_err());
 
         match result.unwrap_err() {
@@ -719,7 +806,7 @@ mod tests {
 
         // Starting serve should clean up the stale socket and bind fresh.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "restart-cell").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "restart-cell", None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -743,12 +830,14 @@ mod tests {
             "planner".into(),
             "Plans things".into(),
             vec!["plan:create plans".into()],
+            None,
         );
         let id2 = state.register_worker(
             "worker-b".into(),
             "coder".into(),
             "Writes code".into(),
             vec![],
+            None,
         );
         assert_ne!(id1, id2, "each registration must produce a unique ID");
         assert_eq!(state.workers.len(), 2);
@@ -762,6 +851,7 @@ mod tests {
             "reviewer".into(),
             "Reviews pull requests".into(),
             vec!["review:code".into(), "review:docs".into()],
+            None,
         );
         let worker = state.workers.get(&id).unwrap();
         assert_eq!(worker.name, "my-worker");
@@ -778,7 +868,13 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let id = state.register_worker("ttl-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "ttl-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         let worker = state.workers.get(&id).unwrap();
         // Should expire roughly DEFAULT_WORKER_TTL_SECS from now.
         assert!(worker.expires_at >= now + DEFAULT_WORKER_TTL_SECS - 1);
@@ -788,7 +884,13 @@ mod tests {
     #[test]
     fn test_evict_expired_workers() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("soon-expired".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "soon-expired".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         // Manually set expiry to the past.
         state.workers.get_mut(&id).unwrap().expires_at = 0;
         state.evict_expired();
@@ -803,7 +905,7 @@ mod tests {
 
         // Start broker.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "reg-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "reg-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Send register request via raw socket.
@@ -849,7 +951,7 @@ mod tests {
         let project_root = tmp.path().to_path_buf();
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "cap-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "cap-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, "cap-test");
@@ -911,9 +1013,14 @@ mod tests {
     fn test_list_workers_excludes_expired() {
         let mut state = BrokerState::new();
         let active_id =
-            state.register_worker("active".into(), "coder".into(), "desc".into(), vec![]);
-        let expired_id =
-            state.register_worker("expired".into(), "coder".into(), "desc".into(), vec![]);
+            state.register_worker("active".into(), "coder".into(), "desc".into(), vec![], None);
+        let expired_id = state.register_worker(
+            "expired".into(),
+            "coder".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         // Expire one worker.
         state.workers.get_mut(&expired_id).unwrap().expires_at = 0;
 
@@ -925,7 +1032,13 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_renews_ttl() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("hb-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "hb-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         let original_expiry = state.workers.get(&id).unwrap().expires_at;
 
         // Manually lower the expiry to simulate time passing.
@@ -947,7 +1060,13 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_expired() {
         let mut state = BrokerState::new();
-        let id = state.register_worker("exp-worker".into(), "role".into(), "desc".into(), vec![]);
+        let id = state.register_worker(
+            "exp-worker".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         state.workers.get_mut(&id).unwrap().expires_at = 0;
 
         assert!(
@@ -963,7 +1082,7 @@ mod tests {
         let cell_id = "team-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "team-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "team-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1002,7 +1121,7 @@ mod tests {
         let cell_id = "hb-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "hb-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1034,7 +1153,7 @@ mod tests {
         let cell_id = "hb-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "hb-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1058,7 +1177,8 @@ mod tests {
     #[test]
     fn test_send_message_queues_in_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let msg_id = state.send_message(worker_id.clone(), "hello".into(), Some("sender-1".into()));
         assert!(msg_id.is_some(), "send_message should return a message ID");
@@ -1082,8 +1202,13 @@ mod tests {
     #[test]
     fn test_send_message_expired_recipient() {
         let mut state = BrokerState::new();
-        let worker_id =
-            state.register_worker("expiring".into(), "role".into(), "desc".into(), vec![]);
+        let worker_id = state.register_worker(
+            "expiring".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+        );
         state.workers.get_mut(&worker_id).unwrap().expires_at = 0;
 
         let result = state.send_message(worker_id, "hello".into(), None);
@@ -1093,7 +1218,8 @@ mod tests {
     #[test]
     fn test_send_message_unique_ids() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let id1 = state
             .send_message(worker_id.clone(), "msg1".into(), None)
@@ -1108,7 +1234,8 @@ mod tests {
     #[test]
     fn test_send_message_without_from() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
 
         let msg_id = state
             .send_message(worker_id.clone(), "anon msg".into(), None)
@@ -1125,7 +1252,7 @@ mod tests {
         let cell_id = "send-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1166,7 +1293,7 @@ mod tests {
         let cell_id = "send-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1196,7 +1323,8 @@ mod tests {
     #[test]
     fn test_pop_message_returns_fifo_order() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         state.send_message(worker_id.clone(), "first".into(), None);
         state.send_message(worker_id.clone(), "second".into(), None);
 
@@ -1210,7 +1338,8 @@ mod tests {
     #[test]
     fn test_pop_message_empty_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         assert!(state.pop_message(&worker_id).is_none());
     }
 
@@ -1223,7 +1352,8 @@ mod tests {
     #[test]
     fn test_get_notifier_returns_same_instance() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![]);
+        let worker_id =
+            state.register_worker("recv".into(), "coder".into(), "desc".into(), vec![], None);
         let n1 = state.get_notifier(&worker_id);
         let n2 = state.get_notifier(&worker_id);
         assert!(Arc::ptr_eq(&n1, &n2), "same worker should get same Notify");
@@ -1236,7 +1366,7 @@ mod tests {
         let cell_id = "listen-imm-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-imm-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-imm-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1282,7 +1412,7 @@ mod tests {
         let cell_id = "listen-to-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-to-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-to-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1321,7 +1451,7 @@ mod tests {
         let cell_id = "listen-lp-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-lp-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-lp-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1373,7 +1503,7 @@ mod tests {
         let cell_id = "listen-ttl-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-ttl-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-ttl-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1421,7 +1551,7 @@ mod tests {
         let cell_id = "listen-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-err-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "listen-err-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1449,7 +1579,8 @@ mod tests {
         let cell_id = "listen-fifo-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-fifo-test").await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&root, "listen-fifo-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1494,7 +1625,7 @@ mod tests {
         let cell_id = "send-multi-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-multi-test").await });
+        let serve_handle = tokio::spawn(async move { serve(&root, "send-multi-test", None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -25,6 +25,9 @@ pub struct BrokerEvent {
     pub kind: String,
     pub worker_id: String,
     pub detail: String,
+    /// Full structured payload for the event (shown in web UI and console).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
     pub timestamp: u64,
 }
 
@@ -34,16 +37,14 @@ pub struct BrokerEvent {
 /// over a UDS, send one JSON-line request, and receive one JSON-line
 /// response before the connection is closed.
 pub struct LocalBackend {
-    project_root: PathBuf,
-    cell_id: String,
+    config: crate::config::ResolvedConfig,
     monitor_port: Option<u16>,
 }
 
 impl LocalBackend {
-    pub fn new(project_root: &Path, cell_id: &str, monitor_port: Option<u16>) -> Self {
+    pub fn new(config: &crate::config::ResolvedConfig, monitor_port: Option<u16>) -> Self {
         Self {
-            project_root: project_root.to_path_buf(),
-            cell_id: cell_id.to_string(),
+            config: config.clone(),
             monitor_port,
         }
     }
@@ -54,21 +55,21 @@ impl super::Backend for LocalBackend {
     /// Start the broker server on a Unix domain socket, blocking until
     /// a shutdown signal (SIGINT/SIGTERM) is received.
     async fn serve(&self) -> Result<(), DispatchError> {
-        serve(&self.project_root, &self.cell_id, self.monitor_port).await
+        serve(&self.config, self.monitor_port).await
     }
 
     /// Send a request to the broker over a Unix domain socket and
     /// return the response.
-    #[instrument(skip(self, request), fields(cell_id = %self.cell_id))]
+    #[instrument(skip(self, request), fields(cell_id = %self.config.cell_id))]
     async fn send_request(&self, request: &BrokerRequest) -> Result<BrokerResponse, DispatchError> {
-        let sock = socket_path(&self.project_root, &self.cell_id);
+        let sock = socket_path(&self.config.project_root, &self.config.cell_id);
 
         let stream = UnixStream::connect(&sock).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound
                 || e.kind() == std::io::ErrorKind::ConnectionRefused
             {
                 DispatchError::BrokerNotRunning {
-                    cell_id: self.cell_id.clone(),
+                    cell_id: self.config.cell_id.clone(),
                 }
             } else {
                 DispatchError::ConnectionFailed {
@@ -119,6 +120,12 @@ pub struct BrokerState {
     pub mailboxes: HashMap<String, VecDeque<Message>>,
     /// Per-worker notification channels for long-poll wakeup.
     pub notifiers: HashMap<String, Arc<Notify>>,
+    /// Total number of messages sent through the broker.
+    pub messages_sent: u64,
+    /// Total number of messages delivered to listeners.
+    pub messages_delivered: u64,
+    /// Total number of requests handled.
+    pub requests_handled: u64,
 }
 
 impl BrokerState {
@@ -285,10 +292,11 @@ async fn check_no_existing_broker(socket: &Path, cell_id: &str) -> Result<(), Di
 /// Returns when a shutdown signal (SIGINT/SIGTERM) is received.
 #[instrument(skip_all, fields(cell_id, socket_path))]
 pub async fn serve(
-    project_root: &Path,
-    cell_id: &str,
+    config: &crate::config::ResolvedConfig,
     monitor_port: Option<u16>,
 ) -> Result<(), DispatchError> {
+    let cell_id = &config.cell_id;
+    let project_root = &config.project_root;
     let socket = socket_path(project_root, cell_id);
 
     // Ensure parent directory exists.
@@ -312,25 +320,76 @@ pub async fn serve(
     let state = Arc::new(Mutex::new(BrokerState::new()));
     let (event_tx, _) = broadcast::channel::<BrokerEvent>(256);
 
+    // Shutdown signal shared with the monitor dashboard.
+    let monitor_shutdown = Arc::new(Notify::new());
+
     // Optionally start the HTTP monitor dashboard.
-    if let Some(port) = monitor_port {
+    let monitor_url = if let Some(port) = monitor_port {
         let monitor_state = super::monitor::MonitorState {
             broker: Arc::clone(&state),
             events: event_tx.clone(),
+            shutdown: Arc::clone(&monitor_shutdown),
+            name: config.name.clone(),
+            cell_id: cell_id.clone(),
+            started_at: now_secs(),
+            agents: config.agents.clone(),
+            main_agent: config.main_agent.clone(),
+            heartbeats: config.heartbeats.clone(),
         };
         tokio::spawn(async move {
             if let Err(e) = super::monitor::run_monitor(port, monitor_state).await {
                 tracing::error!(error = %e, "monitor server error");
             }
         });
-        eprintln!("dispatch serve: monitor dashboard at http://localhost:{port}");
+        let url = format!("http://localhost:{port}");
+        eprintln!("dispatch serve: monitor dashboard at {url}");
+        Some(url)
+    } else {
+        None
+    };
+
+    // Launch configured agents.
+    let mut orchestrator = super::orchestrator::AgentOrchestrator::new(
+        cell_id,
+        &socket,
+        monitor_url.clone(),
+        project_root,
+    );
+    if !config.agents.is_empty() {
+        orchestrator.launch_all(&config.agents).await?;
     }
 
-    // Run until shutdown signal.
+    // Start configured heartbeat timers.
+    if !config.heartbeats.is_empty() {
+        orchestrator.start_heartbeats(&config.heartbeats, &event_tx);
+    }
+
+    // Print the main agent launch command.
+    if let Some(ref main_agent) = config.main_agent {
+        let cmd = super::orchestrator::build_main_agent_command(
+            main_agent,
+            cell_id,
+            monitor_url.as_deref(),
+        );
+        eprintln!("\ndispatch serve: ready. Start the main session:\n");
+        eprintln!("  {cmd}\n");
+    }
+
+    // Run until shutdown signal (OS signal or monitor UI).
     let result = tokio::select! {
         res = accept_loop(&listener, state, event_tx) => res,
         _ = shutdown_signal() => {
             tracing::info!("shutdown signal received");
+            eprintln!("dispatch serve: shutting down agents...");
+            orchestrator.shutdown_all().await;
+            eprintln!("dispatch serve: shutting down");
+            Ok(())
+        }
+        _ = monitor_shutdown.notified() => {
+            tracing::info!("shutdown requested via monitor");
+            eprintln!("dispatch serve: shutdown requested from monitor");
+            eprintln!("dispatch serve: shutting down agents...");
+            orchestrator.shutdown_all().await;
             eprintln!("dispatch serve: shutting down");
             Ok(())
         }
@@ -405,13 +464,36 @@ async fn handle_connection(
 }
 
 /// Emit a broker event (best-effort, ignores send failures).
-fn emit_event(tx: &broadcast::Sender<BrokerEvent>, kind: &str, worker_id: &str, detail: &str) {
+/// Also prints a human-readable line to stderr for the serve console.
+fn emit_event(
+    tx: &broadcast::Sender<BrokerEvent>,
+    kind: &str,
+    worker_id: &str,
+    detail: &str,
+    payload: Option<serde_json::Value>,
+) {
+    let ts = chrono_ts();
+    if let Some(ref p) = payload {
+        eprintln!("[{ts}] {kind:>10}  {worker_id}  {detail}  {p}");
+    } else {
+        eprintln!("[{ts}] {kind:>10}  {worker_id}  {detail}");
+    }
     let _ = tx.send(BrokerEvent {
         kind: kind.to_string(),
         worker_id: worker_id.to_string(),
         detail: detail.to_string(),
+        payload,
         timestamp: now_secs(),
     });
+}
+
+/// Format current time as HH:MM:SS for console output.
+fn chrono_ts() -> String {
+    let secs = now_secs();
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    format!("{h:02}:{m:02}:{s:02}")
 }
 
 /// Route a parsed request to the appropriate handler.
@@ -420,6 +502,10 @@ async fn handle_request(
     state: Arc<Mutex<BrokerState>>,
     event_tx: &broadcast::Sender<BrokerEvent>,
 ) -> BrokerResponse {
+    {
+        let mut s = state.lock().await;
+        s.requests_handled += 1;
+    }
     match request {
         BrokerRequest::Register {
             name,
@@ -442,13 +528,23 @@ async fn handle_request(
                 "register",
                 &worker_id,
                 &format!("{name} ({role})"),
+                Some(serde_json::json!({
+                    "name": name,
+                    "role": role,
+                })),
             );
             BrokerResponse::Ok {
                 payload: ResponsePayload::WorkerRegistered { worker_id },
             }
         }
-        BrokerRequest::Team => {
+        BrokerRequest::Team { from } => {
             let mut state = state.lock().await;
+            // Renew caller's TTL if identified.
+            if let Some(ref caller_id) = from {
+                if let Some(w) = state.workers.get_mut(caller_id) {
+                    w.expires_at = now_secs() + DEFAULT_WORKER_TTL_SECS;
+                }
+            }
             let workers = state.list_workers();
             tracing::info!(count = workers.len(), "team listing");
             BrokerResponse::Ok {
@@ -457,14 +553,39 @@ async fn handle_request(
         }
         BrokerRequest::Send { to, body, from } => {
             let mut state = state.lock().await;
+            // Renew sender's TTL if they're a registered worker.
+            if let Some(ref sender_id) = from {
+                if let Some(w) = state.workers.get_mut(sender_id) {
+                    w.expires_at = now_secs() + DEFAULT_WORKER_TTL_SECS;
+                }
+            }
+            let body_clone = body.clone();
+            let from_clone = from.clone();
             match state.send_message(to.clone(), body, from) {
                 Some(message_id) => {
+                    state.messages_sent += 1;
                     tracing::info!(message_id = %message_id, to = %to, "message queued");
+                    // Truncate body for display (full body in payload).
+                    let preview = if body_clone.len() > 120 {
+                        format!("{}...", &body_clone[..120])
+                    } else {
+                        body_clone.clone()
+                    };
                     emit_event(
                         event_tx,
                         "send",
                         &to,
-                        &format!("message {}", &message_id[..8]),
+                        &format!(
+                            "from {} → {}",
+                            from_clone.as_deref().unwrap_or("anonymous"),
+                            &to
+                        ),
+                        Some(serde_json::json!({
+                            "from": from_clone,
+                            "to": to,
+                            "body": preview,
+                            "message_id": &message_id[..8],
+                        })),
                     );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::MessageAck { message_id },
@@ -490,7 +611,7 @@ async fn handle_request(
                 let mut s = state.lock().await;
                 let expired = s.evict_expired();
                 for id in &expired {
-                    emit_event(event_tx, "expire", id, "worker expired");
+                    emit_event(event_tx, "expire", id, "worker expired", None);
                 }
                 if !s.workers.contains_key(&worker_id) {
                     return BrokerResponse::Error {
@@ -508,12 +629,30 @@ async fn handle_request(
 
             // If a message was immediately available, return it.
             if let Some(msg) = immediate_msg {
+                {
+                    state.lock().await.messages_delivered += 1;
+                }
                 tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: immediate delivery");
+                let body_preview = if msg.body.len() > 120 {
+                    format!("{}...", &msg.body[..120])
+                } else {
+                    msg.body.clone()
+                };
                 emit_event(
                     event_tx,
                     "deliver",
                     &worker_id,
-                    &format!("message {}", &msg.message_id[..8]),
+                    &format!(
+                        "from {} → {}",
+                        msg.from.as_deref().unwrap_or("anonymous"),
+                        &worker_id
+                    ),
+                    Some(serde_json::json!({
+                        "from": msg.from,
+                        "to": msg.to,
+                        "body": body_preview,
+                        "message_id": &msg.message_id[..8],
+                    })),
                 );
                 return BrokerResponse::Ok {
                     payload: ResponsePayload::Message {
@@ -533,12 +672,28 @@ async fn handle_request(
                 // Notified — try to pop a message.
                 let mut s = state.lock().await;
                 if let Some(msg) = s.pop_message(&worker_id) {
+                    s.messages_delivered += 1;
                     tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: delivered after wait");
+                    let body_preview = if msg.body.len() > 120 {
+                        format!("{}...", &msg.body[..120])
+                    } else {
+                        msg.body.clone()
+                    };
                     emit_event(
                         event_tx,
                         "deliver",
                         &worker_id,
-                        &format!("message {}", &msg.message_id[..8]),
+                        &format!(
+                            "from {} → {}",
+                            msg.from.as_deref().unwrap_or("anonymous"),
+                            &worker_id
+                        ),
+                        Some(serde_json::json!({
+                            "from": msg.from,
+                            "to": msg.to,
+                            "body": body_preview,
+                            "message_id": &msg.message_id[..8],
+                        })),
                     );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::Message {
@@ -568,7 +723,7 @@ async fn handle_request(
             match state.heartbeat_worker(&worker_id) {
                 Some(expires_at) => {
                     tracing::info!(worker_id = %worker_id, expires_at, "heartbeat renewed");
-                    emit_event(event_tx, "heartbeat", &worker_id, "TTL renewed");
+                    emit_event(event_tx, "heartbeat", &worker_id, "TTL renewed", None);
                     BrokerResponse::Ok {
                         payload: ResponsePayload::HeartbeatAck {
                             worker_id,
@@ -605,17 +760,35 @@ async fn shutdown_signal() {
 mod tests {
     use super::*;
     use crate::backend::Backend;
+    use crate::config::ResolvedConfig;
     use tempfile::TempDir;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    /// Create a minimal ResolvedConfig for testing.
+    fn test_config(project_root: &Path, cell_id: &str) -> ResolvedConfig {
+        ResolvedConfig {
+            name: None,
+            cell_id: cell_id.to_string(),
+            backend: None,
+            project_root: project_root.to_path_buf(),
+            monitor_port: None,
+            agents: vec![],
+            main_agent: None,
+            heartbeats: vec![],
+        }
+    }
 
     // ---- Client-side tests (formerly in client.rs) ----
 
     #[tokio::test]
     async fn test_client_broker_not_running() {
         let tmp = TempDir::new().unwrap();
-        let backend = LocalBackend::new(tmp.path(), "nonexistent-cell", None);
+        let config = test_config(tmp.path(), "nonexistent-cell");
+        let backend = LocalBackend::new(&config, None);
 
-        let result = backend.send_request(&BrokerRequest::Team).await;
+        let result = backend
+            .send_request(&BrokerRequest::Team { from: None })
+            .await;
         assert!(result.is_err());
 
         match result.unwrap_err() {
@@ -634,13 +807,17 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "client-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait for broker to start.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        let backend = LocalBackend::new(&project_root, cell_id, None);
-        let response = backend.send_request(&BrokerRequest::Team).await;
+        let cfg = test_config(&project_root, cell_id);
+        let backend = LocalBackend::new(&cfg, None);
+        let response = backend
+            .send_request(&BrokerRequest::Team { from: None })
+            .await;
         assert!(response.is_ok(), "expected Ok response, got: {response:?}");
 
         let resp = response.unwrap();
@@ -726,7 +903,8 @@ mod tests {
 
         // Start broker in background.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "test-cell", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -772,7 +950,7 @@ mod tests {
         });
 
         // Try to start second broker — should fail.
-        let result = serve(&project_root, cell_id, None).await;
+        let result = serve(&test_config(&project_root, cell_id), None).await;
         assert!(result.is_err());
 
         match result.unwrap_err() {
@@ -806,7 +984,8 @@ mod tests {
 
         // Starting serve should clean up the stale socket and bind fresh.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "restart-cell", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -905,7 +1084,8 @@ mod tests {
 
         // Start broker.
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "reg-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Send register request via raw socket.
@@ -949,9 +1129,11 @@ mod tests {
     async fn test_register_capability_storage_via_broker() {
         let tmp = TempDir::new().unwrap();
         let project_root = tmp.path().to_path_buf();
+        let cell_id = "cap-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "cap-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, "cap-test");
@@ -1082,7 +1264,8 @@ mod tests {
         let cell_id = "team-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "team-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1121,7 +1304,8 @@ mod tests {
         let cell_id = "hb-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1153,7 +1337,8 @@ mod tests {
         let cell_id = "hb-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "hb-err-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1252,7 +1437,8 @@ mod tests {
         let cell_id = "send-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1293,7 +1479,8 @@ mod tests {
         let cell_id = "send-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-err-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1366,7 +1553,8 @@ mod tests {
         let cell_id = "listen-imm-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-imm-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1412,7 +1600,8 @@ mod tests {
         let cell_id = "listen-to-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-to-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1451,7 +1640,8 @@ mod tests {
         let cell_id = "listen-lp-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-lp-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1503,7 +1693,8 @@ mod tests {
         let cell_id = "listen-ttl-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-ttl-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1551,7 +1742,8 @@ mod tests {
         let cell_id = "listen-err-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "listen-err-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1580,7 +1772,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&root, "listen-fifo-test", None).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -1625,7 +1817,8 @@ mod tests {
         let cell_id = "send-multi-test";
 
         let root = project_root.clone();
-        let serve_handle = tokio::spawn(async move { serve(&root, "send-multi-test", None).await });
+        let serve_handle =
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -565,12 +565,6 @@ async fn handle_request(
                 Some(message_id) => {
                     state.messages_sent += 1;
                     tracing::info!(message_id = %message_id, to = %to, "message queued");
-                    // Truncate body for display (full body in payload).
-                    let preview = if body_clone.len() > 120 {
-                        format!("{}...", &body_clone[..120])
-                    } else {
-                        body_clone.clone()
-                    };
                     emit_event(
                         event_tx,
                         "send",
@@ -583,7 +577,7 @@ async fn handle_request(
                         Some(serde_json::json!({
                             "from": from_clone,
                             "to": to,
-                            "body": preview,
+                            "body": body_clone,
                             "message_id": &message_id[..8],
                         })),
                     );
@@ -633,11 +627,6 @@ async fn handle_request(
                     state.lock().await.messages_delivered += 1;
                 }
                 tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: immediate delivery");
-                let body_preview = if msg.body.len() > 120 {
-                    format!("{}...", &msg.body[..120])
-                } else {
-                    msg.body.clone()
-                };
                 emit_event(
                     event_tx,
                     "deliver",
@@ -650,7 +639,7 @@ async fn handle_request(
                     Some(serde_json::json!({
                         "from": msg.from,
                         "to": msg.to,
-                        "body": body_preview,
+                        "body": msg.body,
                         "message_id": &msg.message_id[..8],
                     })),
                 );
@@ -674,11 +663,6 @@ async fn handle_request(
                 if let Some(msg) = s.pop_message(&worker_id) {
                     s.messages_delivered += 1;
                     tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: delivered after wait");
-                    let body_preview = if msg.body.len() > 120 {
-                        format!("{}...", &msg.body[..120])
-                    } else {
-                        msg.body.clone()
-                    };
                     emit_event(
                         event_tx,
                         "deliver",
@@ -691,7 +675,7 @@ async fn handle_request(
                         Some(serde_json::json!({
                             "from": msg.from,
                             "to": msg.to,
-                            "body": body_preview,
+                            "body": msg.body,
                             "message_id": &msg.message_id[..8],
                         })),
                     );

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod local;
+pub mod monitor;
 
 use async_trait::async_trait;
 
@@ -27,9 +28,14 @@ pub fn create_backend(
     backend_name: Option<&str>,
     project_root: &std::path::Path,
     cell_id: &str,
+    monitor_port: Option<u16>,
 ) -> Result<Box<dyn Backend>, DispatchError> {
     match backend_name.unwrap_or("local") {
-        "local" => Ok(Box::new(local::LocalBackend::new(project_root, cell_id))),
+        "local" => Ok(Box::new(local::LocalBackend::new(
+            project_root,
+            cell_id,
+            monitor_port,
+        ))),
         other => Err(DispatchError::UnknownBackend {
             name: other.to_string(),
         }),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,8 +1,10 @@
 pub mod local;
 pub mod monitor;
+pub mod orchestrator;
 
 use async_trait::async_trait;
 
+use crate::config::ResolvedConfig;
 use crate::errors::DispatchError;
 use crate::protocol::{BrokerRequest, BrokerResponse};
 
@@ -25,17 +27,11 @@ pub trait Backend: Send + Sync {
 /// - `None` or `"local"` → `LocalBackend`
 /// - Anything else → `DispatchError::UnknownBackend`
 pub fn create_backend(
-    backend_name: Option<&str>,
-    project_root: &std::path::Path,
-    cell_id: &str,
+    config: &ResolvedConfig,
     monitor_port: Option<u16>,
 ) -> Result<Box<dyn Backend>, DispatchError> {
-    match backend_name.unwrap_or("local") {
-        "local" => Ok(Box::new(local::LocalBackend::new(
-            project_root,
-            cell_id,
-            monitor_port,
-        ))),
+    match config.backend.as_deref().unwrap_or("local") {
+        "local" => Ok(Box::new(local::LocalBackend::new(config, monitor_port))),
         other => Err(DispatchError::UnknownBackend {
             name: other.to_string(),
         }),

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dispatch Monitor</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; background: #0d1117; color: #c9d1d9; }
+  .header { padding: 12px 20px; border-bottom: 1px solid #21262d; display: flex; align-items: center; gap: 12px; }
+  .header h1 { font-size: 14px; font-weight: 600; color: #58a6ff; }
+  .header .cell { font-size: 12px; color: #8b949e; }
+  .container { display: grid; grid-template-columns: 1fr 1fr; height: calc(100vh - 45px); }
+  .pane { padding: 16px; overflow-y: auto; }
+  .pane:first-child { border-right: 1px solid #21262d; }
+  .pane h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: #8b949e; margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th { text-align: left; padding: 6px 8px; color: #8b949e; border-bottom: 1px solid #21262d; font-weight: 500; }
+  td { padding: 6px 8px; border-bottom: 1px solid #161b22; }
+  .role { color: #d2a8ff; }
+  .id { color: #8b949e; font-size: 11px; }
+  .event-log { display: flex; flex-direction: column; gap: 2px; }
+  .event { font-size: 12px; padding: 4px 8px; border-radius: 4px; display: flex; gap: 12px; }
+  .event .ts { color: #484f58; min-width: 60px; }
+  .event .kind { min-width: 72px; font-weight: 600; }
+  .event .detail { color: #8b949e; }
+  .kind-register { color: #3fb950; }
+  .kind-send { color: #d29922; }
+  .kind-deliver { color: #58a6ff; }
+  .kind-heartbeat { color: #484f58; }
+  .kind-expire { color: #f85149; }
+  .empty { color: #484f58; font-style: italic; font-size: 12px; }
+  .status-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: #3fb950; margin-right: 6px; }
+  .worker-count { color: #8b949e; font-size: 12px; font-weight: 400; }
+</style>
+</head>
+<body>
+<div class="header">
+  <span class="status-dot"></span>
+  <h1>Dispatch Monitor</h1>
+  <span class="cell" id="cell-id"></span>
+</div>
+<div class="container">
+  <div class="pane">
+    <h2>Team <span class="worker-count" id="worker-count"></span></h2>
+    <table>
+      <thead><tr><th>Name</th><th>Role</th><th>ID</th><th>TTL</th></tr></thead>
+      <tbody id="team-body"><tr><td colspan="4" class="empty">No workers registered</td></tr></tbody>
+    </table>
+  </div>
+  <div class="pane">
+    <h2>Events</h2>
+    <div class="event-log" id="event-log">
+      <div class="empty">Waiting for events...</div>
+    </div>
+  </div>
+</div>
+<script>
+async function refreshTeam() {
+  try {
+    const resp = await fetch('/api/team');
+    const workers = await resp.json();
+    const tbody = document.getElementById('team-body');
+    const count = document.getElementById('worker-count');
+    count.textContent = `(${workers.length})`;
+    if (workers.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="4" class="empty">No workers registered</td></tr>';
+      return;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    tbody.innerHTML = workers.map(w => {
+      const ttl = Math.max(0, w.expires_at - now);
+      return `<tr><td>${esc(w.name)}</td><td class="role">${esc(w.role)}</td><td class="id">${esc(w.id.slice(0,8))}...</td><td>${ttl}s</td></tr>`;
+    }).join('');
+  } catch(e) { /* ignore fetch errors */ }
+}
+setInterval(refreshTeam, 2000);
+refreshTeam();
+
+const log = document.getElementById('event-log');
+let firstEvent = true;
+const es = new EventSource('/api/events');
+es.addEventListener('broker', (e) => {
+  if (firstEvent) { log.innerHTML = ''; firstEvent = false; }
+  const ev = JSON.parse(e.data);
+  const d = new Date(ev.timestamp * 1000);
+  const ts = d.toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  const el = document.createElement('div');
+  el.className = 'event';
+  el.innerHTML = `<span class="ts">${ts}</span><span class="kind kind-${esc(ev.kind)}">${esc(ev.kind)}</span><span class="detail">${esc(ev.detail)}</span>`;
+  log.prepend(el);
+  if (log.children.length > 500) log.removeChild(log.lastChild);
+  refreshTeam();
+});
+es.onerror = () => { /* reconnect is automatic */ };
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+</script>
+</body>
+</html>

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -5,95 +5,459 @@
 <title>Dispatch Monitor</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; background: #0d1117; color: #c9d1d9; }
-  .header { padding: 12px 20px; border-bottom: 1px solid #21262d; display: flex; align-items: center; gap: 12px; }
+  body { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; font-size: 15px; background: #0d1117; color: #c9d1d9; display: flex; flex-direction: column; height: 100vh; }
+
+  /* Header */
+  .header { padding: 10px 16px; border-bottom: 1px solid #21262d; display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+  .status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: #3fb950; }
+  .status-dot.stopped { background: #f85149; }
   .header h1 { font-size: 14px; font-weight: 600; color: #58a6ff; }
-  .header .cell { font-size: 12px; color: #8b949e; }
-  .container { display: grid; grid-template-columns: 1fr 1fr; height: calc(100vh - 45px); }
-  .pane { padding: 16px; overflow-y: auto; }
-  .pane:first-child { border-right: 1px solid #21262d; }
-  .pane h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 1px; color: #8b949e; margin-bottom: 12px; }
-  table { width: 100%; border-collapse: collapse; font-size: 12px; }
-  th { text-align: left; padding: 6px 8px; color: #8b949e; border-bottom: 1px solid #21262d; font-weight: 500; }
-  td { padding: 6px 8px; border-bottom: 1px solid #161b22; }
-  .role { color: #d2a8ff; }
-  .id { color: #8b949e; font-size: 11px; }
-  .event-log { display: flex; flex-direction: column; gap: 2px; }
-  .event { font-size: 12px; padding: 4px 8px; border-radius: 4px; display: flex; gap: 12px; }
-  .event .ts { color: #484f58; min-width: 60px; }
-  .event .kind { min-width: 72px; font-weight: 600; }
-  .event .detail { color: #8b949e; }
+  .header .cell { font-size: 11px; color: #484f58; }
+  .header .spacer { flex: 1; }
+  .stop-btn { background: transparent; border: 1px solid #f85149; color: #f85149; font-family: inherit; font-size: 11px; padding: 3px 10px; border-radius: 4px; cursor: pointer; }
+  .stop-btn:hover { background: #f8514920; }
+  .stop-btn:disabled { opacity: 0.4; cursor: default; }
+
+  /* Layout */
+  .layout { display: flex; flex: 1; overflow: hidden; }
+
+  /* Sidebar */
+  .sidebar { width: 220px; min-width: 220px; border-right: 1px solid #21262d; display: flex; flex-direction: column; overflow-y: auto; }
+  .sidebar .section-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: #484f58; padding: 12px 14px 4px; }
+  .sidebar .nav-item { display: flex; align-items: center; gap: 8px; padding: 7px 14px; font-size: 12px; cursor: pointer; color: #8b949e; border-left: 2px solid transparent; }
+  .sidebar .nav-item:hover { background: #161b22; color: #c9d1d9; }
+  .sidebar .nav-item.active { background: #161b22; color: #c9d1d9; border-left-color: #58a6ff; }
+  .sidebar .nav-item .dot { width: 6px; height: 6px; border-radius: 50%; background: #484f58; flex-shrink: 0; }
+  .sidebar .nav-item .dot.live { background: #3fb950; }
+  .sidebar .nav-item .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .sidebar .nav-item .role-tag { font-size: 10px; color: #484f58; }
+
+  /* Main content */
+  .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+
+  /* Dashboard view */
+  .dashboard { padding: 20px; overflow-y: auto; flex: 1; }
+  .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; margin-bottom: 20px; }
+  .stat-card { background: #161b22; border: 1px solid #21262d; border-radius: 6px; padding: 12px; }
+  .stat-card .stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 4px; }
+  .stat-card .stat-value { font-size: 20px; font-weight: 600; color: #c9d1d9; }
+  .stat-card .stat-value.green { color: #3fb950; }
+  .sparkline-container { background: #161b22; border: 1px solid #21262d; border-radius: 6px; padding: 12px; margin-bottom: 20px; }
+  .sparkline-container .stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 8px; }
+  .sparkline { display: flex; align-items: flex-end; gap: 2px; height: 40px; }
+  .sparkline .bar { background: #58a6ff40; border-radius: 1px; min-width: 4px; flex: 1; transition: height 0.3s; }
+  .recent-section h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 8px; }
+
+  /* Event stream view */
+  .event-stream { flex: 1; overflow-y: auto; padding: 12px; }
+  .event { font-size: 12px; padding: 6px 8px; border-bottom: 1px solid #161b22; }
+  .event .event-header { display: flex; gap: 10px; }
+  .event .ts { color: #484f58; min-width: 60px; font-size: 11px; }
+  .event .kind { min-width: 68px; font-weight: 600; font-size: 11px; }
+  .event .detail { color: #8b949e; font-size: 11px; }
+  .event .payload { color: #6e7681; font-size: 11px; margin-top: 2px; word-break: break-word; }
+  .event .payload .body-text { color: #c9d1d9; }
+  .event .payload .label { color: #484f58; }
   .kind-register { color: #3fb950; }
   .kind-send { color: #d29922; }
   .kind-deliver { color: #58a6ff; }
   .kind-heartbeat { color: #484f58; }
   .kind-expire { color: #f85149; }
+
+  /* Agent detail view */
+  .agent-detail { flex: 1; overflow-y: auto; padding: 16px; }
+  .agent-detail .tab-bar { display: flex; gap: 0; margin-bottom: 16px; border-bottom: 1px solid #21262d; }
+  .agent-detail .tab { padding: 6px 16px; font-size: 11px; color: #8b949e; cursor: pointer; border-bottom: 2px solid transparent; }
+  .agent-detail .tab:hover { color: #c9d1d9; }
+  .agent-detail .tab.active { color: #c9d1d9; border-bottom-color: #58a6ff; }
+  .config-section { margin-bottom: 16px; }
+  .config-section .config-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 4px; }
+  .config-section .config-value { font-size: 12px; color: #c9d1d9; background: #161b22; padding: 8px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
+  .config-section .config-value.command { color: #d2a8ff; }
+
   .empty { color: #484f58; font-style: italic; font-size: 12px; }
-  .status-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: #3fb950; margin-right: 6px; }
-  .worker-count { color: #8b949e; font-size: 12px; font-weight: 400; }
+  .hidden { display: none !important; }
 </style>
 </head>
 <body>
 <div class="header">
-  <span class="status-dot"></span>
-  <h1>Dispatch Monitor</h1>
+  <span class="status-dot" id="status-dot"></span>
+  <h1 id="title">Dispatch Monitor</h1>
   <span class="cell" id="cell-id"></span>
+  <span class="spacer"></span>
+  <button class="stop-btn" id="stop-btn" onclick="stopServer()">Stop Server</button>
 </div>
-<div class="container">
-  <div class="pane">
-    <h2>Team <span class="worker-count" id="worker-count"></span></h2>
-    <table>
-      <thead><tr><th>Name</th><th>Role</th><th>ID</th><th>TTL</th></tr></thead>
-      <tbody id="team-body"><tr><td colspan="4" class="empty">No workers registered</td></tr></tbody>
-    </table>
+<div class="layout">
+  <div class="sidebar">
+    <div class="section-label">Views</div>
+    <div class="nav-item active" data-view="dashboard" onclick="selectView('dashboard')">
+      <span class="name">Dashboard</span>
+    </div>
+    <div class="nav-item" data-view="all" onclick="selectView('all')">
+      <span class="name">All Events</span>
+    </div>
+    <div class="section-label">Agents</div>
+    <div id="agent-list">
+      <div class="nav-item empty" style="cursor:default">No agents yet</div>
+    </div>
   </div>
-  <div class="pane">
-    <h2>Events</h2>
-    <div class="event-log" id="event-log">
+  <div class="main">
+    <!-- Dashboard view -->
+    <div class="dashboard" id="view-dashboard">
+      <div class="stats-grid">
+        <div class="stat-card"><div class="stat-label">Uptime</div><div class="stat-value" id="dash-uptime">--</div></div>
+        <div class="stat-card"><div class="stat-label">Workers</div><div class="stat-value green" id="dash-workers">0</div></div>
+        <div class="stat-card"><div class="stat-label">Messages Sent</div><div class="stat-value" id="dash-sent">0</div></div>
+        <div class="stat-card"><div class="stat-label">Messages Delivered</div><div class="stat-value" id="dash-delivered">0</div></div>
+        <div class="stat-card"><div class="stat-label">Requests</div><div class="stat-value" id="dash-requests">0</div></div>
+        <div class="stat-card"><div class="stat-label">Version</div><div class="stat-value" id="dash-version">--</div></div>
+      </div>
+      <div class="sparkline-container">
+        <div class="stat-label">Event Volume (last 60s)</div>
+        <div class="sparkline" id="sparkline"></div>
+      </div>
+      <div class="recent-section">
+        <h3>Recent Events</h3>
+        <div id="recent-events"><div class="empty">Waiting for events...</div></div>
+      </div>
+    </div>
+    <!-- All events view -->
+    <div class="event-stream hidden" id="view-all">
       <div class="empty">Waiting for events...</div>
+    </div>
+    <!-- Agent detail view -->
+    <div class="agent-detail hidden" id="view-agent">
+      <div class="tab-bar">
+        <div class="tab active" data-tab="config" onclick="selectAgentTab('config')">Config</div>
+        <div class="tab" data-tab="events" onclick="selectAgentTab('events')">Events</div>
+      </div>
+      <div id="agent-config-panel">
+        <div class="empty">Select an agent</div>
+      </div>
+      <div id="agent-events-panel" class="hidden">
+        <div class="empty">No events yet</div>
+      </div>
     </div>
   </div>
 </div>
 <script>
+// --- State ---
+let serverAlive = true;
+let currentView = 'dashboard';
+let selectedAgent = null; // worker_id
+let allEvents = []; // all events cached
+const MAX_EVENTS = 1000;
+let agentConfigs = []; // from /api/agents
+let teamWorkers = []; // from /api/team
+// Sparkline: 60 buckets, each 1 second
+const SPARK_BUCKETS = 60;
+let sparkData = new Array(SPARK_BUCKETS).fill(0);
+let sparkInterval = null;
+// Server timestamps for client-side ticking
+let serverStartedAt = 0; // Unix seconds
+let serverTimeDrift = 0; // server_time - client_time (to correct clock skew)
+
+// --- Initialization ---
+async function init() {
+  await Promise.all([fetchAgentConfigs(), refreshTeam(), pingServer()]);
+  setupSSE();
+  setInterval(refreshTeam, 2000);
+  setInterval(pingServer, 5000);
+  setInterval(tickUI, 1000); // tick uptime + TTL every second
+  sparkInterval = setInterval(tickSparkline, 1000);
+}
+
+// --- SSE ---
+function setupSSE() {
+  const es = new EventSource('/api/events');
+  es.addEventListener('broker', (e) => {
+    const ev = JSON.parse(e.data);
+    ev._ts = new Date(ev.timestamp * 1000);
+    allEvents.unshift(ev);
+    if (allEvents.length > MAX_EVENTS) allEvents.pop();
+    sparkData[sparkData.length - 1]++;
+    renderCurrentView();
+    refreshTeam();
+  });
+  es.onerror = () => { markDisconnected(); };
+}
+
+// --- API ---
+async function fetchAgentConfigs() {
+  try {
+    const resp = await fetch('/api/agents');
+    const data = await resp.json();
+    agentConfigs = data.agents || [];
+    if (data.main_agent) {
+      agentConfigs.unshift({ ...data.main_agent, name: 'main', role: 'main-agent', description: 'Main interactive agent', _isMain: true });
+    }
+  } catch(e) {}
+}
+
 async function refreshTeam() {
   try {
     const resp = await fetch('/api/team');
-    const workers = await resp.json();
-    const tbody = document.getElementById('team-body');
-    const count = document.getElementById('worker-count');
-    count.textContent = `(${workers.length})`;
-    if (workers.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="4" class="empty">No workers registered</td></tr>';
-      return;
-    }
-    const now = Math.floor(Date.now() / 1000);
-    tbody.innerHTML = workers.map(w => {
-      const ttl = Math.max(0, w.expires_at - now);
-      return `<tr><td>${esc(w.name)}</td><td class="role">${esc(w.role)}</td><td class="id">${esc(w.id.slice(0,8))}...</td><td>${ttl}s</td></tr>`;
-    }).join('');
-  } catch(e) { /* ignore fetch errors */ }
+    teamWorkers = await resp.json();
+    renderSidebar();
+  } catch(e) {}
 }
-setInterval(refreshTeam, 2000);
-refreshTeam();
 
-const log = document.getElementById('event-log');
-let firstEvent = true;
-const es = new EventSource('/api/events');
-es.addEventListener('broker', (e) => {
-  if (firstEvent) { log.innerHTML = ''; firstEvent = false; }
-  const ev = JSON.parse(e.data);
-  const d = new Date(ev.timestamp * 1000);
-  const ts = d.toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
-  const el = document.createElement('div');
-  el.className = 'event';
-  el.innerHTML = `<span class="ts">${ts}</span><span class="kind kind-${esc(ev.kind)}">${esc(ev.kind)}</span><span class="detail">${esc(ev.detail)}</span>`;
-  log.prepend(el);
-  if (log.children.length > 500) log.removeChild(log.lastChild);
-  refreshTeam();
-});
-es.onerror = () => { /* reconnect is automatic */ };
+async function pingServer() {
+  try {
+    const resp = await fetch('/api/health', { signal: AbortSignal.timeout(3000) });
+    if (!resp.ok) { markDisconnected(); return; }
+    markConnected();
+    const h = await resp.json();
+    // Store timestamps for client-side ticking
+    serverStartedAt = h.started_at || 0;
+    const clientNow = Math.floor(Date.now() / 1000);
+    serverTimeDrift = (h.server_time || clientNow) - clientNow;
+    // Update static fields
+    const name = h.name || 'Dispatch Monitor';
+    document.getElementById('title').textContent = name;
+    document.title = serverAlive ? name : '[offline] ' + name;
+    document.getElementById('cell-id').textContent = h.cell_id || '';
+    document.getElementById('dash-workers').textContent = h.workers || 0;
+    document.getElementById('dash-sent').textContent = h.messages_sent || 0;
+    document.getElementById('dash-delivered').textContent = h.messages_delivered || 0;
+    document.getElementById('dash-requests').textContent = h.requests_handled || 0;
+    document.getElementById('dash-version').textContent = 'v' + (h.version || '?');
+    tickUI(); // immediate update
+  } catch(e) { markDisconnected(); }
+}
 
-function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+// --- Connection state ---
+function markDisconnected() {
+  if (!serverAlive) return;
+  serverAlive = false;
+  document.getElementById('status-dot').classList.add('stopped');
+  document.getElementById('stop-btn').disabled = true;
+  document.getElementById('stop-btn').textContent = 'Offline';
+  const name = document.getElementById('title').textContent;
+  document.title = '[offline] ' + name;
+}
+function markConnected() {
+  if (serverAlive) return;
+  serverAlive = true;
+  document.getElementById('status-dot').classList.remove('stopped');
+  document.getElementById('stop-btn').disabled = false;
+  document.getElementById('stop-btn').textContent = 'Stop Server';
+  document.title = document.getElementById('title').textContent;
+}
+
+// --- Sidebar ---
+function renderSidebar() {
+  const list = document.getElementById('agent-list');
+  if (teamWorkers.length === 0 && agentConfigs.length === 0) {
+    list.innerHTML = '<div class="nav-item empty" style="cursor:default">No agents yet</div>';
+    return;
+  }
+  // Match team workers to agent configs by name
+  let html = '';
+  for (const w of teamWorkers) {
+    const isActive = selectedAgent === w.id && currentView === 'agent';
+    const isLive = true; // they're in the team list, so alive
+    html += `<div class="nav-item${isActive ? ' active' : ''}" data-view="agent" data-worker-id="${esc(w.id)}" onclick="selectAgent('${esc(w.id)}')">`;
+    html += `<span class="dot${isLive ? ' live' : ''}"></span>`;
+    html += `<span class="name">${esc(w.name)}</span>`;
+    html += `<span class="role-tag">${esc(w.role)}</span>`;
+    html += `</div>`;
+  }
+  list.innerHTML = html || '<div class="nav-item empty" style="cursor:default">No agents yet</div>';
+}
+
+// --- View switching ---
+function selectView(view) {
+  currentView = view;
+  selectedAgent = null;
+  document.querySelectorAll('.sidebar .nav-item').forEach(el => el.classList.remove('active'));
+  const navEl = document.querySelector(`.sidebar .nav-item[data-view="${view}"]`);
+  if (navEl) navEl.classList.add('active');
+  showView(view);
+  renderCurrentView();
+}
+
+function selectAgent(workerId) {
+  currentView = 'agent';
+  selectedAgent = workerId;
+  document.querySelectorAll('.sidebar .nav-item').forEach(el => el.classList.remove('active'));
+  const navEl = document.querySelector(`.sidebar .nav-item[data-worker-id="${CSS.escape(workerId)}"]`);
+  if (navEl) navEl.classList.add('active');
+  showView('agent');
+  renderCurrentView();
+}
+
+function showView(view) {
+  document.getElementById('view-dashboard').classList.toggle('hidden', view !== 'dashboard');
+  document.getElementById('view-all').classList.toggle('hidden', view !== 'all');
+  document.getElementById('view-agent').classList.toggle('hidden', view !== 'agent');
+}
+
+// --- Agent detail tabs ---
+let agentTab = 'config';
+function selectAgentTab(tab) {
+  agentTab = tab;
+  document.querySelectorAll('.agent-detail .tab').forEach(el => el.classList.toggle('active', el.dataset.tab === tab));
+  document.getElementById('agent-config-panel').classList.toggle('hidden', tab !== 'config');
+  document.getElementById('agent-events-panel').classList.toggle('hidden', tab !== 'events');
+  if (tab === 'events') renderAgentEvents();
+}
+
+// --- Rendering ---
+function renderCurrentView() {
+  if (currentView === 'dashboard') renderDashboard();
+  else if (currentView === 'all') renderAllEvents();
+  else if (currentView === 'agent') renderAgentDetail();
+}
+
+function renderDashboard() {
+  renderSparkline();
+  // Recent events (last 20)
+  const container = document.getElementById('recent-events');
+  const recent = allEvents.slice(0, 20);
+  if (recent.length === 0) {
+    container.innerHTML = '<div class="empty">Waiting for events...</div>';
+    return;
+  }
+  container.innerHTML = recent.map(renderEvent).join('');
+}
+
+function renderAllEvents() {
+  const container = document.getElementById('view-all');
+  if (allEvents.length === 0) {
+    container.innerHTML = '<div class="empty">Waiting for events...</div>';
+    return;
+  }
+  container.innerHTML = allEvents.map(renderEvent).join('');
+}
+
+function renderAgentDetail() {
+  if (!selectedAgent) return;
+  const worker = teamWorkers.find(w => w.id === selectedAgent);
+  if (!worker) return;
+
+  // Config panel
+  const configPanel = document.getElementById('agent-config-panel');
+  const agentCfg = agentConfigs.find(a => a.name === worker.name);
+  let cfgHtml = '';
+  cfgHtml += configBlock('Name', worker.name);
+  cfgHtml += configBlock('Role', worker.role);
+  cfgHtml += configBlock('Description', worker.description);
+  cfgHtml += configBlock('Worker ID', worker.id);
+  const now = Math.floor(Date.now() / 1000) + serverTimeDrift;
+  const ttlSecs = Math.max(0, worker.expires_at - now);
+  cfgHtml += `<div class="config-section"><div class="config-label">TTL</div><div class="config-value"><span data-expires-at="${worker.expires_at}">${formatDuration(ttlSecs)}</span></div></div>`;
+  cfgHtml += configBlock('Capabilities', worker.capabilities.join(', ') || 'none');
+  if (agentCfg) {
+    cfgHtml += configBlock('Command', agentCfg.command || '--', true);
+    if (agentCfg.prompt) cfgHtml += configBlock('Prompt', agentCfg.prompt);
+  }
+  configPanel.innerHTML = cfgHtml;
+
+  // Events panel
+  if (agentTab === 'events') renderAgentEvents();
+}
+
+function renderAgentEvents() {
+  const panel = document.getElementById('agent-events-panel');
+  if (!selectedAgent) { panel.innerHTML = '<div class="empty">Select an agent</div>'; return; }
+  const filtered = allEvents.filter(ev => ev.worker_id === selectedAgent);
+  if (filtered.length === 0) {
+    panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
+    return;
+  }
+  panel.innerHTML = filtered.map(renderEvent).join('');
+}
+
+function configBlock(label, value, isCommand) {
+  return `<div class="config-section"><div class="config-label">${esc(label)}</div><div class="config-value${isCommand ? ' command' : ''}">${esc(value || '--')}</div></div>`;
+}
+
+function renderEvent(ev) {
+  const ts = ev._ts.toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  let html = `<div class="event"><div class="event-header"><span class="ts">${ts}</span><span class="kind kind-${esc(ev.kind)}">${esc(ev.kind)}</span><span class="detail">${esc(ev.detail)}</span></div>`;
+  if (ev.payload) {
+    html += `<div class="payload">${formatPayload(ev.kind, ev.payload)}</div>`;
+  }
+  html += '</div>';
+  return html;
+}
+
+function formatPayload(kind, p) {
+  if (kind === 'send' || kind === 'deliver') {
+    const from = p.from ? esc(p.from.slice(0,8)) + '...' : 'anonymous';
+    const to = p.to ? esc(p.to.slice(0,8)) + '...' : '?';
+    let s = `<span class="label">from:</span> ${from} <span class="label">to:</span> ${to}`;
+    if (p.body) s += `<br><span class="body-text">${esc(p.body)}</span>`;
+    return s;
+  }
+  if (kind === 'register') {
+    return `<span class="label">name:</span> ${esc(p.name||'')} <span class="label">role:</span> ${esc(p.role||'')}`;
+  }
+  return esc(JSON.stringify(p));
+}
+
+// --- Sparkline ---
+function tickSparkline() {
+  sparkData.shift();
+  sparkData.push(0);
+  if (currentView === 'dashboard') renderSparkline();
+}
+function renderSparkline() {
+  const el = document.getElementById('sparkline');
+  const max = Math.max(1, ...sparkData);
+  el.innerHTML = sparkData.map(v => {
+    const h = Math.max(1, Math.round((v / max) * 40));
+    return `<div class="bar" style="height:${h}px"></div>`;
+  }).join('');
+}
+
+// --- Client-side tick (uptime + TTL) ---
+function tickUI() {
+  if (!serverStartedAt) return;
+  const now = Math.floor(Date.now() / 1000) + serverTimeDrift;
+  // Uptime
+  const uptime = Math.max(0, now - serverStartedAt);
+  document.getElementById('dash-uptime').textContent = formatDuration(uptime);
+  // TTL countdown on sidebar agents (if visible) and agent detail
+  document.querySelectorAll('[data-expires-at]').forEach(el => {
+    const exp = parseInt(el.dataset.expiresAt, 10);
+    const ttl = Math.max(0, exp - now);
+    el.textContent = formatDuration(ttl);
+  });
+}
+function formatDuration(secs) {
+  if (secs >= 3600) {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    const s = secs % 60;
+    return h + 'h ' + m + 'm ' + s + 's';
+  }
+  if (secs >= 60) {
+    const m = Math.floor(secs / 60);
+    const s = secs % 60;
+    return m + 'm ' + s + 's';
+  }
+  return secs + 's';
+}
+
+// --- Stop server ---
+async function stopServer() {
+  if (!confirm('Stop the dispatch server? This will shut down all agents.')) return;
+  const btn = document.getElementById('stop-btn');
+  btn.disabled = true;
+  btn.textContent = 'Stopping...';
+  try {
+    await fetch('/api/shutdown', { method: 'POST' });
+  } catch(e) {}
+  markDisconnected();
+}
+
+// --- Util ---
+function esc(s) { if (s == null) return ''; const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+
+// --- Boot ---
+init();
 </script>
 </body>
 </html>

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -1,0 +1,70 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::Html;
+use axum::routing::get;
+use axum::Router;
+use futures_util::stream::Stream;
+use tokio::sync::{broadcast, Mutex};
+
+use super::local::{BrokerEvent, BrokerState};
+
+/// Shared state for the monitor HTTP server.
+#[derive(Clone)]
+pub struct MonitorState {
+    pub broker: Arc<Mutex<BrokerState>>,
+    pub events: broadcast::Sender<BrokerEvent>,
+}
+
+/// Start the HTTP monitor dashboard on the given port.
+pub async fn run_monitor(
+    port: u16,
+    state: MonitorState,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let app = Router::new()
+        .route("/", get(dashboard))
+        .route("/api/team", get(api_team))
+        .route("/api/events", get(api_events))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+    tracing::info!(port, "monitor dashboard listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Serve the embedded HTML dashboard.
+async fn dashboard() -> Html<&'static str> {
+    Html(include_str!("monitor.html"))
+}
+
+/// Return the current team as JSON.
+async fn api_team(State(state): State<MonitorState>) -> axum::Json<Vec<crate::protocol::Worker>> {
+    let mut broker = state.broker.lock().await;
+    let workers = broker.list_workers();
+    axum::Json(workers)
+}
+
+/// Stream broker events via Server-Sent Events.
+async fn api_events(
+    State(state): State<MonitorState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.events.subscribe();
+
+    let stream = futures_util::stream::unfold(rx, |mut rx| async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let sse_event = Event::default().event("broker").json_data(&event).unwrap();
+                    return Some((Ok(sse_event), rx));
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -52,8 +52,20 @@ async fn dashboard() -> Html<&'static str> {
 }
 
 /// Return the current team as JSON.
+/// Evicts expired workers first and emits expire events so the dashboard
+/// stays consistent even when no other request triggers eviction.
 async fn api_team(State(state): State<MonitorState>) -> axum::Json<Vec<crate::protocol::Worker>> {
     let mut broker = state.broker.lock().await;
+    let expired = broker.evict_expired();
+    for id in &expired {
+        let _ = state.events.send(super::local::BrokerEvent {
+            kind: "expire".to_string(),
+            worker_id: id.clone(),
+            detail: "worker expired".to_string(),
+            payload: None,
+            timestamp: super::local::now_secs(),
+        });
+    }
     let workers = broker.list_workers();
     axum::Json(workers)
 }

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -7,7 +7,7 @@ use axum::response::Html;
 use axum::routing::get;
 use axum::Router;
 use futures_util::stream::Stream;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, Notify};
 
 use super::local::{BrokerEvent, BrokerState};
 
@@ -16,6 +16,14 @@ use super::local::{BrokerEvent, BrokerState};
 pub struct MonitorState {
     pub broker: Arc<Mutex<BrokerState>>,
     pub events: broadcast::Sender<BrokerEvent>,
+    pub shutdown: Arc<Notify>,
+    pub name: Option<String>,
+    pub cell_id: String,
+    /// Unix timestamp (seconds) when the server started.
+    pub started_at: u64,
+    pub agents: Vec<crate::config::ResolvedAgentConfig>,
+    pub main_agent: Option<crate::config::MainAgentConfig>,
+    pub heartbeats: Vec<crate::config::HeartbeatConfig>,
 }
 
 /// Start the HTTP monitor dashboard on the given port.
@@ -27,6 +35,9 @@ pub async fn run_monitor(
         .route("/", get(dashboard))
         .route("/api/team", get(api_team))
         .route("/api/events", get(api_events))
+        .route("/api/health", get(api_health))
+        .route("/api/agents", get(api_agents))
+        .route("/api/shutdown", axum::routing::post(api_shutdown))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
@@ -67,4 +78,75 @@ async fn api_events(
     });
 
     Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Health check endpoint — returns server timestamps and stats.
+/// Sends absolute UTC timestamps so the UI can tick locally between polls.
+async fn api_health(State(state): State<MonitorState>) -> axum::Json<serde_json::Value> {
+    let mut broker = state.broker.lock().await;
+    let workers = broker.list_workers();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    axum::Json(serde_json::json!({
+        "status": "ok",
+        "name": state.name,
+        "cell_id": state.cell_id,
+        "started_at": state.started_at,
+        "server_time": now,
+        "workers": workers.len(),
+        "messages_sent": broker.messages_sent,
+        "messages_delivered": broker.messages_delivered,
+        "requests_handled": broker.requests_handled,
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+/// Return configured agent definitions (for the sidebar agent detail view).
+async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json::Value> {
+    let agents: Vec<serde_json::Value> = state
+        .agents
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "name": a.name,
+                "role": a.role,
+                "description": a.description,
+                "command": a.command,
+                "prompt": a.prompt,
+                "ttl": a.ttl,
+            })
+        })
+        .collect();
+    let main_agent = state.main_agent.as_ref().map(|m| {
+        serde_json::json!({
+            "command": m.command,
+            "model": m.model,
+            "prompt": m.prompt,
+        })
+    });
+    let heartbeats: Vec<serde_json::Value> = state
+        .heartbeats
+        .iter()
+        .map(|h| {
+            serde_json::json!({
+                "name": h.name,
+                "command": h.command,
+                "every": h.every,
+            })
+        })
+        .collect();
+    axum::Json(serde_json::json!({
+        "agents": agents,
+        "main_agent": main_agent,
+        "heartbeats": heartbeats,
+    }))
+}
+
+/// Trigger a graceful server shutdown from the monitor UI.
+async fn api_shutdown(State(state): State<MonitorState>) -> axum::http::StatusCode {
+    tracing::info!("shutdown requested via monitor");
+    state.shutdown.notify_one();
+    axum::http::StatusCode::OK
 }

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -40,7 +40,7 @@ pub async fn run_monitor(
         .route("/api/shutdown", axum::routing::post(api_shutdown))
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
     tracing::info!(port, "monitor dashboard listening");
     axum::serve(listener, app).await?;
     Ok(())

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -1,0 +1,332 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tokio::process::{Child, Command};
+
+use crate::config::ResolvedAgentConfig;
+use crate::errors::DispatchError;
+
+/// Kill an entire process group. Sends SIGTERM first, then SIGKILL after a timeout.
+async fn kill_process_group(pid: u32) {
+    let pgid = pid as i32;
+    // Send SIGTERM to the process group.
+    unsafe {
+        libc::kill(-pgid, libc::SIGTERM);
+    }
+    // Give processes a moment to exit gracefully.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    // Force kill any remaining processes.
+    unsafe {
+        libc::kill(-pgid, libc::SIGKILL);
+    }
+}
+
+/// Standard dispatch-comms instructions embedded at compile time.
+const DISPATCH_COMMS: &str = include_str!("comms.md");
+
+/// Info about a running agent for external queries.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentInfo {
+    pub name: String,
+    pub role: String,
+    pub pid: u32,
+    pub running: bool,
+}
+
+/// A running agent subprocess.
+struct RunningAgent {
+    name: String,
+    role: String,
+    child: Child,
+    pid: u32,
+}
+
+/// A running heartbeat timer task.
+struct RunningHeartbeat {
+    name: String,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+/// Manages the lifecycle of agent subprocesses and heartbeat timers.
+pub struct AgentOrchestrator {
+    agents: Vec<RunningAgent>,
+    heartbeats: Vec<RunningHeartbeat>,
+    cell_id: String,
+    socket_path: PathBuf,
+    monitor_url: Option<String>,
+    project_root: PathBuf,
+}
+
+impl AgentOrchestrator {
+    pub fn new(
+        cell_id: &str,
+        socket_path: &Path,
+        monitor_url: Option<String>,
+        project_root: &Path,
+    ) -> Self {
+        Self {
+            agents: Vec::new(),
+            heartbeats: Vec::new(),
+            cell_id: cell_id.to_string(),
+            socket_path: socket_path.to_path_buf(),
+            monitor_url,
+            project_root: project_root.to_path_buf(),
+        }
+    }
+
+    /// Build the environment variables injected into every agent subprocess.
+    fn env_vars(&self, name: &str, role: &str) -> HashMap<String, String> {
+        let mut vars = HashMap::new();
+        vars.insert("DISPATCH_CELL_ID".into(), self.cell_id.clone());
+        vars.insert(
+            "DISPATCH_SOCKET_PATH".into(),
+            self.socket_path.display().to_string(),
+        );
+        if let Some(ref url) = self.monitor_url {
+            vars.insert("DISPATCH_MONITOR_URL".into(), url.clone());
+        }
+        vars.insert("DISPATCH_AGENT_NAME".into(), name.into());
+        vars.insert("DISPATCH_AGENT_ROLE".into(), role.into());
+        vars
+    }
+
+    /// Build the full shell command for an agent.
+    fn build_command(config: &ResolvedAgentConfig) -> String {
+        let base = &config.command;
+
+        // For claude/codex commands, append the prompt with comms instructions
+        let is_llm = base.starts_with("claude") || base.starts_with("codex");
+        if is_llm {
+            let full_prompt = if let Some(ref prompt) = config.prompt {
+                format!("{DISPATCH_COMMS}\n\n---\n\n{prompt}")
+            } else {
+                DISPATCH_COMMS.to_string()
+            };
+            format!("{base} -p {}", shell_escape(&full_prompt))
+        } else {
+            // Shell commands run as-is with env vars
+            base.clone()
+        }
+    }
+
+    /// Spawn a single agent as a subprocess.
+    pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
+        let env_vars = self.env_vars(&config.name, &config.role);
+        let full_command = Self::build_command(config);
+
+        tracing::info!(
+            agent = %config.name,
+            role = %config.role,
+            command = %config.command,
+            "launching agent"
+        );
+
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg(&full_command)
+            .envs(&env_vars)
+            .current_dir(&self.project_root)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .process_group(0) // Own process group so we can kill the whole tree.
+            .spawn()
+            .map_err(|e| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: e.to_string(),
+            })?;
+
+        let pid = child.id().unwrap_or(0);
+        eprintln!(
+            "dispatch serve: launched agent '{}' (role={}, pid={})",
+            config.name, config.role, pid
+        );
+
+        self.agents.push(RunningAgent {
+            name: config.name.clone(),
+            role: config.role.clone(),
+            child,
+            pid,
+        });
+
+        Ok(())
+    }
+
+    /// Launch all configured agents sequentially with a brief pause between.
+    pub async fn launch_all(
+        &mut self,
+        configs: &[ResolvedAgentConfig],
+    ) -> Result<(), DispatchError> {
+        for config in configs {
+            self.spawn_agent(config).await?;
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        Ok(())
+    }
+
+    /// Return info about all agents.
+    pub fn list(&mut self) -> Vec<AgentInfo> {
+        self.agents
+            .iter_mut()
+            .map(|a| {
+                let running = a.child.try_wait().ok().flatten().is_none();
+                AgentInfo {
+                    name: a.name.clone(),
+                    role: a.role.clone(),
+                    pid: a.pid,
+                    running,
+                }
+            })
+            .collect()
+    }
+
+    /// Start all configured heartbeat timers.
+    pub fn start_heartbeats(
+        &mut self,
+        configs: &[crate::config::HeartbeatConfig],
+        event_tx: &tokio::sync::broadcast::Sender<super::local::BrokerEvent>,
+    ) {
+        for config in configs {
+            let name = config.name.clone();
+            let command = config.command.clone();
+            let every = config.every;
+            let after = config.after.unwrap_or(0);
+            let cell_id = self.cell_id.clone();
+            let socket_path = self.socket_path.display().to_string();
+            let project_root = self.project_root.clone();
+            let event_tx = event_tx.clone();
+
+            if after > 0 {
+                eprintln!(
+                    "dispatch serve: heartbeat '{}' every {}s (after {}s): {}",
+                    name, every, after, command
+                );
+            } else {
+                eprintln!(
+                    "dispatch serve: heartbeat '{}' every {}s: {}",
+                    name, every, command
+                );
+            }
+
+            let hb_name = name.clone();
+            let handle = tokio::spawn(async move {
+                // Initial delay: use `after` for first wait, then `every` thereafter.
+                let first_delay = if after > 0 { after } else { every };
+                tokio::time::sleep(std::time::Duration::from_secs(first_delay)).await;
+
+                loop {
+                    tracing::debug!(heartbeat = %hb_name, "firing heartbeat");
+
+                    let result = tokio::process::Command::new("sh")
+                        .arg("-c")
+                        .arg(&command)
+                        .env("DISPATCH_CELL_ID", &cell_id)
+                        .env("DISPATCH_SOCKET_PATH", &socket_path)
+                        .current_dir(&project_root)
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status()
+                        .await;
+
+                    let detail = match result {
+                        Ok(status) if status.success() => format!("{hb_name}: ok"),
+                        Ok(status) => {
+                            format!("{hb_name}: exit {}", status.code().unwrap_or(-1))
+                        }
+                        Err(e) => format!("{hb_name}: error: {e}"),
+                    };
+
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    let _ = event_tx.send(super::local::BrokerEvent {
+                        kind: "heartbeat".into(),
+                        worker_id: String::new(),
+                        detail,
+                        payload: Some(serde_json::json!({
+                            "name": hb_name,
+                            "command": command,
+                            "every": every,
+                        })),
+                        timestamp: now,
+                    });
+
+                    tokio::time::sleep(std::time::Duration::from_secs(every)).await;
+                }
+            });
+
+            self.heartbeats.push(RunningHeartbeat { name, handle });
+        }
+    }
+
+    /// Kill all running agent processes, cancel heartbeats, and wait for cleanup.
+    pub async fn shutdown_all(&mut self) {
+        // Cancel heartbeat timers.
+        for hb in &self.heartbeats {
+            tracing::info!(heartbeat = %hb.name, "stopping heartbeat");
+            hb.handle.abort();
+        }
+        self.heartbeats.clear();
+
+        // Kill agent processes.
+        for agent in &mut self.agents {
+            if agent.child.try_wait().ok().flatten().is_none() {
+                tracing::info!(agent = %agent.name, pid = agent.pid, "stopping agent");
+                kill_process_group(agent.pid).await;
+                // Reap the child to avoid zombies.
+                let _ = agent.child.wait().await;
+            }
+        }
+        self.agents.clear();
+    }
+
+    /// Stop a specific agent by name.
+    pub async fn stop_agent(&mut self, name: &str) -> bool {
+        if let Some(idx) = self.agents.iter().position(|a| a.name == name) {
+            let agent = &mut self.agents[idx];
+            if agent.child.try_wait().ok().flatten().is_none() {
+                kill_process_group(agent.pid).await;
+                let _ = agent.child.wait().await;
+            }
+            self.agents.remove(idx);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Build the main agent command string for the user to paste.
+pub fn build_main_agent_command(
+    main: &crate::config::MainAgentConfig,
+    cell_id: &str,
+    monitor_url: Option<&str>,
+) -> String {
+    let mut parts = vec![format!("DISPATCH_CELL_ID={cell_id}")];
+
+    if let Some(url) = monitor_url {
+        parts.push(format!("DISPATCH_MONITOR_URL={url}"));
+    }
+
+    parts.push(main.command.clone());
+
+    if let Some(ref model) = main.model {
+        parts.push(format!("--model {model}"));
+    }
+
+    if let Some(ref prompt) = main.prompt {
+        let full_prompt = format!("{DISPATCH_COMMS}\n\n---\n\n{prompt}");
+        parts.push(format!("\"{}\"", full_prompt.replace('"', "\\\"")));
+    } else {
+        parts.push(format!("\"{}\"", DISPATCH_COMMS.replace('"', "\\\"")));
+    }
+
+    parts.join(" ")
+}
+
+/// Shell-escape a string for use in `sh -c` commands.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,11 @@ pub enum Commands {
     Init,
 
     /// Start the embedded broker server on a Unix domain socket
-    Serve,
+    Serve {
+        /// Start an HTTP monitor dashboard on this port
+        #[arg(long)]
+        monitor: Option<u16>,
+    },
 
     /// Register a worker with the broker
     Register {
@@ -48,6 +52,10 @@ pub enum Commands {
         /// Worker capabilities (repeatable)
         #[arg(long = "capability")]
         capabilities: Vec<String>,
+
+        /// Worker TTL in seconds (default: 300)
+        #[arg(long)]
+        ttl: Option<u64>,
     },
 
     /// List active workers in the current cell

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub cell_id: Option<String>,
 
+    /// Identify the calling worker (renews TTL on all commands, used as sender on send)
+    #[arg(long, global = true)]
+    pub from: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -70,10 +74,6 @@ pub enum Commands {
         /// Message body
         #[arg(long)]
         body: String,
-
-        /// Sender identity (optional)
-        #[arg(long)]
-        from: Option<String>,
     },
 
     /// Long-poll for incoming messages

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,22 +10,161 @@ use crate::errors::DispatchError;
 /// Runtime configuration for Dispatch, resolved from multiple sources.
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
+    /// Human-readable project name (shown in monitor dashboard).
+    pub name: Option<String>,
     /// The cell identity for this project.
     pub cell_id: String,
     /// Backend URL (if configured).
     pub backend: Option<String>,
     /// The project root (directory containing dispatch.config.toml, or cwd).
     pub project_root: PathBuf,
+    /// Monitor dashboard port (from config or CLI flag).
+    pub monitor_port: Option<u16>,
+    /// Agent definitions to launch on serve.
+    pub agents: Vec<ResolvedAgentConfig>,
+    /// Main interactive agent (printed as a command, not auto-launched).
+    pub main_agent: Option<MainAgentConfig>,
+    /// Scheduled heartbeat commands.
+    pub heartbeats: Vec<HeartbeatConfig>,
+}
+
+/// Agent config after prompt_file has been resolved to prompt text.
+#[derive(Debug, Clone)]
+pub struct ResolvedAgentConfig {
+    pub name: String,
+    pub role: String,
+    pub description: String,
+    pub command: String,
+    pub prompt: Option<String>,
+    pub ttl: Option<u64>,
 }
 
 /// On-disk config file shape.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigFile {
+    /// Human-readable project name.
+    pub name: Option<String>,
     /// Explicit cell identity override.
     pub cell_id: Option<String>,
     /// Backend URL.
     pub backend: Option<String>,
+    /// Monitor dashboard configuration.
+    pub monitor: Option<MonitorConfig>,
+    /// Agent definitions to launch on serve.
+    #[serde(default)]
+    pub agents: Vec<AgentConfig>,
+    /// Main interactive agent configuration.
+    pub main_agent: Option<MainAgentConfig>,
+    /// Scheduled heartbeat commands.
+    #[serde(default)]
+    pub heartbeats: Vec<HeartbeatConfig>,
+}
+
+/// On-disk heartbeat (scheduled command) definition.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HeartbeatConfig {
+    /// Name for this heartbeat (shown in monitor/logs).
+    pub name: String,
+    /// Shell command to execute.
+    pub command: String,
+    /// Interval in seconds between executions.
+    pub every: u64,
+    /// Initial delay in seconds before the first execution.
+    #[serde(default)]
+    pub after: Option<u64>,
+}
+
+/// On-disk monitor configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MonitorConfig {
+    pub port: u16,
+}
+
+/// On-disk agent definition.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentConfig {
+    pub name: String,
+    pub role: String,
+    pub description: String,
+    pub command: String,
+    pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
+    pub ttl: Option<u64>,
+}
+
+/// On-disk main agent definition.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MainAgentConfig {
+    pub command: String,
+    pub model: Option<String>,
+    pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
+}
+
+/// Resolve an agent config by reading prompt_file if specified.
+fn resolve_agent_config(
+    agent: &AgentConfig,
+    project_root: &Path,
+) -> Result<ResolvedAgentConfig, DispatchError> {
+    let prompt = match (&agent.prompt, &agent.prompt_file) {
+        (Some(_), Some(_)) => {
+            return Err(DispatchError::AgentConfigError {
+                name: agent.name.clone(),
+                reason: "cannot specify both 'prompt' and 'prompt_file'".into(),
+            });
+        }
+        (Some(p), None) => Some(p.clone()),
+        (None, Some(path)) => {
+            let full_path = project_root.join(path);
+            let content = std::fs::read_to_string(&full_path).map_err(|_| {
+                DispatchError::PromptFileNotFound {
+                    name: agent.name.clone(),
+                    path: full_path,
+                }
+            })?;
+            Some(content)
+        }
+        (None, None) => None,
+    };
+
+    Ok(ResolvedAgentConfig {
+        name: agent.name.clone(),
+        role: agent.role.clone(),
+        description: agent.description.clone(),
+        command: agent.command.clone(),
+        prompt,
+        ttl: agent.ttl,
+    })
+}
+
+/// Resolve the main agent prompt_file if specified.
+fn resolve_main_agent_prompt(
+    main: &MainAgentConfig,
+    project_root: &Path,
+) -> Result<Option<String>, DispatchError> {
+    match (&main.prompt, &main.prompt_file) {
+        (Some(_), Some(_)) => Err(DispatchError::AgentConfigError {
+            name: "main_agent".into(),
+            reason: "cannot specify both 'prompt' and 'prompt_file'".into(),
+        }),
+        (Some(p), None) => Ok(Some(p.clone())),
+        (None, Some(path)) => {
+            let full_path = project_root.join(path);
+            let content = std::fs::read_to_string(&full_path).map_err(|_| {
+                DispatchError::PromptFileNotFound {
+                    name: "main_agent".into(),
+                    path: full_path,
+                }
+            })?;
+            Ok(Some(content))
+        }
+        (None, None) => Ok(None),
+    }
 }
 
 /// Search upward from `start_dir` for `dispatch.config.toml`.
@@ -70,10 +209,39 @@ const CONFIG_TEMPLATE: &str = "\
 # Dispatch configuration
 # https://github.com/codesoda/dispatch-cli
 
+# Human-readable project name (shown in monitor dashboard).
+# name = \"My Project\"
+
 # Cell identity for this project.
 # If omitted, a stable ID is derived from the project directory path.
 # Override precedence: --cell-id flag > DISPATCH_CELL_ID env var > this value > derived
 # cell_id = \"my-project\"
+
+# Monitor dashboard — starts an HTTP dashboard on serve
+# [monitor]
+# port = 8384
+
+# Agent definitions — launched automatically by `dispatch serve`
+# [[agents]]
+# name = \"reviewer\"
+# role = \"code-reviewer\"
+# description = \"Reviews code changes\"
+# command = \"claude --model sonnet\"
+# prompt_file = \"prompts/reviewer.md\"
+# ttl = 3600
+
+# Main interactive agent — printed as a ready-to-paste command
+# [main_agent]
+# command = \"claude\"
+# model = \"opus\"
+# prompt = \"You are the lead agent for this project...\"
+
+# Scheduled heartbeats — commands run on a timer while the broker is running
+# [[heartbeats]]
+# name = \"check-prs\"
+# command = \"dispatch send --to $GITHUB_AGENT --body '{\\\"type\\\":\\\"check_prs\\\"}'\"
+# every = 120
+# after = 30  # optional: wait this long before the first execution
 ";
 
 /// Create a `dispatch.config.toml` in `cwd` with commented-out defaults.
@@ -141,12 +309,49 @@ fn resolve_config_inner(
         derive_cell_id(&project_root)
     };
 
-    let backend = config_file.and_then(|c| c.backend);
+    // Extract fields from config file
+    let (name, backend, monitor_config, raw_agents, main_agent_config, heartbeats) =
+        match config_file {
+            Some(c) => (
+                c.name,
+                c.backend,
+                c.monitor,
+                c.agents,
+                c.main_agent,
+                c.heartbeats,
+            ),
+            None => (None, None, None, vec![], None, vec![]),
+        };
+    let monitor_port = monitor_config.map(|m| m.port);
+
+    // Resolve agent prompt files
+    let agents: Vec<ResolvedAgentConfig> = raw_agents
+        .iter()
+        .map(|a| resolve_agent_config(a, &project_root))
+        .collect::<Result<_, _>>()?;
+
+    // Resolve main agent prompt file
+    let main_agent = if let Some(ref ma) = main_agent_config {
+        let resolved_prompt = resolve_main_agent_prompt(ma, &project_root)?;
+        Some(MainAgentConfig {
+            command: ma.command.clone(),
+            model: ma.model.clone(),
+            prompt: resolved_prompt,
+            prompt_file: None,
+        })
+    } else {
+        None
+    };
 
     Ok(ResolvedConfig {
+        name,
         cell_id,
         backend,
         project_root,
+        monitor_port,
+        agents,
+        main_agent,
+        heartbeats,
     })
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,15 @@ pub enum DispatchError {
     #[error("connection failed: {reason}")]
     ConnectionFailed { reason: String },
 
+    #[error("agent config error for \"{name}\": {reason}")]
+    AgentConfigError { name: String, reason: String },
+
+    #[error("failed to launch agent \"{name}\": {reason}")]
+    AgentLaunchFailed { name: String, reason: String },
+
+    #[error("prompt file not found for agent \"{name}\": {path}")]
+    PromptFileNotFound { name: String, path: PathBuf },
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,30 +41,40 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
 
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
 
+    // Extract monitor port before matching (Serve consumes it).
+    let monitor_port = if let Commands::Serve { monitor } = &cli.command {
+        *monitor
+    } else {
+        None
+    };
+
     let backend = create_backend(
         config.backend.as_deref(),
         &config.project_root,
         &config.cell_id,
+        monitor_port,
     )?;
 
     match cli.command {
-        Commands::Serve => {
+        Commands::Serve { .. } => {
             backend.serve().await?;
         }
         cmd => {
             let request = match cmd {
                 Commands::Init => unreachable!(),
-                Commands::Serve => unreachable!(),
+                Commands::Serve { .. } => unreachable!(),
                 Commands::Register {
                     name,
                     role,
                     description,
                     capabilities,
+                    ttl,
                 } => BrokerRequest::Register {
                     name,
                     role,
                     description,
                     capabilities,
+                    ttl_secs: ttl,
                 },
                 Commands::Team => BrokerRequest::Team,
                 Commands::Send { to, body, from } => BrokerRequest::Send { to, body, from },

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,19 +41,14 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
 
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
 
-    // Extract monitor port before matching (Serve consumes it).
+    // Extract monitor port: CLI flag takes precedence over config.
     let monitor_port = if let Commands::Serve { monitor } = &cli.command {
-        *monitor
+        monitor.or(config.monitor_port)
     } else {
         None
     };
 
-    let backend = create_backend(
-        config.backend.as_deref(),
-        &config.project_root,
-        &config.cell_id,
-        monitor_port,
-    )?;
+    let backend = create_backend(&config, monitor_port)?;
 
     match cli.command {
         Commands::Serve { .. } => {
@@ -76,8 +71,14 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     capabilities,
                     ttl_secs: ttl,
                 },
-                Commands::Team => BrokerRequest::Team,
-                Commands::Send { to, body, from } => BrokerRequest::Send { to, body, from },
+                Commands::Team => BrokerRequest::Team {
+                    from: cli.from.clone(),
+                },
+                Commands::Send { to, body } => BrokerRequest::Send {
+                    to,
+                    body,
+                    from: cli.from.clone(),
+                },
                 Commands::Listen { worker_id, timeout } => BrokerRequest::Listen {
                     worker_id,
                     timeout_secs: timeout,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -20,6 +20,8 @@ pub enum BrokerRequest {
         role: String,
         description: String,
         capabilities: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ttl_secs: Option<u64>,
     },
     /// List active workers.
     Team,
@@ -109,6 +111,7 @@ mod tests {
                 role: "builder".into(),
                 description: "test".into(),
                 capabilities: vec!["rust".into()],
+                ttl_secs: None,
             },
             BrokerRequest::Team,
             BrokerRequest::Send {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -24,7 +24,10 @@ pub enum BrokerRequest {
         ttl_secs: Option<u64>,
     },
     /// List active workers.
-    Team,
+    Team {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        from: Option<String>,
+    },
     /// Send a message to a worker.
     Send {
         to: String,
@@ -113,7 +116,7 @@ mod tests {
                 capabilities: vec!["rust".into()],
                 ttl_secs: None,
             },
-            BrokerRequest::Team,
+            BrokerRequest::Team { from: None },
             BrokerRequest::Send {
                 to: "w1".into(),
                 body: "hello".into(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,13 +1,27 @@
-use std::process::{Child, Command};
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
 use assert_cmd::cargo::CommandCargoExt;
 use tempfile::TempDir;
 
+/// RAII guard that kills the broker child process on drop.
+/// Ensures cleanup even if a test panics.
+struct BrokerGuard {
+    child: std::process::Child,
+}
+
+impl Drop for BrokerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 /// Start a `dispatch serve` broker as a background process in the given
-/// temp directory with the given cell ID. Returns the child process handle.
-fn start_broker(dir: &TempDir, cell_id: &str) -> Child {
+/// temp directory with the given cell ID. Returns a guard that kills
+/// the broker when dropped.
+fn start_broker(dir: &TempDir, cell_id: &str) -> BrokerGuard {
     // Remove any stale socket from a previous test run so the broker
     // can bind cleanly.
     let socket =
@@ -26,7 +40,7 @@ fn start_broker(dir: &TempDir, cell_id: &str) -> Child {
         .expect("failed to start broker");
     for _ in 0..50 {
         if socket.exists() {
-            return child;
+            return BrokerGuard { child };
         }
         thread::sleep(Duration::from_millis(50));
     }
@@ -68,16 +82,13 @@ fn serve_creates_socket_file() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-serve-socket";
 
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
     let socket =
         std::path::PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"));
     assert!(
         socket.exists(),
         "socket file should exist while broker runs"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── Register + Team round-trip ────────────────────────────────────────
@@ -86,7 +97,7 @@ fn serve_creates_socket_file() {
 fn register_returns_worker_id() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-register";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     let output = dispatch_cmd(&dir, cell_id)
         .args([
@@ -111,16 +122,13 @@ fn register_returns_worker_id() {
         json["worker_id"].is_string(),
         "response should contain worker_id"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 #[test]
 fn team_lists_registered_workers() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-team";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     // Register a worker first.
     dispatch_cmd(&dir, cell_id)
@@ -157,9 +165,6 @@ fn team_lists_registered_workers() {
     assert_eq!(workers[0]["name"], "bob");
     assert_eq!(workers[0]["role"], "tester");
     assert_eq!(workers[0]["capabilities"][0], "rust");
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── Send + Listen round-trip ──────────────────────────────────────────
@@ -168,7 +173,7 @@ fn team_lists_registered_workers() {
 fn send_and_listen_round_trip() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-send-listen";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     // Register a worker.
     let reg_out = dispatch_cmd(&dir, cell_id)
@@ -225,9 +230,6 @@ fn send_and_listen_round_trip() {
     assert_eq!(listen_json["body"], "hello from test");
     assert_eq!(listen_json["from"], "test-harness");
     assert_eq!(listen_json["to"], worker_id);
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── Error cases ───────────────────────────────────────────────────────
@@ -236,7 +238,7 @@ fn send_and_listen_round_trip() {
 fn send_to_invalid_worker_returns_error_response() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-send-invalid";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     // The broker returns a JSON error response (exit 0) when the
     // recipient worker does not exist. The CLI only exits non-zero
@@ -265,9 +267,6 @@ fn send_to_invalid_worker_returns_error_response() {
             .contains("nonexistent-worker"),
         "error message should mention the missing worker"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── Heartbeat ─────────────────────────────────────────────────────────
@@ -276,7 +275,7 @@ fn send_to_invalid_worker_returns_error_response() {
 fn heartbeat_renews_worker_ttl() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-heartbeat";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     // Register a worker.
     let reg_out = dispatch_cmd(&dir, cell_id)
@@ -314,9 +313,6 @@ fn heartbeat_renews_worker_ttl() {
         hb_json["expires_at"].is_number(),
         "should return expires_at timestamp"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── Listen timeout ────────────────────────────────────────────────────
@@ -325,7 +321,7 @@ fn heartbeat_renews_worker_ttl() {
 fn listen_times_out_with_no_messages() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-listen-timeout";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     // Register a worker.
     let reg_out = dispatch_cmd(&dir, cell_id)
@@ -372,9 +368,6 @@ fn listen_times_out_with_no_messages() {
         json.get("expires_at").is_none(),
         "timeout should not contain expires_at"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }
 
 // ── stdout/stderr separation ──────────────────────────────────────────
@@ -383,7 +376,7 @@ fn listen_times_out_with_no_messages() {
 fn stdout_is_json_stderr_is_empty_on_success() {
     let dir = TempDir::new().unwrap();
     let cell_id = "test-stdio-sep";
-    let mut broker = start_broker(&dir, cell_id);
+    let _broker = start_broker(&dir, cell_id);
 
     let output = dispatch_cmd(&dir, cell_id)
         .arg("team")
@@ -402,7 +395,4 @@ fn stdout_is_json_stderr_is_empty_on_success() {
         stderr.is_empty(),
         "stderr should be empty on success, got: {stderr}"
     );
-
-    broker.kill().ok();
-    broker.wait().ok();
 }


### PR DESCRIPTION
## Summary

- **Declarative agent orchestration** — define `[[agents]]` and `[main_agent]` in `dispatch.config.toml`; agents auto-launch on `dispatch serve` with embedded comms instructions and env vars
- **Redesigned monitor dashboard** — sidebar with Dashboard/All Events/per-agent views, health stats cards, event volume sparkline, agent config+events detail panel, stop server button, connection state indicator
- **Scheduled heartbeats** — `[[heartbeats]]` config runs commands on a timer with optional `after` delay for initial wait
- **Global `--from` flag** — identifies the calling worker on every command, renews TTL on team/send/listen
- **`name` field in config** — human-readable project name shown as monitor page title
- **Health API** (`GET /api/health`) — server timestamps, uptime, message/request counters, version
- **Agents API** (`GET /api/agents`) — configured agent definitions, main agent, heartbeat configs
- **Shutdown API** (`POST /api/shutdown`) — graceful stop from the monitor UI
- **Rich event payloads** — full structured data (from, to, body) in console output and web UI events
- **Process group cleanup** — agents spawn in own pgid, shutdown sends SIGTERM→SIGKILL to whole tree, reaps children
- **Test cleanup** — RAII `BrokerGuard` in integration tests prevents orphaned broker processes

## Test plan

- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test` — all 69 tests pass (59 unit + 10 integration)
- [ ] `dispatch init` creates config with all new sections commented out
- [ ] Existing configs without `[[agents]]`/`[[heartbeats]]` still work unchanged
- [ ] `dispatch serve --monitor 8384` with agents config: agents spawn, register, monitor shows them
- [ ] Monitor dashboard: sidebar navigation, health stats tick every second, sparkline updates, agent detail shows config+events
- [ ] Stop Server button triggers graceful shutdown of agents and broker
- [ ] `--from` flag renews TTL on team/send/listen commands
- [ ] Heartbeats fire on schedule, emit events to monitor, cancel on shutdown
- [ ] No orphaned processes after `cargo test` or broker shutdown