### PR TITLE
feat: monitor open config and --config flag (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `open` option in `[monitor]` config — automatically opens the dashboard in your default browser on `dispatch serve`
+- `--config <PATH>` global flag — specify an explicit config file path instead of requiring `dispatch.config.toml` in the current directory
+
+### Changed
+- Config file lookup no longer walks parent directories — it checks the current directory only, or uses the explicit `--config` path
+- `project_root` is set to the directory containing the config file, so `prompt_file` and other relative paths resolve from the config location
 
 ## [0.3.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-16
+
+### Added
+- `open` option in `[monitor]` config — automatically opens the dashboard in your default browser on `dispatch serve`
+
 ## [0.3.0] - 2026-04-13
 
 ### Added
@@ -63,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binary integration tests for all CLI commands
 - GitHub Actions CI workflow (fmt, clippy, build, test)
 
-[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/codesoda/dispatch-cli/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/codesoda/dispatch-cli/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/codesoda/dispatch-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/codesoda/dispatch-cli/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/codesoda/dispatch-cli/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "libc",
+ "open",
  "predicates",
  "reqwest",
  "semver",
@@ -750,6 +751,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +934,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +972,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 
@@ -22,6 +22,7 @@ async-trait = "0.1.89"
 axum = "0.8"
 futures-util = "0.3"
 libc = "0.2"
+open = "5.3.3"
 
 [profile.release]
 strip = true

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -343,6 +343,11 @@ pub async fn serve(
         });
         let url = format!("http://localhost:{port}");
         eprintln!("dispatch serve: monitor dashboard at {url}");
+        if config.monitor_open {
+            if let Err(e) = open::that(&url) {
+                tracing::warn!(error = %e, "failed to open monitor in browser");
+            }
+        }
         Some(url)
     } else {
         None
@@ -756,6 +761,7 @@ mod tests {
             backend: None,
             project_root: project_root.to_path_buf(),
             monitor_port: None,
+            monitor_open: false,
             agents: vec![],
             main_agent: None,
             heartbeats: vec![],

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,10 @@ Exit codes:
 Docs: https://github.com/codesoda/dispatch"
 )]
 pub struct Cli {
+    /// Path to dispatch.config.toml (default: ./dispatch.config.toml)
+    #[arg(long, global = true)]
+    pub config: Option<std::path::PathBuf>,
+
     /// Override the cell identity (takes precedence over env var and config)
     #[arg(long, global = true)]
     pub cell_id: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,18 +172,14 @@ fn resolve_main_agent_prompt(
     }
 }
 
-/// Search upward from `start_dir` for `dispatch.config.toml`.
+/// Find `dispatch.config.toml` in the current directory.
 /// Returns the path to the config file and the directory containing it.
-pub fn find_config_file(start_dir: &Path) -> Option<(PathBuf, PathBuf)> {
-    let mut current = start_dir.to_path_buf();
-    loop {
-        let candidate = current.join("dispatch.config.toml");
-        if candidate.is_file() {
-            return Some((candidate, current));
-        }
-        if !current.pop() {
-            return None;
-        }
+pub fn find_config_file(cwd: &Path) -> Option<(PathBuf, PathBuf)> {
+    let candidate = cwd.join("dispatch.config.toml");
+    if candidate.is_file() {
+        Some((candidate, cwd.to_path_buf()))
+    } else {
+        None
     }
 }
 
@@ -262,42 +258,41 @@ pub fn init_config(cwd: &Path) -> Result<PathBuf, DispatchError> {
         return Err(DispatchError::ConfigAlreadyExists { path: config_path });
     }
 
-    // Check for config in a parent directory (skip cwd itself)
-    if let Some(parent) = cwd.parent() {
-        if let Some((parent_config, _)) = find_config_file(parent) {
-            eprintln!(
-                "Note: found existing config at {}, creating a new one in the current directory",
-                parent_config.display()
-            );
-        }
-    }
-
     std::fs::write(&config_path, CONFIG_TEMPLATE)?;
     Ok(config_path)
 }
 
 /// Resolve configuration with full precedence:
 /// CLI flag > env var > config file > derived fallback.
+///
+/// If `cli_config_path` is provided, that file is loaded directly and
+/// `project_root` is set to its parent directory.  Otherwise we look for
+/// `dispatch.config.toml` in `cwd`.
 pub fn resolve_config(
     cli_cell_id: Option<&str>,
-    start_dir: &Path,
+    cli_config_path: Option<&Path>,
+    cwd: &Path,
 ) -> Result<ResolvedConfig, DispatchError> {
     let env_cell_id = env::var("DISPATCH_CELL_ID").ok();
-    resolve_config_inner(cli_cell_id, env_cell_id.as_deref(), start_dir)
+    resolve_config_inner(cli_cell_id, env_cell_id.as_deref(), cli_config_path, cwd)
 }
 
 fn resolve_config_inner(
     cli_cell_id: Option<&str>,
     env_cell_id: Option<&str>,
-    start_dir: &Path,
+    cli_config_path: Option<&Path>,
+    cwd: &Path,
 ) -> Result<ResolvedConfig, DispatchError> {
-    // Try to find and load config file
-    let (config_file, project_root) = if let Some((config_path, root)) = find_config_file(start_dir)
-    {
+    // Locate config: explicit --config path, or dispatch.config.toml in cwd.
+    let (config_file, project_root) = if let Some(path) = cli_config_path {
+        let config = load_config_file(path)?;
+        let root = path.parent().unwrap_or(cwd).to_path_buf();
+        (Some(config), root)
+    } else if let Some((config_path, root)) = find_config_file(cwd) {
         let config = load_config_file(&config_path)?;
         (Some(config), root)
     } else {
-        (None, start_dir.to_path_buf())
+        (None, cwd.to_path_buf())
     };
 
     // Resolve cell_id with precedence: CLI > env > config > derived
@@ -329,7 +324,7 @@ fn resolve_config_inner(
             None => (None, None, None, vec![], None, vec![]),
         };
     let monitor_port = monitor_config.as_ref().map(|m| m.port);
-    let monitor_open = monitor_config.as_ref().map_or(false, |m| m.open);
+    let monitor_open = monitor_config.as_ref().is_some_and(|m| m.open);
 
     // Resolve agent prompt files
     let agents: Vec<ResolvedAgentConfig> = raw_agents
@@ -383,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_config_in_parent_dir() {
+    fn test_find_config_does_not_walk_parents() {
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("dispatch.config.toml");
         fs::write(&config_path, "").unwrap();
@@ -392,10 +387,7 @@ mod tests {
         fs::create_dir(&child).unwrap();
 
         let result = find_config_file(&child);
-        assert!(result.is_some());
-        let (path, root) = result.unwrap();
-        assert_eq!(path, config_path);
-        assert_eq!(root, tmp.path().to_path_buf());
+        assert!(result.is_none());
     }
 
     #[test]
@@ -457,7 +449,7 @@ backend = "https://example.com"
         let config_path = tmp.path().join("dispatch.config.toml");
         fs::write(&config_path, r#"cell_id = "from-config""#).unwrap();
 
-        let resolved = resolve_config_inner(Some("from-cli"), None, tmp.path()).unwrap();
+        let resolved = resolve_config_inner(Some("from-cli"), None, None, tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "from-cli");
     }
 
@@ -467,7 +459,7 @@ backend = "https://example.com"
         let config_path = tmp.path().join("dispatch.config.toml");
         fs::write(&config_path, r#"cell_id = "from-config""#).unwrap();
 
-        let resolved = resolve_config_inner(None, Some("from-env"), tmp.path()).unwrap();
+        let resolved = resolve_config_inner(None, Some("from-env"), None, tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "from-env");
     }
 
@@ -477,7 +469,7 @@ backend = "https://example.com"
         let config_path = tmp.path().join("dispatch.config.toml");
         fs::write(&config_path, r#"cell_id = "from-config""#).unwrap();
 
-        let resolved = resolve_config_inner(None, None, tmp.path()).unwrap();
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "from-config");
     }
 
@@ -485,7 +477,7 @@ backend = "https://example.com"
     fn test_resolve_config_derived_fallback() {
         let tmp = TempDir::new().unwrap();
 
-        let resolved = resolve_config_inner(None, None, tmp.path()).unwrap();
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
         assert!(resolved.cell_id.starts_with("cell-"));
     }
 
@@ -494,7 +486,7 @@ backend = "https://example.com"
         let tmp = TempDir::new().unwrap();
 
         let resolved =
-            resolve_config_inner(Some("from-cli"), Some("from-env"), tmp.path()).unwrap();
+            resolve_config_inner(Some("from-cli"), Some("from-env"), None, tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "from-cli");
     }
 
@@ -532,33 +524,16 @@ backend = "https://example.com"
     }
 
     #[test]
-    fn test_init_config_with_parent_config() {
+    fn test_resolve_config_explicit_config_path() {
         let tmp = TempDir::new().unwrap();
-        // Config in parent
-        let parent_config = tmp.path().join("dispatch.config.toml");
-        fs::write(&parent_config, "").unwrap();
+        let config_dir = tmp.path().join("other");
+        fs::create_dir(&config_dir).unwrap();
+        let config_path = config_dir.join("dispatch.config.toml");
+        fs::write(&config_path, r#"cell_id = "explicit""#).unwrap();
 
-        // Init in child — should succeed despite parent config
-        let child = tmp.path().join("subdir");
-        fs::create_dir(&child).unwrap();
-
-        let result = init_config(&child);
-        assert!(result.is_ok());
-        let path = result.unwrap();
-        assert_eq!(path, child.join("dispatch.config.toml"));
-        assert!(path.is_file());
-    }
-
-    #[test]
-    fn test_resolve_config_project_root_with_config() {
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("dispatch.config.toml");
-        fs::write(&config_path, "").unwrap();
-
-        let child = tmp.path().join("sub");
-        fs::create_dir(&child).unwrap();
-
-        let resolved = resolve_config_inner(None, None, &child).unwrap();
-        assert_eq!(resolved.project_root, tmp.path().to_path_buf());
+        // cwd is tmp root, config is in other/ — project_root should be other/
+        let resolved = resolve_config_inner(None, None, Some(&config_path), tmp.path()).unwrap();
+        assert_eq!(resolved.cell_id, "explicit");
+        assert_eq!(resolved.project_root, config_dir);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct ResolvedConfig {
     pub project_root: PathBuf,
     /// Monitor dashboard port (from config or CLI flag).
     pub monitor_port: Option<u16>,
+    /// Open the monitor dashboard in a browser on serve.
+    pub monitor_open: bool,
     /// Agent definitions to launch on serve.
     pub agents: Vec<ResolvedAgentConfig>,
     /// Main interactive agent (printed as a command, not auto-launched).
@@ -81,6 +83,9 @@ pub struct HeartbeatConfig {
 #[serde(deny_unknown_fields)]
 pub struct MonitorConfig {
     pub port: u16,
+    /// Open the dashboard in the default browser on serve.
+    #[serde(default)]
+    pub open: bool,
 }
 
 /// On-disk agent definition.
@@ -220,6 +225,7 @@ const CONFIG_TEMPLATE: &str = "\
 # Monitor dashboard — starts an HTTP dashboard on serve
 # [monitor]
 # port = 8384
+# open = true  # open the dashboard in your default browser
 
 # Agent definitions — launched automatically by `dispatch serve`
 # [[agents]]
@@ -322,7 +328,8 @@ fn resolve_config_inner(
             ),
             None => (None, None, None, vec![], None, vec![]),
         };
-    let monitor_port = monitor_config.map(|m| m.port);
+    let monitor_port = monitor_config.as_ref().map(|m| m.port);
+    let monitor_open = monitor_config.as_ref().map_or(false, |m| m.open);
 
     // Resolve agent prompt files
     let agents: Vec<ResolvedAgentConfig> = raw_agents
@@ -349,6 +356,7 @@ fn resolve_config_inner(
         backend,
         project_root,
         monitor_port,
+        monitor_open,
         agents,
         main_agent,
         heartbeats,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         return Ok(());
     }
 
-    let config = resolve_config(cli.cell_id.as_deref(), &cwd)?;
+    let config = resolve_config(cli.cell_id.as_deref(), cli.config.as_deref(), &cwd)?;
 
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
 


### PR DESCRIPTION
## Summary
- Add `open = true` option in `[monitor]` config to auto-launch the dashboard in the default browser on `dispatch serve`
- Add `--config <PATH>` global flag to specify an explicit config file path
- Config lookup no longer walks parent directories — checks cwd only, or uses the explicit `--config` path
- All relative file lookups (`prompt_file`, etc.) resolve from the config file's directory
- Bump version to 0.3.1

## Test plan
- [x] All 68 unit and integration tests pass
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean
- [ ] Verify `dispatch serve` with `[monitor] open = true` opens browser
- [ ] Verify `dispatch --config path/to/config.toml serve` resolves paths relative to config location
- [ ] Verify `dispatch serve` without `--config` finds `dispatch.config.toml` in cwd
- [ ] Verify missing config in cwd (without `--config`) falls back to derived defaults