### PR TITLE
feat: adapters, agent lifecycle, vendor hooks, cards dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2] - 2026-04-19
-
-### Added
-- `POST /api/agents/{name}/start|stop|restart` — monitor UI and external callers can drive the orchestrator directly (local-loopback, unauthenticated; matches `/api/shutdown`)
-- `Worker.status_history` — last 3 prior status taglines retained per worker with dedupe, surfaced via `/api/team`
-- `AgentState::Running` now carries `started_at` (Unix seconds) alongside `pid` for client-side uptime
-- Expanded monitor agent cards: adapter badge, current + last 2 prior statuses, uptime, heartbeat age, Start/Stop/Restart buttons, and a Copy-command button for `launch = false` agents
-- Toast feedback in the dashboard for action outcomes (disables buttons while in-flight)
-
-### Changed
-- `dispatch {codex,claude}-hook stop` probes the broker socket before emitting the block decision: when dispatch is unreachable the hook prints nothing and exits 0 so the vendor can stop the agent cleanly
-- `dispatch status --clear` no longer wipes the historical status buffer — clear is a display-level reset only
-
 ## [0.4.1] - 2026-04-19
 
 ### Added
@@ -32,10 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent supervisor with exponential-backoff auto-restart (1s → 30s cap, 5 consecutive failures = crashed; counter resets after 30s stable)
 - `dispatch codex-hook {stop,install,uninstall}` — writes `.codex/hooks.json` + enables `features.codex_hooks`; Stop handler emits a block decision so the agent keeps listening for dispatch messages
 - `dispatch claude-hook {stop,install,uninstall}` — same pattern via `.claude/settings.local.json` (merges into existing `settings.json` if present)
+- `POST /api/agents/{name}/start|stop|restart` — monitor UI and external callers can drive the orchestrator directly (local-loopback, unauthenticated; matches `/api/shutdown`)
+- `Worker.status_history` — last 3 prior status taglines retained per worker with dedupe, surfaced via `/api/team`
+- `AgentState::Running` now carries `started_at` (Unix seconds) alongside `pid` for client-side uptime
 - Monitor dashboard: agent cards grid showing supervisor state per agent (running/starting/restarting/crashed/stopped), PID, short worker ID; clicking a card opens the existing agent detail view
+- Expanded monitor agent cards: adapter badge, current + last 2 prior statuses, uptime, heartbeat age, Start/Stop/Restart buttons, and a Copy-command button for `launch = false` agents
+- Toast feedback in the dashboard for action outcomes (disables buttons while in-flight)
 - `GET /api/agents/state` — live supervisor state for each managed agent
 - Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
 - Per-agent log files at `logs/<name>.log`
+
+### Changed
+- `dispatch {codex,claude}-hook stop` probes the broker socket before emitting the block decision: when dispatch is unreachable the hook prints nothing and exits 0 so the vendor can stop the agent cleanly
+- `dispatch status --clear` no longer wipes the historical status buffer — clear is a display-level reset only
 
 ### Changed
 - Agent configs require `adapter = "..."`; the old `command = "..."` shell-one-liner shape no longer parses and must be migrated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-agent `launch = true/false` flag (auto-start only agents with `launch = true`)
 - Prompt files now piped as stdin for the `claude` and `codex` adapters (no more `< {prompt_file}` shell redirect)
 - Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`, `dispatch history`
+- `dispatch agent {start,stop,restart} <name|worker-id>` — lifecycle control for managed agents over the broker socket; name or worker ID accepted
 - Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
 - Per-agent log files at `logs/<name>.log`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-19
+
+### Added
+- Adapter abstraction for agent launches — each `[[agents]]` entry declares `adapter = "command" | "claude" | "codex"` instead of embedding a shell one-liner
+- `extra_args = [...]` on agents — adapter-appended argv without touching the launch string
+- Per-agent `launch = true/false` flag (auto-start only agents with `launch = true`)
+- Prompt files now piped as stdin for the `claude` and `codex` adapters (no more `< {prompt_file}` shell redirect)
+- Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`, `dispatch history`
+- Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
+- Per-agent log files at `logs/<name>.log`
+
+### Changed
+- Agent configs require `adapter = "..."`; the old `command = "..."` shell-one-liner shape no longer parses and must be migrated
+
 ## [0.3.1] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent supervisor with exponential-backoff auto-restart (1s → 30s cap, 5 consecutive failures = crashed; counter resets after 30s stable)
 - `dispatch codex-hook {stop,install,uninstall}` — writes `.codex/hooks.json` + enables `features.codex_hooks`; Stop handler emits a block decision so the agent keeps listening for dispatch messages
 - `dispatch claude-hook {stop,install,uninstall}` — same pattern via `.claude/settings.local.json` (merges into existing `settings.json` if present)
+- Monitor dashboard: agent cards grid showing supervisor state per agent (running/starting/restarting/crashed/stopped), PID, short worker ID; clicking a card opens the existing agent detail view
+- `GET /api/agents/state` — live supervisor state for each managed agent
 - Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
 - Per-agent log files at `logs/<name>.log`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extra_args = [...]` on agents — adapter-appended argv without touching the launch string
 - Per-agent `launch = true/false` flag (auto-start only agents with `launch = true`)
 - Prompt files now piped as stdin for the `claude` and `codex` adapters (no more `< {prompt_file}` shell redirect)
-- Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`, `dispatch history`
+- Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`
 - `dispatch agent {start,stop,restart} <name|worker-id>` — lifecycle control for managed agents over the broker socket; name or worker ID accepted
 - Agent supervisor with exponential-backoff auto-restart (1s → 30s cap, 5 consecutive failures = crashed; counter resets after 30s stable)
 - `dispatch codex-hook {stop,install,uninstall}` — writes `.codex/hooks.json` + enables `features.codex_hooks`; Stop handler emits a block decision so the agent keeps listening for dispatch messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-19
+
+### Added
+- `POST /api/agents/{name}/start|stop|restart` — monitor UI and external callers can drive the orchestrator directly (local-loopback, unauthenticated; matches `/api/shutdown`)
+- `Worker.status_history` — last 3 prior status taglines retained per worker with dedupe, surfaced via `/api/team`
+- `AgentState::Running` now carries `started_at` (Unix seconds) alongside `pid` for client-side uptime
+- Expanded monitor agent cards: adapter badge, current + last 2 prior statuses, uptime, heartbeat age, Start/Stop/Restart buttons, and a Copy-command button for `launch = false` agents
+- Toast feedback in the dashboard for action outcomes (disables buttons while in-flight)
+
+### Changed
+- `dispatch {codex,claude}-hook stop` probes the broker socket before emitting the block decision: when dispatch is unreachable the hook prints nothing and exits 0 so the vendor can stop the agent cleanly
+- `dispatch status --clear` no longer wipes the historical status buffer — clear is a display-level reset only
+
 ## [0.4.1] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`, `dispatch history`
 - `dispatch agent {start,stop,restart} <name|worker-id>` — lifecycle control for managed agents over the broker socket; name or worker ID accepted
 - Agent supervisor with exponential-backoff auto-restart (1s → 30s cap, 5 consecutive failures = crashed; counter resets after 30s stable)
+- `dispatch codex-hook {stop,install,uninstall}` — writes `.codex/hooks.json` + enables `features.codex_hooks`; Stop handler emits a block decision so the agent keeps listening for dispatch messages
+- `dispatch claude-hook {stop,install,uninstall}` — same pattern via `.claude/settings.local.json` (merges into existing `settings.json` if present)
 - Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
 - Per-agent log files at `logs/<name>.log`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prompt files now piped as stdin for the `claude` and `codex` adapters (no more `< {prompt_file}` shell redirect)
 - Introspection commands: `dispatch ack`, `dispatch status`, `dispatch heartbeat --status`, `dispatch events`, `dispatch messages`, `dispatch history`
 - `dispatch agent {start,stop,restart} <name|worker-id>` — lifecycle control for managed agents over the broker socket; name or worker ID accepted
+- Agent supervisor with exponential-backoff auto-restart (1s → 30s cap, 5 consecutive failures = crashed; counter resets after 30s stable)
 - Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors
 - Per-agent log files at `logs/<name>.log`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.4.2"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.4.2"
+version = "0.4.1"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,29 @@ Both methods symlink into `~/.local/bin/` by default. Pass `--skip-symlink` to o
 dispatch serve
 
 # Register a worker
-dispatch register --name my-worker --role coder --description "Writes code"
+dispatch register --name my-worker --role coder \
+  --description "Writes code" --capability rust
 
 # Send a message to a worker
-dispatch send --to <worker-id> --body "Hello, worker!"
+dispatch send --to <worker-id> --body '{"type":"task","detail":"implement login"}'
 
 # Listen for messages (long-poll)
 dispatch listen --worker-id <worker-id>
+
+# Acknowledge a received message
+dispatch ack --worker-id <worker-id> --message-id <msg-id> --note "starting work"
+
+# Publish status while working
+dispatch heartbeat --worker-id <worker-id> --status "implementing login 2/5"
+
+# Check what everyone's doing
+dispatch status
+
+# View recent broker events
+dispatch events --since 10m
+
+# Inspect a worker's inbox without consuming
+dispatch messages --worker-id <worker-id>
 ```
 
 ## Architecture
@@ -51,14 +67,26 @@ Dispatch runs as a **cell** — a single broker process that coordinates workers
 
 ## Commands
 
+### Core
+
 | Command | Description |
 |---------|-------------|
-| `dispatch serve` | Start the embedded broker |
-| `dispatch register` | Register a worker with name, role, and capabilities |
+| `dispatch init` | Create a `dispatch.config.toml` in the current directory |
+| `dispatch serve` | Start the broker (prints agent commands; use `--launch` to auto-start) |
+| `dispatch register` | Register a worker (`--evict` replaces existing by name) |
 | `dispatch team` | List active workers |
 | `dispatch send` | Send a direct message to a worker |
 | `dispatch listen` | Long-poll for incoming messages |
-| `dispatch heartbeat` | Renew worker liveness TTL |
+| `dispatch heartbeat` | Renew worker TTL (add `--status "doing X"` to publish status) |
+
+### Introspection
+
+| Command | Description |
+|---------|-------------|
+| `dispatch ack` | Acknowledge receipt of a message (`--message-id`, `--note`) |
+| `dispatch status` | View worker status taglines (or `--clear` to wipe) |
+| `dispatch events` | Query event history (`--type`, `--worker`, `--since`, `--limit`) |
+| `dispatch messages` | Inspect message history (`--worker-id`, `--unacked`, `--sent`) |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ dispatch codex-hook install       # writes .codex/hooks.json + enables features.
 dispatch claude-hook install      # merges a Stop hook into .claude/settings.json
 ```
 
-The hook runs `dispatch {codex,claude}-hook stop`, which emits `{"decision":"block","reason":"..."}` on stdout when a dispatch broker is reachable on the project's socket. When it can't reach a broker (dispatch is shutting down, was never started, or the agent is running outside a dispatch project), the hook prints nothing and exits `0` so the vendor can stop the agent cleanly instead of pinning it alive. Uninstall with `... uninstall`.
+The hook runs `dispatch {codex,claude}-hook stop`, which emits `{"decision":"block","reason":"..."}` on stdout when a dispatch broker is reachable on the project's socket. The block decision tells the vendor not to exit at end-of-turn; the `reason` instructs the agent to call `dispatch listen` again with its `worker_id`, which keeps it alive and waiting for the next message instead of treating its job as done.
+
+The reason string is prefixed with an "if you are a dispatch agent" guard so ad-hoc sessions you start by hand inside the same repo can ignore it and stop normally — the hook fires for every claude/codex session in the repo, not just dispatch-launched ones.
+
+When the hook can't reach a broker (dispatch is shutting down, was never started, or the agent is running outside a dispatch project), it prints nothing and exits `0` so the vendor stops the agent cleanly instead of pinning it alive. Uninstall with `... uninstall`.
 
 ### Monitor dashboard
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ Dispatch runs as a **cell** — a single broker process that coordinates workers
 | `dispatch events` | Query event history (`--type`, `--worker`, `--since`, `--limit`) |
 | `dispatch messages` | Inspect message history (`--worker-id`, `--unacked`, `--sent`) |
 
+### Agent lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `dispatch agent start <name\|id>` | Start a configured agent by name or worker ID |
+| `dispatch agent stop <name\|id>` | Stop a running agent (skips restart budget) |
+| `dispatch agent restart <name\|id>` | Stop and re-spawn |
+
+### Vendor hooks
+
+| Command | Description |
+|---------|-------------|
+| `dispatch codex-hook install` | Register a Stop hook in `.codex/hooks.json` + enable `features.codex_hooks` |
+| `dispatch codex-hook uninstall` | Remove the hook (preserves other codex config) |
+| `dispatch claude-hook install` | Merge a Stop hook into `.claude/settings.json` |
+| `dispatch claude-hook uninstall` | Remove the Stop hook entry |
+| `dispatch codex-hook stop` / `dispatch claude-hook stop` | Hook handler invoked by the vendor CLI — prints a JSON block decision |
+
 ## Configuration
 
 Dispatch searches upward from the current directory for `dispatch.config.toml`:
@@ -97,6 +115,62 @@ cell_id = "my-project"
 ```
 
 Override precedence (highest wins): `--cell-id` flag > `DISPATCH_CELL_ID` env var > config file > derived from path.
+
+## Agent orchestration
+
+`dispatch serve` can launch and supervise agents declared in config. Each agent picks an **adapter** (how to invoke the underlying binary) and opts in to auto-launch with `launch = true`:
+
+```toml
+[[agents]]
+name = "implementer"
+role = "code.implementer"
+description = "Writes code based on plans"
+adapter = "codex"                      # "command" | "claude" | "codex"
+prompt_file = "prompts/implementer.md" # piped as stdin to claude/codex
+launch = true
+extra_args = [
+  "-s", "danger-full-access",
+  "-m", "gpt-5.4",
+  "-c", "model_reasoning_effort=\"xhigh\"",
+]
+
+[[agents]]
+name = "reviewer"
+role = "code.reviewer"
+description = "Reviews code for quality"
+adapter = "claude"
+prompt_file = "prompts/reviewer.md"
+launch = true
+extra_args = ["--dangerously-skip-permissions", "--model", "sonnet"]
+
+[[agents]]
+name = "watcher"
+role = "file.watcher"
+description = "Watches files and forwards stale messages"
+adapter = "command"
+command = "./examples/watch-files.sh --worker-id $DISPATCH_WORKER_ID src/"
+launch = true
+```
+
+Run `dispatch serve --launch` to auto-spawn every agent with `launch = true`. Agents with `launch = false` (the default) are printed as ready-to-paste commands so you can run them in separate terminals.
+
+### Supervisor + auto-restart
+
+Each supervised agent runs under a task that restarts it on exit with exponential backoff: **1s, 2s, 4s, 8s, 16s, 30s (cap)**. After **5 consecutive unstable failures** the supervisor gives up and marks the agent `crashed` in the monitor UI. An agent that ran for at least 30s before exiting gets a fresh restart budget, so a long-lived process that dies once isn't treated as flaky.
+
+Use `dispatch agent {start,stop,restart} <name|worker-id>` to intervene while the broker is up.
+
+### Vendor hooks (keeping LLM agents alive)
+
+LLM vendor CLIs (`claude`, `codex`) finish their turn and exit by default. To keep them alive for the next dispatch message, install a Stop hook that tells the vendor to block the exit:
+
+```sh
+# In your project root:
+dispatch codex-hook install       # writes .codex/hooks.json + enables features.codex_hooks
+dispatch claude-hook install      # merges a Stop hook into .claude/settings.json
+```
+
+The hook runs `dispatch {codex,claude}-hook stop`, which emits `{"decision":"block","reason":"..."}` on stdout. The reason tells the agent to call `dispatch listen` again with its worker ID. Uninstall with `... uninstall`.
 
 ## Stale & Refresh Control Messages
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,18 @@ dispatch codex-hook install       # writes .codex/hooks.json + enables features.
 dispatch claude-hook install      # merges a Stop hook into .claude/settings.json
 ```
 
-The hook runs `dispatch {codex,claude}-hook stop`, which emits `{"decision":"block","reason":"..."}` on stdout. The reason tells the agent to call `dispatch listen` again with its worker ID. Uninstall with `... uninstall`.
+The hook runs `dispatch {codex,claude}-hook stop`, which emits `{"decision":"block","reason":"..."}` on stdout when a dispatch broker is reachable on the project's socket. When it can't reach a broker (dispatch is shutting down, was never started, or the agent is running outside a dispatch project), the hook prints nothing and exits `0` so the vendor can stop the agent cleanly instead of pinning it alive. Uninstall with `... uninstall`.
+
+### Monitor dashboard
+
+`dispatch serve --monitor <port>` (or `[monitor] port = ...` in config) starts a dashboard at `http://localhost:<port>`. Each configured agent gets a card:
+
+- **Adapter badge** (`codex` / `claude` / `command`) and a **state pill** (running / starting / restarting / crashed / stopped / unmanaged).
+- **Current status tagline** (whatever the agent last set via `dispatch status` / `dispatch heartbeat --status`) plus the last two prior taglines as faded context.
+- **Uptime** for running agents and **last heartbeat age** for registered workers, ticked locally every second so the card stays live between polls.
+- **Start / Stop / Restart** buttons wired to `POST /api/agents/{name}/{action}`. A **Copy cmd** button appears for `launch = false` agents so you can paste the launch command into another terminal.
+
+The card endpoints are unauthenticated and local-loopback only — the same posture as `POST /api/shutdown`.
 
 ## Stale & Refresh Control Messages
 

--- a/examples/dispatch-comms.md
+++ b/examples/dispatch-comms.md
@@ -8,9 +8,10 @@ You are a worker in a dispatch cell — a group of agents coordinating on one ma
 
 You are a long-lived worker, not a one-shot command. After you finish handling a message:
 
-1. Update your status with `dispatch heartbeat --status "..."`
-2. Call `dispatch listen --worker-id <YOUR_WORKER_ID> --timeout 600` again
-3. Handle the next message that arrives (or the timeout, then loop)
+1. Acknowledge the message you just handled with `dispatch ack --message-id <id>` (or include `--note "..."` with a short result). Silence reads as failure to the sender — always ack as soon as you start handling a message, and again when you complete it if the result is meaningful.
+2. Update your status with `dispatch heartbeat --status "..."`
+3. Call `dispatch listen --worker-id <YOUR_WORKER_ID> --timeout 600` again
+4. Handle the next message that arrives (or the timeout, then loop)
 
 **Do not exit after processing a single message.** If the broker has nothing for you right now, `listen` will return `{"status":"timeout"}` after the timeout — that's normal; call `listen` again.
 
@@ -110,6 +111,6 @@ All message bodies should be valid JSON with a `type` field so the recipient kno
 - Run `dispatch heartbeat` before every `dispatch listen`
 - Use `--status` on heartbeat to let the team know what you're doing
 - Ack messages when you start handling them — silence looks like failure
-- The other agents are Claude Code instances in separate terminals — give them time to respond
+- The other agents may be Claude Code, Codex, or plain worker scripts running in separate terminals — give them time to respond, and don't assume any specific reply latency or LLM-style answer format
 - Show the user every message you send and receive so they can follow the collaboration
 - Use `dispatch events --since 5m` to debug what happened if something seems lost

--- a/examples/dispatch-comms.md
+++ b/examples/dispatch-comms.md
@@ -1,6 +1,6 @@
 # Dispatch Communication Guide
 
-You are a worker in a dispatch cell — a group of agents coordinating on one machine through the `dispatch` CLI. This guide explains how to register, send messages, and listen for messages.
+You are a worker in a dispatch cell — a group of agents coordinating on one machine through the `dispatch` CLI. This guide explains how to register, communicate, and report status.
 
 **IMPORTANT: `dispatch` is already installed and the broker is already running. Do NOT build anything. Do NOT run cargo. Just use the `dispatch` commands below directly.**
 
@@ -11,10 +11,10 @@ Before you can send or receive messages, register with the broker:
 ```bash
 dispatch register --name <YOUR_NAME> --role <YOUR_ROLE> \
   --description "<what you do>" \
-  --capability <skill1> --capability <skill2>
+  --capability <skill1> --capability <skill2> --evict
 ```
 
-This returns JSON with your `worker_id`. Save it — you need it for all communication.
+This returns JSON with your `worker_id`. Save it — you need it for all communication. The `--evict` flag ensures any stale registration with the same name is replaced.
 
 ## Find other workers
 
@@ -22,7 +22,7 @@ This returns JSON with your `worker_id`. Save it — you need it for all communi
 dispatch team
 ```
 
-Returns a JSON list of all active workers with their `id`, `name`, `role`, and `capabilities`. Use this to find the worker you need to talk to.
+Returns a JSON list of all active workers with their `id`, `name`, `role`, `capabilities`, and `last_status`. Use this to find the worker you need to talk to.
 
 ## Send a message
 
@@ -44,6 +44,46 @@ Always send a heartbeat before listening. Workers expire after 1 hour without a 
 
 If you get `"status":"timeout"`, just heartbeat and listen again.
 
+## Acknowledge messages
+
+When you receive a message and start working on it, acknowledge it so the sender (and the monitoring dashboard) knows you picked it up:
+
+```bash
+dispatch ack --worker-id <YOUR_WORKER_ID> \
+  --message-id <MESSAGE_ID> --note "starting implementation"
+```
+
+The `--note` is optional but useful for context.
+
+## Report your status
+
+While working on a task, update your status so the team knows what you're doing:
+
+```bash
+dispatch heartbeat --worker-id <YOUR_WORKER_ID> \
+  --status "implementing login flow 2/5"
+```
+
+Status is a short tagline visible in `dispatch team`, `dispatch status`, and the monitor dashboard. Update it as your work progresses.
+
+## Check team status
+
+```bash
+dispatch status                              # all workers with their latest status
+dispatch status --worker-id <WORKER_ID>      # one worker's status
+```
+
+## Inspect messages and events
+
+```bash
+dispatch messages --worker-id <YOUR_WORKER_ID>         # your inbox
+dispatch messages --worker-id <YOUR_WORKER_ID> --sent   # messages you sent
+dispatch events --since 5m                              # recent broker activity
+dispatch events --type ack --since 10m                  # recent acks
+```
+
+These are non-destructive — they don't consume messages or affect state.
+
 ## Message format
 
 All message bodies should be valid JSON with a `type` field so the recipient knows how to handle it. For example:
@@ -56,5 +96,8 @@ All message bodies should be valid JSON with a `type` field so the recipient kno
 ## Tips
 
 - Run `dispatch heartbeat` before every `dispatch listen`
+- Use `--status` on heartbeat to let the team know what you're doing
+- Ack messages when you start handling them — silence looks like failure
 - The other agents are Claude Code instances in separate terminals — give them time to respond
 - Show the user every message you send and receive so they can follow the collaboration
+- Use `dispatch events --since 5m` to debug what happened if something seems lost

--- a/examples/dispatch-comms.md
+++ b/examples/dispatch-comms.md
@@ -4,6 +4,18 @@ You are a worker in a dispatch cell — a group of agents coordinating on one ma
 
 **IMPORTANT: `dispatch` is already installed and the broker is already running. Do NOT build anything. Do NOT run cargo. Just use the `dispatch` commands below directly.**
 
+## The listen loop
+
+You are a long-lived worker, not a one-shot command. After you finish handling a message:
+
+1. Update your status with `dispatch heartbeat --status "..."`
+2. Call `dispatch listen --worker-id <YOUR_WORKER_ID> --timeout 600` again
+3. Handle the next message that arrives (or the timeout, then loop)
+
+**Do not exit after processing a single message.** If the broker has nothing for you right now, `listen` will return `{"status":"timeout"}` after the timeout — that's normal; call `listen` again.
+
+A vendor Stop hook may also remind you to keep listening by injecting a "do not stop" instruction. Behave correctly without relying on the hook — it's a safety net, not the primary mechanism.
+
 ## Register yourself
 
 Before you can send or receive messages, register with the broker:

--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -23,6 +23,15 @@ mod tests {
     use super::super::{Adapter, BuildContext};
     use std::path::Path;
 
+    fn ctx<'a>(extras: &'a [String], prompt_file: Option<&'a Path>) -> BuildContext<'a> {
+        BuildContext {
+            extra_args: extras,
+            prompt_file,
+            prompt_inline: None,
+            command_string: None,
+        }
+    }
+
     #[test]
     fn extra_args_precede_dash_p() {
         let extras = vec![
@@ -30,12 +39,7 @@ mod tests {
             "--model".to_string(),
             "sonnet".to_string(),
         ];
-        let ctx = BuildContext {
-            extra_args: &extras,
-            prompt_file: None,
-            command_string: None,
-        };
-        let launch = Adapter::Claude.build(&ctx).unwrap();
+        let launch = Adapter::Claude.build(&ctx(&extras, None)).unwrap();
         assert_eq!(launch.program, "claude");
         assert_eq!(
             launch.args,
@@ -48,12 +52,7 @@ mod tests {
     #[test]
     fn prompt_file_becomes_stdin() {
         let prompt = Path::new("/tmp/prompt.md");
-        let ctx = BuildContext {
-            extra_args: &[],
-            prompt_file: Some(prompt),
-            command_string: None,
-        };
-        let launch = Adapter::Claude.build(&ctx).unwrap();
+        let launch = Adapter::Claude.build(&ctx(&[], Some(prompt))).unwrap();
         assert_eq!(launch.args, vec!["-p"]);
         assert_eq!(launch.stdin_file.as_deref(), Some(prompt));
     }

--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -1,0 +1,60 @@
+//! Claude Code CLI adapter.
+//!
+//! Assembles `claude [extra_args...] -p` and feeds the prompt via stdin from
+//! `prompt_file`. Non-interactive (`-p`) mode only; interactive support is a
+//! follow-up.
+
+use super::{AdapterError, BuildContext, Launch};
+
+pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
+    let mut args: Vec<String> = ctx.extra_args.to_vec();
+    args.push("-p".to_string());
+
+    Ok(Launch {
+        program: "claude".to_string(),
+        args,
+        wrap_in_shell: false,
+        stdin_file: ctx.prompt_file.map(|p| p.to_path_buf()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Adapter, BuildContext};
+    use std::path::Path;
+
+    #[test]
+    fn extra_args_precede_dash_p() {
+        let extras = vec![
+            "--dangerously-skip-permissions".to_string(),
+            "--model".to_string(),
+            "sonnet".to_string(),
+        ];
+        let ctx = BuildContext {
+            extra_args: &extras,
+            prompt_file: None,
+            command_string: None,
+        };
+        let launch = Adapter::Claude.build(&ctx).unwrap();
+        assert_eq!(launch.program, "claude");
+        assert_eq!(
+            launch.args,
+            vec!["--dangerously-skip-permissions", "--model", "sonnet", "-p"]
+        );
+        assert!(!launch.wrap_in_shell);
+        assert!(launch.stdin_file.is_none());
+    }
+
+    #[test]
+    fn prompt_file_becomes_stdin() {
+        let prompt = Path::new("/tmp/prompt.md");
+        let ctx = BuildContext {
+            extra_args: &[],
+            prompt_file: Some(prompt),
+            command_string: None,
+        };
+        let launch = Adapter::Claude.build(&ctx).unwrap();
+        assert_eq!(launch.args, vec!["-p"]);
+        assert_eq!(launch.stdin_file.as_deref(), Some(prompt));
+    }
+}

--- a/src/adapter/codex.rs
+++ b/src/adapter/codex.rs
@@ -33,7 +33,7 @@ mod tests {
     }
 
     #[test]
-    fn exec_preceeds_extra_args() {
+    fn exec_precedes_extra_args() {
         let extras = vec![
             "-s".to_string(),
             "danger-full-access".to_string(),

--- a/src/adapter/codex.rs
+++ b/src/adapter/codex.rs
@@ -1,0 +1,87 @@
+//! Codex CLI adapter.
+//!
+//! Assembles `codex exec [extra_args...]` and feeds the prompt via stdin from
+//! `prompt_file`. Non-interactive (`exec`) mode only; interactive support is
+//! a follow-up.
+
+use super::{AdapterError, BuildContext, Launch};
+
+pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
+    let mut args: Vec<String> = vec!["exec".to_string()];
+    args.extend(ctx.extra_args.iter().cloned());
+
+    Ok(Launch {
+        program: "codex".to_string(),
+        args,
+        wrap_in_shell: false,
+        stdin_file: ctx.prompt_file.map(|p| p.to_path_buf()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Adapter, BuildContext};
+    use std::path::Path;
+
+    #[test]
+    fn exec_preceeds_extra_args() {
+        let extras = vec![
+            "-s".to_string(),
+            "danger-full-access".to_string(),
+            "-m".to_string(),
+            "gpt-5.4".to_string(),
+        ];
+        let ctx = BuildContext {
+            extra_args: &extras,
+            prompt_file: None,
+            command_string: None,
+        };
+        let launch = Adapter::Codex.build(&ctx).unwrap();
+        assert_eq!(launch.program, "codex");
+        assert_eq!(
+            launch.args,
+            vec!["exec", "-s", "danger-full-access", "-m", "gpt-5.4"]
+        );
+        assert!(!launch.wrap_in_shell);
+        assert!(launch.stdin_file.is_none());
+    }
+
+    #[test]
+    fn prompt_file_becomes_stdin() {
+        let prompt = Path::new("/tmp/prompt.md");
+        let ctx = BuildContext {
+            extra_args: &[],
+            prompt_file: Some(prompt),
+            command_string: None,
+        };
+        let launch = Adapter::Codex.build(&ctx).unwrap();
+        assert_eq!(launch.args, vec!["exec"]);
+        assert_eq!(launch.stdin_file.as_deref(), Some(prompt));
+    }
+
+    #[test]
+    fn preserves_flag_ordering() {
+        let extras = vec![
+            "-c".to_string(),
+            "model_reasoning_effort=\"xhigh\"".to_string(),
+            "-c".to_string(),
+            "service_tier=\"fast\"".to_string(),
+        ];
+        let ctx = BuildContext {
+            extra_args: &extras,
+            prompt_file: None,
+            command_string: None,
+        };
+        let launch = Adapter::Codex.build(&ctx).unwrap();
+        assert_eq!(
+            launch.args,
+            vec![
+                "exec",
+                "-c",
+                "model_reasoning_effort=\"xhigh\"",
+                "-c",
+                "service_tier=\"fast\"",
+            ]
+        );
+    }
+}

--- a/src/adapter/codex.rs
+++ b/src/adapter/codex.rs
@@ -23,6 +23,15 @@ mod tests {
     use super::super::{Adapter, BuildContext};
     use std::path::Path;
 
+    fn ctx<'a>(extras: &'a [String], prompt_file: Option<&'a Path>) -> BuildContext<'a> {
+        BuildContext {
+            extra_args: extras,
+            prompt_file,
+            prompt_inline: None,
+            command_string: None,
+        }
+    }
+
     #[test]
     fn exec_preceeds_extra_args() {
         let extras = vec![
@@ -31,12 +40,7 @@ mod tests {
             "-m".to_string(),
             "gpt-5.4".to_string(),
         ];
-        let ctx = BuildContext {
-            extra_args: &extras,
-            prompt_file: None,
-            command_string: None,
-        };
-        let launch = Adapter::Codex.build(&ctx).unwrap();
+        let launch = Adapter::Codex.build(&ctx(&extras, None)).unwrap();
         assert_eq!(launch.program, "codex");
         assert_eq!(
             launch.args,
@@ -49,12 +53,7 @@ mod tests {
     #[test]
     fn prompt_file_becomes_stdin() {
         let prompt = Path::new("/tmp/prompt.md");
-        let ctx = BuildContext {
-            extra_args: &[],
-            prompt_file: Some(prompt),
-            command_string: None,
-        };
-        let launch = Adapter::Codex.build(&ctx).unwrap();
+        let launch = Adapter::Codex.build(&ctx(&[], Some(prompt))).unwrap();
         assert_eq!(launch.args, vec!["exec"]);
         assert_eq!(launch.stdin_file.as_deref(), Some(prompt));
     }
@@ -67,12 +66,7 @@ mod tests {
             "-c".to_string(),
             "service_tier=\"fast\"".to_string(),
         ];
-        let ctx = BuildContext {
-            extra_args: &extras,
-            prompt_file: None,
-            command_string: None,
-        };
-        let launch = Adapter::Codex.build(&ctx).unwrap();
+        let launch = Adapter::Codex.build(&ctx(&extras, None)).unwrap();
         assert_eq!(
             launch.args,
             vec![

--- a/src/adapter/command.rs
+++ b/src/adapter/command.rs
@@ -4,12 +4,19 @@
 //! for bash-script / non-LLM workers where the caller wants full control over
 //! the launch string.
 
-use super::{AdapterError, BuildContext, Launch};
+use super::{shell_arg_quote, AdapterError, BuildContext, Launch};
 
 pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
     let cmd = ctx
         .command_string
         .ok_or(AdapterError::MissingCommandString)?;
+
+    if cmd.contains("{prompt_file}") && ctx.prompt_file.is_none() {
+        return Err(AdapterError::MissingPromptFile);
+    }
+    if cmd.contains("{prompt}") && ctx.prompt_inline.is_none() {
+        return Err(AdapterError::MissingPromptInline);
+    }
 
     let expanded = substitute(cmd, ctx);
 
@@ -22,15 +29,20 @@ pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
 }
 
 /// Replace `{prompt_file}` / `{prompt}` tokens in a shell command template.
-/// Useful for bash-script workers that need the prompt path as an argument
-/// rather than on stdin.
+/// Each replacement is POSIX-shell-escaped so prompt content with spaces,
+/// quotes, or `$(...)` is treated as literal text by `sh -c`, not as shell
+/// syntax. Users should NOT wrap the tokens in their own quotes — the
+/// adapter does the quoting.
 fn substitute(template: &str, ctx: &BuildContext<'_>) -> String {
     let mut out = template.to_string();
     if let Some(path) = ctx.prompt_file {
-        out = out.replace("{prompt_file}", &path.display().to_string());
+        out = out.replace(
+            "{prompt_file}",
+            &shell_arg_quote(&path.display().to_string()),
+        );
     }
     if let Some(text) = ctx.prompt_inline {
-        out = out.replace("{prompt}", text);
+        out = out.replace("{prompt}", &shell_arg_quote(text));
     }
     out
 }
@@ -82,9 +94,60 @@ mod tests {
 
     #[test]
     fn substitutes_prompt_inline_token() {
-        let mut c = ctx(Some("echo '{prompt}'"));
+        let mut c = ctx(Some("echo {prompt}"));
         c.prompt_inline = Some("hello world");
         let launch = Adapter::Command.build(&c).unwrap();
         assert_eq!(launch.args, vec!["-c", "echo 'hello world'"]);
+    }
+
+    #[test]
+    fn escapes_injection_in_prompt_inline() {
+        // Arbitrary shell metacharacters must stay inside single quotes and
+        // never execute as shell.
+        let mut c = ctx(Some("worker --prompt {prompt}"));
+        c.prompt_inline = Some("$(rm -rf /)");
+        let launch = Adapter::Command.build(&c).unwrap();
+        assert_eq!(
+            launch.args,
+            vec!["-c", "worker --prompt '$(rm -rf /)'"],
+            "injection attempt must be quoted, not executed"
+        );
+    }
+
+    #[test]
+    fn escapes_single_quote_in_prompt_inline() {
+        let mut c = ctx(Some("worker {prompt}"));
+        c.prompt_inline = Some("it's broken");
+        let launch = Adapter::Command.build(&c).unwrap();
+        assert_eq!(launch.args, vec!["-c", r#"worker 'it'\''s broken'"#]);
+    }
+
+    #[test]
+    fn escapes_spaces_in_prompt_file_path() {
+        let mut c = ctx(Some("./worker.sh --prompt {prompt_file}"));
+        c.prompt_file = Some(Path::new("/tmp/my prompt.md"));
+        let launch = Adapter::Command.build(&c).unwrap();
+        assert_eq!(
+            launch.args,
+            vec!["-c", "./worker.sh --prompt '/tmp/my prompt.md'"]
+        );
+    }
+
+    #[test]
+    fn missing_prompt_file_errors_when_token_used() {
+        let c = ctx(Some("./worker.sh --prompt {prompt_file}"));
+        assert!(matches!(
+            Adapter::Command.build(&c),
+            Err(AdapterError::MissingPromptFile)
+        ));
+    }
+
+    #[test]
+    fn missing_prompt_inline_errors_when_token_used() {
+        let c = ctx(Some("worker --prompt {prompt}"));
+        assert!(matches!(
+            Adapter::Command.build(&c),
+            Err(AdapterError::MissingPromptInline)
+        ));
     }
 }

--- a/src/adapter/command.rs
+++ b/src/adapter/command.rs
@@ -11,27 +11,50 @@ pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
         .command_string
         .ok_or(AdapterError::MissingCommandString)?;
 
+    let expanded = substitute(cmd, ctx);
+
     Ok(Launch {
         program: "sh".to_string(),
-        args: vec!["-c".to_string(), cmd.to_string()],
+        args: vec!["-c".to_string(), expanded],
         wrap_in_shell: true,
         stdin_file: None,
     })
+}
+
+/// Replace `{prompt_file}` / `{prompt}` tokens in a shell command template.
+/// Useful for bash-script workers that need the prompt path as an argument
+/// rather than on stdin.
+fn substitute(template: &str, ctx: &BuildContext<'_>) -> String {
+    let mut out = template.to_string();
+    if let Some(path) = ctx.prompt_file {
+        out = out.replace("{prompt_file}", &path.display().to_string());
+    }
+    if let Some(text) = ctx.prompt_inline {
+        out = out.replace("{prompt}", text);
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::{Adapter, BuildContext};
     use super::*;
+    use std::path::Path;
+
+    fn ctx<'a>(command: Option<&'a str>) -> BuildContext<'a> {
+        BuildContext {
+            extra_args: &[],
+            prompt_file: None,
+            prompt_inline: None,
+            command_string: command,
+        }
+    }
 
     #[test]
     fn wraps_in_sh_dash_c() {
-        let ctx = BuildContext {
-            extra_args: &[],
-            prompt_file: None,
-            command_string: Some("./worker.sh --flag"),
-        };
-        let launch = Adapter::Command.build(&ctx).unwrap();
+        let launch = Adapter::Command
+            .build(&ctx(Some("./worker.sh --flag")))
+            .unwrap();
         assert_eq!(launch.program, "sh");
         assert_eq!(launch.args, vec!["-c", "./worker.sh --flag"]);
         assert!(launch.wrap_in_shell);
@@ -40,14 +63,28 @@ mod tests {
 
     #[test]
     fn missing_command_string_errors() {
-        let ctx = BuildContext {
-            extra_args: &[],
-            prompt_file: None,
-            command_string: None,
-        };
         assert!(matches!(
-            Adapter::Command.build(&ctx),
+            Adapter::Command.build(&ctx(None)),
             Err(AdapterError::MissingCommandString)
         ));
+    }
+
+    #[test]
+    fn substitutes_prompt_file_token() {
+        let mut c = ctx(Some("./worker.sh --prompt {prompt_file}"));
+        c.prompt_file = Some(Path::new("/tmp/prompt.md"));
+        let launch = Adapter::Command.build(&c).unwrap();
+        assert_eq!(
+            launch.args,
+            vec!["-c", "./worker.sh --prompt /tmp/prompt.md"]
+        );
+    }
+
+    #[test]
+    fn substitutes_prompt_inline_token() {
+        let mut c = ctx(Some("echo '{prompt}'"));
+        c.prompt_inline = Some("hello world");
+        let launch = Adapter::Command.build(&c).unwrap();
+        assert_eq!(launch.args, vec!["-c", "echo 'hello world'"]);
     }
 }

--- a/src/adapter/command.rs
+++ b/src/adapter/command.rs
@@ -1,0 +1,53 @@
+//! Generic shell-command adapter.
+//!
+//! Runs whatever the user wrote in `command = "..."` under `sh -c`. Useful
+//! for bash-script / non-LLM workers where the caller wants full control over
+//! the launch string.
+
+use super::{AdapterError, BuildContext, Launch};
+
+pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
+    let cmd = ctx
+        .command_string
+        .ok_or(AdapterError::MissingCommandString)?;
+
+    Ok(Launch {
+        program: "sh".to_string(),
+        args: vec!["-c".to_string(), cmd.to_string()],
+        wrap_in_shell: true,
+        stdin_file: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Adapter, BuildContext};
+    use super::*;
+
+    #[test]
+    fn wraps_in_sh_dash_c() {
+        let ctx = BuildContext {
+            extra_args: &[],
+            prompt_file: None,
+            command_string: Some("./worker.sh --flag"),
+        };
+        let launch = Adapter::Command.build(&ctx).unwrap();
+        assert_eq!(launch.program, "sh");
+        assert_eq!(launch.args, vec!["-c", "./worker.sh --flag"]);
+        assert!(launch.wrap_in_shell);
+        assert!(launch.stdin_file.is_none());
+    }
+
+    #[test]
+    fn missing_command_string_errors() {
+        let ctx = BuildContext {
+            extra_args: &[],
+            prompt_file: None,
+            command_string: None,
+        };
+        assert!(matches!(
+            Adapter::Command.build(&ctx),
+            Err(AdapterError::MissingCommandString)
+        ));
+    }
+}

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,0 +1,170 @@
+//! Adapter abstraction for launching dispatch agents.
+//!
+//! Each agent in `dispatch.config.toml` selects an adapter (`command`, `claude`,
+//! `codex`). Adapters encapsulate vendor-specific launch concerns: which binary
+//! to run, which args to inject, how the prompt is supplied.
+//!
+//! This module exposes only the launch-spec assembly. Env injection, cwd,
+//! stdout/stderr wiring, and process supervision are handled by the caller
+//! (typically the orchestrator).
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+pub mod claude;
+pub mod codex;
+pub mod command;
+
+/// Which adapter an agent uses to launch.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Adapter {
+    Command,
+    Claude,
+    Codex,
+}
+
+impl std::fmt::Display for Adapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Adapter::Command => write!(f, "command"),
+            Adapter::Claude => write!(f, "claude"),
+            Adapter::Codex => write!(f, "codex"),
+        }
+    }
+}
+
+/// Inputs an adapter needs to assemble a launch specification.
+pub struct BuildContext<'a> {
+    /// User-supplied extra args, appended to the adapter-assembled argv.
+    pub extra_args: &'a [String],
+    /// Path to a prompt file, if the agent has one. Adapters that consume
+    /// prompts via stdin (claude, codex) populate `Launch::stdin_file`.
+    pub prompt_file: Option<&'a Path>,
+    /// Full shell command — only used by the `command` adapter.
+    pub command_string: Option<&'a str>,
+}
+
+/// The result of an adapter building a launch specification.
+///
+/// Callers translate this into a concrete `tokio::process::Command` and add
+/// env vars, cwd, and stdout/stderr wiring.
+#[derive(Debug)]
+pub struct Launch {
+    /// Program to exec (e.g. `claude`, `codex`, or `sh` for the command adapter).
+    pub program: String,
+    /// Argv excluding `program`.
+    pub args: Vec<String>,
+    /// True when `program == "sh"` and `args` is `["-c", <cmd>]`. Purely
+    /// informational — the caller can infer the same from `program`.
+    pub wrap_in_shell: bool,
+    /// File to read as stdin for the spawned process. None = inherit/null
+    /// (caller decides).
+    pub stdin_file: Option<PathBuf>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdapterError {
+    #[error("command adapter requires `command = \"...\"` in agent config")]
+    MissingCommandString,
+    #[error("hook install not supported for the `command` adapter")]
+    HookInstallNotSupported,
+    #[error("hook install not yet implemented for adapter `{0}`")]
+    HookInstallPending(Adapter),
+}
+
+impl Adapter {
+    /// Assemble a launch spec for this adapter.
+    pub fn build(&self, ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
+        match self {
+            Adapter::Command => command::build(ctx),
+            Adapter::Claude => claude::build(ctx),
+            Adapter::Codex => codex::build(ctx),
+        }
+    }
+
+    /// Install the vendor stop-hook in the given repo root.
+    /// (Deferred to a later step — returns a pending error for now.)
+    pub fn hook_install(&self, _repo_root: &Path) -> Result<PathBuf, AdapterError> {
+        match self {
+            Adapter::Command => Err(AdapterError::HookInstallNotSupported),
+            other => Err(AdapterError::HookInstallPending(*other)),
+        }
+    }
+
+    /// Remove the vendor stop-hook from the given repo root.
+    /// (Deferred to a later step.)
+    pub fn hook_uninstall(&self, _repo_root: &Path) -> Result<(), AdapterError> {
+        match self {
+            Adapter::Command => Err(AdapterError::HookInstallNotSupported),
+            other => Err(AdapterError::HookInstallPending(*other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Wrapper {
+        a: Adapter,
+    }
+
+    #[test]
+    fn adapter_parses_from_toml_lowercase() {
+        assert_eq!(
+            toml::from_str::<Wrapper>("a = \"command\"").unwrap().a,
+            Adapter::Command
+        );
+        assert_eq!(
+            toml::from_str::<Wrapper>("a = \"claude\"").unwrap().a,
+            Adapter::Claude
+        );
+        assert_eq!(
+            toml::from_str::<Wrapper>("a = \"codex\"").unwrap().a,
+            Adapter::Codex
+        );
+    }
+
+    #[test]
+    fn adapter_rejects_unknown_variant() {
+        let err = toml::from_str::<Wrapper>("a = \"gpt\"").unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("expected"));
+    }
+
+    #[test]
+    fn display_matches_serde_name() {
+        assert_eq!(Adapter::Command.to_string(), "command");
+        assert_eq!(Adapter::Claude.to_string(), "claude");
+        assert_eq!(Adapter::Codex.to_string(), "codex");
+    }
+
+    #[test]
+    fn hook_install_command_rejects() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Command.hook_install(&tmp),
+            Err(AdapterError::HookInstallNotSupported)
+        ));
+    }
+
+    #[test]
+    fn hook_install_claude_pending() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Claude.hook_install(&tmp),
+            Err(AdapterError::HookInstallPending(Adapter::Claude))
+        ));
+    }
+
+    #[test]
+    fn hook_install_codex_pending() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Codex.hook_install(&tmp),
+            Err(AdapterError::HookInstallPending(Adapter::Codex))
+        ));
+    }
+}

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -42,6 +42,9 @@ pub struct BuildContext<'a> {
     /// Path to a prompt file, if the agent has one. Adapters that consume
     /// prompts via stdin (claude, codex) populate `Launch::stdin_file`.
     pub prompt_file: Option<&'a Path>,
+    /// Inline prompt text — used by the `command` adapter for `{prompt}`
+    /// substitution in the user's command string.
+    pub prompt_inline: Option<&'a str>,
     /// Full shell command — only used by the `command` adapter.
     pub command_string: Option<&'a str>,
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -59,8 +59,9 @@ pub struct Launch {
     pub program: String,
     /// Argv excluding `program`.
     pub args: Vec<String>,
-    /// True when `program == "sh"` and `args` is `["-c", <cmd>]`. Purely
-    /// informational — the caller can infer the same from `program`.
+    /// Authoritative: when true, `program == "sh"` and `args` is `["-c", <cmd>]`.
+    /// Callers that render a shell-pasteable string rely on this flag to decide
+    /// whether to emit the raw command (true) or quote each argv element (false).
     pub wrap_in_shell: bool,
     /// File to read as stdin for the spawned process. None = inherit/null
     /// (caller decides).
@@ -71,10 +72,37 @@ pub struct Launch {
 pub enum AdapterError {
     #[error("command adapter requires `command = \"...\"` in agent config")]
     MissingCommandString,
+    #[error("`{{prompt_file}}` token used in command but no `prompt_file` is configured")]
+    MissingPromptFile,
+    #[error("`{{prompt}}` token used in command but no `prompt` is configured")]
+    MissingPromptInline,
     #[error("hook install not supported for the `command` adapter")]
     HookInstallNotSupported,
     #[error("hook install not yet implemented for adapter `{0}`")]
     HookInstallPending(Adapter),
+    #[error("hook uninstall not supported for the `command` adapter")]
+    HookUninstallNotSupported,
+    #[error("hook uninstall not yet implemented for adapter `{0}`")]
+    HookUninstallPending(Adapter),
+}
+
+/// POSIX single-quote shell escape. Always safe to paste into `sh -c`.
+pub(crate) fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Quote a shell argument only when necessary. Plain alphanumerics, dashes,
+/// dots, slashes, underscores, and equals signs pass through unquoted for
+/// paste-friendly output.
+pub(crate) fn shell_arg_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || "-_/.=".contains(c))
+    {
+        s.to_string()
+    } else {
+        shell_escape(s)
+    }
 }
 
 impl Adapter {
@@ -100,8 +128,8 @@ impl Adapter {
     /// (Deferred to a later step.)
     pub fn hook_uninstall(&self, _repo_root: &Path) -> Result<(), AdapterError> {
         match self {
-            Adapter::Command => Err(AdapterError::HookInstallNotSupported),
-            other => Err(AdapterError::HookInstallPending(*other)),
+            Adapter::Command => Err(AdapterError::HookUninstallNotSupported),
+            other => Err(AdapterError::HookUninstallPending(*other)),
         }
     }
 }
@@ -168,6 +196,33 @@ mod tests {
         assert!(matches!(
             Adapter::Codex.hook_install(&tmp),
             Err(AdapterError::HookInstallPending(Adapter::Codex))
+        ));
+    }
+
+    #[test]
+    fn hook_uninstall_command_rejects() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Command.hook_uninstall(&tmp),
+            Err(AdapterError::HookUninstallNotSupported)
+        ));
+    }
+
+    #[test]
+    fn hook_uninstall_claude_pending() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Claude.hook_uninstall(&tmp),
+            Err(AdapterError::HookUninstallPending(Adapter::Claude))
+        ));
+    }
+
+    #[test]
+    fn hook_uninstall_codex_pending() {
+        let tmp = std::env::temp_dir();
+        assert!(matches!(
+            Adapter::Codex.hook_uninstall(&tmp),
+            Err(AdapterError::HookUninstallPending(Adapter::Codex))
         ));
     }
 }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -116,6 +116,15 @@ impl super::Backend for LocalBackend {
 // Broker state
 // ---------------------------------------------------------------------------
 
+/// Record of a message acknowledgement.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AckRecord {
+    pub message_id: String,
+    pub worker_id: String,
+    pub note: Option<String>,
+    pub acked_at: u64,
+}
+
 /// In-memory broker state.
 #[derive(Debug)]
 pub struct BrokerState {
@@ -125,6 +134,8 @@ pub struct BrokerState {
     pub mailboxes: HashMap<String, VecDeque<Message>>,
     /// Per-worker notification channels for long-poll wakeup.
     pub notifiers: HashMap<String, Arc<Notify>>,
+    /// Message acknowledgement log keyed by message ID.
+    pub ack_log: HashMap<String, AckRecord>,
     /// Default TTL for workers that don't specify one.
     pub default_ttl: u64,
     /// Total number of messages sent through the broker.
@@ -151,6 +162,7 @@ impl BrokerState {
             workers: HashMap::new(),
             mailboxes: HashMap::new(),
             notifiers: HashMap::new(),
+            ack_log: HashMap::new(),
             default_ttl,
             messages_sent: 0,
             messages_delivered: 0,
@@ -197,6 +209,8 @@ impl BrokerState {
             capabilities,
             ttl_secs: ttl,
             expires_at: now + ttl,
+            last_status: None,
+            last_status_at: None,
         };
         self.workers.insert(id.clone(), worker);
         id
@@ -231,16 +245,86 @@ impl BrokerState {
         self.workers.get(worker_id).map(|w| w.name.as_str())
     }
 
-    /// Renew a worker's TTL. Returns the new expiry timestamp, or None if not found/expired.
-    pub fn heartbeat_worker(&mut self, worker_id: &str) -> Option<u64> {
+    /// Renew a worker's TTL and optionally update status.
+    /// Returns the new expiry timestamp, or None if not found/expired.
+    pub fn heartbeat_worker(&mut self, worker_id: &str, status: Option<String>) -> Option<u64> {
         self.evict_expired();
         if let Some(worker) = self.workers.get_mut(worker_id) {
-            let new_expiry = now_secs() + worker.ttl_secs;
-            worker.expires_at = new_expiry;
-            Some(new_expiry)
+            let now = now_secs();
+            worker.expires_at = now + worker.ttl_secs;
+            if let Some(s) = status {
+                worker.last_status = Some(s);
+                worker.last_status_at = Some(now);
+            }
+            Some(worker.expires_at)
         } else {
             None
         }
+    }
+
+    /// Get status summaries for all active workers or a specific worker.
+    pub fn get_status(&mut self, worker_id: Option<&str>) -> Vec<crate::protocol::WorkerStatus> {
+        self.evict_expired();
+        match worker_id {
+            Some(id) => self
+                .workers
+                .get(id)
+                .map(|w| vec![crate::protocol::WorkerStatus {
+                    id: w.id.clone(),
+                    name: w.name.clone(),
+                    role: w.role.clone(),
+                    last_status: w.last_status.clone(),
+                    last_status_at: w.last_status_at,
+                }])
+                .unwrap_or_default(),
+            None => self
+                .workers
+                .values()
+                .map(|w| crate::protocol::WorkerStatus {
+                    id: w.id.clone(),
+                    name: w.name.clone(),
+                    role: w.role.clone(),
+                    last_status: w.last_status.clone(),
+                    last_status_at: w.last_status_at,
+                })
+                .collect(),
+        }
+    }
+
+    /// Clear a worker's status without affecting registration.
+    pub fn clear_status(&mut self, worker_id: &str) -> Result<(), String> {
+        self.evict_expired();
+        if let Some(worker) = self.workers.get_mut(worker_id) {
+            worker.last_status = None;
+            worker.last_status_at = None;
+            Ok(())
+        } else {
+            Err(format!("worker not found or expired: {worker_id}"))
+        }
+    }
+
+    /// Record an acknowledgement for a message.
+    /// Returns an error string if the worker doesn't exist.
+    pub fn ack_message(
+        &mut self,
+        worker_id: &str,
+        message_id: &str,
+        note: Option<String>,
+    ) -> Result<(), String> {
+        self.evict_expired();
+        if !self.workers.contains_key(worker_id) {
+            return Err(format!("worker not found or expired: {worker_id}"));
+        }
+        self.ack_log.insert(
+            message_id.to_string(),
+            AckRecord {
+                message_id: message_id.to_string(),
+                worker_id: worker_id.to_string(),
+                note,
+                acked_at: now_secs(),
+            },
+        );
+        Ok(())
     }
 
     /// Queue a message in a worker's mailbox. Returns the message ID, or None if the
@@ -786,12 +870,21 @@ async fn handle_request(
                 }
             }
         }
-        BrokerRequest::Heartbeat { worker_id } => {
+        BrokerRequest::Heartbeat { worker_id, status } => {
             let mut state = state.lock().await;
-            match state.heartbeat_worker(&worker_id) {
+            let has_status = status.is_some();
+            let status_clone = status.clone();
+            match state.heartbeat_worker(&worker_id, status) {
                 Some(expires_at) => {
+                    let detail = if has_status { "TTL renewed + status updated" } else { "TTL renewed" };
                     tracing::info!(worker_id = %worker_id, expires_at, "heartbeat renewed");
-                    emit_event(event_tx, "heartbeat", &worker_id, "TTL renewed", None);
+                    emit_event(
+                        event_tx,
+                        "heartbeat",
+                        &worker_id,
+                        detail,
+                        status_clone.map(|s| serde_json::json!({ "status": s })),
+                    );
                     BrokerResponse::Ok {
                         payload: ResponsePayload::HeartbeatAck {
                             worker_id,
@@ -802,6 +895,60 @@ async fn handle_request(
                 None => BrokerResponse::Error {
                     message: format!("worker not found or expired: {worker_id}"),
                 },
+            }
+        }
+        BrokerRequest::Ack {
+            worker_id,
+            message_id,
+            note,
+        } => {
+            let mut state = state.lock().await;
+            let note_clone = note.clone();
+            match state.ack_message(&worker_id, &message_id, note) {
+                Ok(()) => {
+                    tracing::info!(worker_id = %worker_id, message_id = %message_id, "message acked");
+                    emit_event(
+                        event_tx,
+                        "ack",
+                        &worker_id,
+                        &format!("acked {}", &message_id[..message_id.len().min(8)]),
+                        Some(serde_json::json!({
+                            "message_id": message_id,
+                            "note": note_clone,
+                        })),
+                    );
+                    BrokerResponse::Ok {
+                        payload: ResponsePayload::AckConfirm {
+                            message_id,
+                            ack_confirmed: true,
+                        },
+                    }
+                }
+                Err(msg) => BrokerResponse::Error { message: msg },
+            }
+        }
+        BrokerRequest::Status { worker_id, clear } => {
+            let mut state = state.lock().await;
+            if clear {
+                match worker_id {
+                    Some(id) => match state.clear_status(&id) {
+                        Ok(()) => {
+                            tracing::info!(worker_id = %id, "status cleared");
+                            BrokerResponse::Ok {
+                                payload: ResponsePayload::Ack {},
+                            }
+                        }
+                        Err(msg) => BrokerResponse::Error { message: msg },
+                    },
+                    None => BrokerResponse::Error {
+                        message: "--clear requires --worker-id".to_string(),
+                    },
+                }
+            } else {
+                let workers = state.get_status(worker_id.as_deref());
+                BrokerResponse::Ok {
+                    payload: ResponsePayload::StatusResult { workers },
+                }
             }
         }
     }
@@ -1304,7 +1451,7 @@ mod tests {
         // Manually lower the expiry to simulate time passing.
         state.workers.get_mut(&id).unwrap().expires_at = now_secs() + 10;
 
-        let new_expiry = state.heartbeat_worker(&id).unwrap();
+        let new_expiry = state.heartbeat_worker(&id, None).unwrap();
         assert!(
             new_expiry >= original_expiry,
             "heartbeat should renew to at least the original TTL"
@@ -1314,7 +1461,7 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_not_found() {
         let mut state = BrokerState::new();
-        assert!(state.heartbeat_worker("nonexistent").is_none());
+        assert!(state.heartbeat_worker("nonexistent", None).is_none());
     }
 
     #[test]
@@ -1331,7 +1478,7 @@ mod tests {
         state.workers.get_mut(&id).unwrap().expires_at = 0;
 
         assert!(
-            state.heartbeat_worker(&id).is_none(),
+            state.heartbeat_worker(&id, None).is_none(),
             "heartbeat for expired worker should return None"
         );
     }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -648,9 +648,17 @@ pub async fn serve(
     );
 
     if launch_agents {
-        // Auto-launch configured agents.
-        if !config.agents.is_empty() {
-            orchestrator.launch_all(&config.agents).await?;
+        // Auto-launch only agents explicitly marked `launch = true`. Agents
+        // with `launch = false` (the default) stay unmanaged and their
+        // copy-paste launch commands are printed below instead.
+        let launchable: Vec<crate::config::ResolvedAgentConfig> = config
+            .agents
+            .iter()
+            .filter(|a| a.launch)
+            .cloned()
+            .collect();
+        if !launchable.is_empty() {
+            orchestrator.launch_all(&launchable).await?;
         }
         // Start configured heartbeat timers.
         if !config.heartbeats.is_empty() {
@@ -658,10 +666,17 @@ pub async fn serve(
         }
     }
 
-    // Print agent commands for the user to run manually.
-    if !config.agents.is_empty() && !launch_agents {
-        eprintln!("\ndispatch serve: ready. Start agents in separate terminals:\n");
-        for agent in &config.agents {
+    // Print copy-paste launch commands for agents that were not auto-launched.
+    // That means: every agent when `--launch` is not set, plus `launch = false`
+    // agents when `--launch` is set.
+    let manual: Vec<&crate::config::ResolvedAgentConfig> = config
+        .agents
+        .iter()
+        .filter(|a| !launch_agents || !a.launch)
+        .collect();
+    if !manual.is_empty() {
+        eprintln!("\ndispatch serve: ready. Unmanaged agents — run these in separate terminals:\n");
+        for agent in &manual {
             let cmd = super::orchestrator::build_agent_command(
                 agent,
                 cell_id,
@@ -725,7 +740,13 @@ async fn accept_loop(
         let event_tx = event_tx.clone();
         tokio::spawn(async move {
             if let Err(e) = handle_connection(stream, state, event_tx).await {
-                tracing::error!(error = %e, "connection handler error");
+                // Broken pipe is expected when clients disconnect before reading the response.
+                let is_broken_pipe = matches!(&e, DispatchError::Io(io) if io.kind() == std::io::ErrorKind::BrokenPipe);
+                if is_broken_pipe {
+                    tracing::debug!(error = %e, "client disconnected before response");
+                } else {
+                    tracing::error!(error = %e, "connection handler error");
+                }
             }
         });
     }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -397,7 +397,11 @@ impl BrokerState {
     }
 
     /// Record an acknowledgement for a message.
-    /// Returns an error string if the worker doesn't exist.
+    ///
+    /// Validates (in order) that the worker exists, the message exists in
+    /// history, and the message was addressed to this worker. Without these
+    /// checks a caller could record acks for arbitrary or nonexistent message
+    /// IDs, corrupting the monitor's message state.
     pub fn ack_message(
         &mut self,
         worker_id: &str,
@@ -407,6 +411,17 @@ impl BrokerState {
         self.evict_expired();
         if !self.workers.contains_key(worker_id) {
             return Err(format!("worker not found or expired: {worker_id}"));
+        }
+        let recipient = self
+            .message_history
+            .iter()
+            .find(|m| m.message_id == message_id)
+            .map(|m| m.to.clone())
+            .ok_or_else(|| format!("message not found: {message_id}"))?;
+        if recipient != worker_id {
+            return Err(format!(
+                "message {message_id} was not addressed to worker {worker_id}"
+            ));
         }
         let now = now_secs();
         self.ack_log.insert(
@@ -418,7 +433,6 @@ impl BrokerState {
                 acked_at: now,
             },
         );
-        // Update acked_at in message history.
         if let Some(hist) = self
             .message_history
             .iter_mut()
@@ -2205,6 +2219,68 @@ mod tests {
         let n1 = state.get_notifier(&worker_id);
         let n2 = state.get_notifier(&worker_id);
         assert!(Arc::ptr_eq(&n1, &n2), "same worker should get same Notify");
+    }
+
+    #[test]
+    fn test_ack_message_rejects_unknown_worker() {
+        let mut state = BrokerState::new();
+        let err = state
+            .ack_message("missing-worker", "msg-1", None)
+            .unwrap_err();
+        assert!(err.contains("worker not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_ack_message_rejects_unknown_message() {
+        let mut state = BrokerState::new();
+        let worker_id = state.register_worker(
+            "recv".into(),
+            "coder".into(),
+            "desc".into(),
+            vec![],
+            None,
+            false,
+        );
+        let err = state
+            .ack_message(&worker_id, "nonexistent-message", None)
+            .unwrap_err();
+        assert!(err.contains("message not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_ack_message_rejects_wrong_recipient() {
+        let mut state = BrokerState::new();
+        let alice =
+            state.register_worker("alice".into(), "r".into(), "d".into(), vec![], None, false);
+        let bob = state.register_worker("bob".into(), "r".into(), "d".into(), vec![], None, false);
+        let message_id = state
+            .send_message(alice.clone(), "for alice".into(), None)
+            .expect("send");
+        let err = state.ack_message(&bob, &message_id, None).unwrap_err();
+        assert!(
+            err.contains("not addressed to worker"),
+            "expected recipient-mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_ack_message_success_updates_history() {
+        let mut state = BrokerState::new();
+        let alice =
+            state.register_worker("alice".into(), "r".into(), "d".into(), vec![], None, false);
+        let message_id = state
+            .send_message(alice.clone(), "hello".into(), None)
+            .expect("send");
+        state
+            .ack_message(&alice, &message_id, Some("noted".into()))
+            .expect("ack should succeed");
+        let hist = state
+            .message_history
+            .iter()
+            .find(|m| m.message_id == message_id)
+            .expect("message in history");
+        assert!(hist.acked_at.is_some(), "acked_at should be set");
+        assert!(state.ack_log.contains_key(&message_id));
     }
 
     #[tokio::test]

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -361,18 +361,26 @@ impl BrokerState {
             payload,
             timestamp: now_secs(),
         };
-        let ts = chrono_ts();
+        // Foreground console echo for `dispatch serve`. Routed through
+        // `tracing::info!` so it lands in both the daily log file AND on
+        // stderr (the same place the previous `eprintln!` wrote), and so
+        // `DISPATCH_LOG=warn` etc. can quiet the broker without losing
+        // file-side logs.
         let display_name = event.worker_name.as_deref().unwrap_or(worker_id);
-        if let Some(ref p) = event.payload {
-            eprintln!(
-                "[{ts}] {:>10}  {display_name}  {}  {p}",
-                event.kind, event.detail
-            );
-        } else {
-            eprintln!(
-                "[{ts}] {:>10}  {display_name}  {}",
-                event.kind, event.detail
-            );
+        match event.payload.as_ref() {
+            Some(p) => tracing::info!(
+                kind = %event.kind,
+                worker = %display_name,
+                detail = %event.detail,
+                payload = %p,
+                "broker event",
+            ),
+            None => tracing::info!(
+                kind = %event.kind,
+                worker = %display_name,
+                detail = %event.detail,
+                "broker event",
+            ),
         }
         let _ = tx.send(event.clone());
         self.event_history.push_back(event);
@@ -862,15 +870,6 @@ async fn handle_connection(
         .map_err(DispatchError::Io)?;
 
     Ok(())
-}
-
-/// Format current time as HH:MM:SS for console output.
-fn chrono_ts() -> String {
-    let secs = now_secs();
-    let s = secs % 60;
-    let m = (secs / 60) % 60;
-    let h = (secs / 3600) % 24;
-    format!("{h:02}:{m:02}:{s:02}")
 }
 
 /// Route a parsed request to the appropriate handler.

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -19,9 +19,13 @@ const DEFAULT_WORKER_TTL_SECS: u64 = 3600;
 /// Default listen timeout in seconds.
 const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 
+/// Default maximum number of events retained in history.
+const DEFAULT_EVENT_HISTORY_MAX: usize = 10_000;
+
 /// Event emitted by the broker for the monitor dashboard.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BrokerEvent {
+    pub id: String,
     pub kind: String,
     pub worker_id: String,
     /// Human-readable worker name (for display in UI).
@@ -136,6 +140,14 @@ pub struct BrokerState {
     pub notifiers: HashMap<String, Arc<Notify>>,
     /// Message acknowledgement log keyed by message ID.
     pub ack_log: HashMap<String, AckRecord>,
+    /// Bounded event history for queries.
+    pub event_history: VecDeque<BrokerEvent>,
+    /// Maximum number of events to retain.
+    pub event_history_max: usize,
+    /// Bounded message history for queries (non-destructive inspection).
+    pub message_history: VecDeque<Message>,
+    /// Maximum number of messages to retain in history.
+    pub message_history_max: usize,
     /// Default TTL for workers that don't specify one.
     pub default_ttl: u64,
     /// Total number of messages sent through the broker.
@@ -163,6 +175,10 @@ impl BrokerState {
             mailboxes: HashMap::new(),
             notifiers: HashMap::new(),
             ack_log: HashMap::new(),
+            event_history: VecDeque::new(),
+            event_history_max: DEFAULT_EVENT_HISTORY_MAX,
+            message_history: VecDeque::new(),
+            message_history_max: DEFAULT_EVENT_HISTORY_MAX,
             default_ttl,
             messages_sent: 0,
             messages_delivered: 0,
@@ -291,6 +307,38 @@ impl BrokerState {
         }
     }
 
+    /// Emit an event: broadcast it, record in history, and print to stderr.
+    pub fn emit_and_record(
+        &mut self,
+        tx: &broadcast::Sender<BrokerEvent>,
+        kind: &str,
+        worker_id: &str,
+        detail: &str,
+        payload: Option<serde_json::Value>,
+    ) {
+        let event = BrokerEvent {
+            id: uuid::Uuid::new_v4().to_string(),
+            kind: kind.to_string(),
+            worker_id: worker_id.to_string(),
+            worker_name: self.worker_name(worker_id).map(|s| s.to_string()),
+            detail: detail.to_string(),
+            payload,
+            timestamp: now_secs(),
+        };
+        let ts = chrono_ts();
+        let display_name = event.worker_name.as_deref().unwrap_or(worker_id);
+        if let Some(ref p) = event.payload {
+            eprintln!("[{ts}] {:>10}  {display_name}  {}  {p}", event.kind, event.detail);
+        } else {
+            eprintln!("[{ts}] {:>10}  {display_name}  {}", event.kind, event.detail);
+        }
+        let _ = tx.send(event.clone());
+        self.event_history.push_back(event);
+        while self.event_history.len() > self.event_history_max {
+            self.event_history.pop_front();
+        }
+    }
+
     /// Clear a worker's status without affecting registration.
     pub fn clear_status(&mut self, worker_id: &str) -> Result<(), String> {
         self.evict_expired();
@@ -315,15 +363,24 @@ impl BrokerState {
         if !self.workers.contains_key(worker_id) {
             return Err(format!("worker not found or expired: {worker_id}"));
         }
+        let now = now_secs();
         self.ack_log.insert(
             message_id.to_string(),
             AckRecord {
                 message_id: message_id.to_string(),
                 worker_id: worker_id.to_string(),
                 note,
-                acked_at: now_secs(),
+                acked_at: now,
             },
         );
+        // Update acked_at in message history.
+        if let Some(hist) = self
+            .message_history
+            .iter_mut()
+            .find(|m| m.message_id == message_id)
+        {
+            hist.acked_at = Some(now);
+        }
         Ok(())
     }
 
@@ -339,13 +396,22 @@ impl BrokerState {
         if !self.workers.contains_key(&to) {
             return None;
         }
+        let now = now_secs();
         let message_id = uuid::Uuid::new_v4().to_string();
         let message = Message {
             message_id: message_id.clone(),
             from,
             to: to.clone(),
             body,
+            sent_at: Some(now),
+            delivered_at: None,
+            acked_at: None,
         };
+        // Record in history before moving into mailbox.
+        self.message_history.push_back(message.clone());
+        while self.message_history.len() > self.message_history_max {
+            self.message_history.pop_front();
+        }
         self.mailboxes
             .entry(to.clone())
             .or_default()
@@ -358,8 +424,85 @@ impl BrokerState {
     }
 
     /// Pop the next message from a worker's mailbox, if any.
+    /// Also marks the message as delivered in the history.
     pub fn pop_message(&mut self, worker_id: &str) -> Option<Message> {
-        self.mailboxes.get_mut(worker_id)?.pop_front()
+        let msg = self.mailboxes.get_mut(worker_id)?.pop_front()?;
+        // Update delivered_at in history.
+        let now = now_secs();
+        if let Some(hist) = self
+            .message_history
+            .iter_mut()
+            .find(|m| m.message_id == msg.message_id)
+        {
+            hist.delivered_at = Some(now);
+        }
+        Some(msg)
+    }
+
+    /// Query event history with optional filters.
+    pub fn query_events(
+        &self,
+        since: Option<u64>,
+        until: Option<u64>,
+        event_type: Option<&str>,
+        worker: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<&BrokerEvent> {
+        let limit = limit.unwrap_or(100);
+        self.event_history
+            .iter()
+            .rev() // most recent first
+            .filter(|e| since.is_none_or(|ts| e.timestamp >= ts))
+            .filter(|e| until.is_none_or(|ts| e.timestamp <= ts))
+            .filter(|e| event_type.is_none_or(|t| e.kind == t))
+            .filter(|e| worker.is_none_or(|w| e.worker_id == w))
+            .take(limit)
+            .collect()
+    }
+
+    /// Query message history with optional filters.
+    pub fn query_messages(
+        &self,
+        worker_id: &str,
+        unacked: bool,
+        sent: bool,
+        since: Option<u64>,
+        limit: Option<usize>,
+        id: Option<&str>,
+    ) -> Vec<&Message> {
+        let limit = limit.unwrap_or(100);
+
+        // Single message by ID
+        if let Some(msg_id) = id {
+            return self
+                .message_history
+                .iter()
+                .filter(|m| m.message_id == msg_id)
+                .collect();
+        }
+
+        self.message_history
+            .iter()
+            .rev() // most recent first
+            .filter(|m| {
+                if sent {
+                    m.from.as_deref() == Some(worker_id)
+                } else {
+                    m.to == worker_id
+                }
+            })
+            .filter(|m| {
+                if unacked {
+                    m.delivered_at.is_some() && m.acked_at.is_none()
+                } else {
+                    true
+                }
+            })
+            .filter(|m| {
+                since.is_none_or(|ts| m.sent_at.unwrap_or(0) >= ts)
+            })
+            .take(limit)
+            .collect()
     }
 
     /// Get or create the Notify handle for a worker's mailbox.
@@ -628,30 +771,7 @@ async fn handle_connection(
     Ok(())
 }
 
-/// Emit a broker event (best-effort, ignores send failures).
-/// Also prints a human-readable line to stderr for the serve console.
-fn emit_event(
-    tx: &broadcast::Sender<BrokerEvent>,
-    kind: &str,
-    worker_id: &str,
-    detail: &str,
-    payload: Option<serde_json::Value>,
-) {
-    let ts = chrono_ts();
-    if let Some(ref p) = payload {
-        eprintln!("[{ts}] {kind:>10}  {worker_id}  {detail}  {p}");
-    } else {
-        eprintln!("[{ts}] {kind:>10}  {worker_id}  {detail}");
-    }
-    let _ = tx.send(BrokerEvent {
-        kind: kind.to_string(),
-        worker_id: worker_id.to_string(),
-        worker_name: None,
-        detail: detail.to_string(),
-        payload,
-        timestamp: now_secs(),
-    });
-}
+
 
 /// Format current time as HH:MM:SS for console output.
 fn chrono_ts() -> String {
@@ -691,7 +811,7 @@ async fn handle_request(
                 evict,
             );
             tracing::info!(worker_id = %worker_id, "worker registered");
-            emit_event(
+            state.emit_and_record(
                 event_tx,
                 "register",
                 &worker_id,
@@ -733,7 +853,7 @@ async fn handle_request(
                 Some(message_id) => {
                     state.messages_sent += 1;
                     tracing::info!(message_id = %message_id, to = %to, "message queued");
-                    emit_event(
+                    state.emit_and_record(
                         event_tx,
                         "send",
                         &to,
@@ -773,7 +893,7 @@ async fn handle_request(
                 let mut s = state.lock().await;
                 let expired = s.evict_expired();
                 for id in &expired {
-                    emit_event(event_tx, "expire", id, "worker expired", None);
+                    s.emit_and_record(event_tx, "expire", id, "worker expired", None);
                 }
                 if !s.workers.contains_key(&worker_id) {
                     return BrokerResponse::Error {
@@ -792,25 +912,25 @@ async fn handle_request(
             // If a message was immediately available, return it.
             if let Some(msg) = immediate_msg {
                 {
-                    state.lock().await.messages_delivered += 1;
+                    let mut s = state.lock().await;
+                    s.messages_delivered += 1;
+                    s.emit_and_record(
+                        event_tx,
+                        "deliver",
+                        &worker_id,
+                        &format!(
+                            "from {} → {}",
+                            msg.from.as_deref().unwrap_or("anonymous"),
+                            &worker_id
+                        ),
+                        Some(serde_json::json!({
+                            "from": msg.from,
+                            "to": msg.to,
+                            "body": msg.body,
+                            "message_id": &msg.message_id[..8],
+                        })),
+                    );
                 }
-                tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: immediate delivery");
-                emit_event(
-                    event_tx,
-                    "deliver",
-                    &worker_id,
-                    &format!(
-                        "from {} → {}",
-                        msg.from.as_deref().unwrap_or("anonymous"),
-                        &worker_id
-                    ),
-                    Some(serde_json::json!({
-                        "from": msg.from,
-                        "to": msg.to,
-                        "body": msg.body,
-                        "message_id": &msg.message_id[..8],
-                    })),
-                );
                 return BrokerResponse::Ok {
                     payload: ResponsePayload::Message {
                         message_id: msg.message_id,
@@ -831,7 +951,7 @@ async fn handle_request(
                 if let Some(msg) = s.pop_message(&worker_id) {
                     s.messages_delivered += 1;
                     tracing::info!(worker_id = %worker_id, message_id = %msg.message_id, "listen: delivered after wait");
-                    emit_event(
+                    s.emit_and_record(
                         event_tx,
                         "deliver",
                         &worker_id,
@@ -878,7 +998,7 @@ async fn handle_request(
                 Some(expires_at) => {
                     let detail = if has_status { "TTL renewed + status updated" } else { "TTL renewed" };
                     tracing::info!(worker_id = %worker_id, expires_at, "heartbeat renewed");
-                    emit_event(
+                    state.emit_and_record(
                         event_tx,
                         "heartbeat",
                         &worker_id,
@@ -907,7 +1027,7 @@ async fn handle_request(
             match state.ack_message(&worker_id, &message_id, note) {
                 Ok(()) => {
                     tracing::info!(worker_id = %worker_id, message_id = %message_id, "message acked");
-                    emit_event(
+                    state.emit_and_record(
                         event_tx,
                         "ack",
                         &worker_id,
@@ -949,6 +1069,53 @@ async fn handle_request(
                 BrokerResponse::Ok {
                     payload: ResponsePayload::StatusResult { workers },
                 }
+            }
+        }
+        BrokerRequest::Events {
+            since,
+            until,
+            event_type,
+            worker,
+            limit,
+        } => {
+            let state = state.lock().await;
+            let events = state.query_events(
+                since,
+                until,
+                event_type.as_deref(),
+                worker.as_deref(),
+                limit,
+            );
+            let events_json: Vec<serde_json::Value> = events
+                .into_iter()
+                .map(|e| serde_json::to_value(e).unwrap_or_default())
+                .collect();
+            BrokerResponse::Ok {
+                payload: ResponsePayload::EventList {
+                    events: events_json,
+                },
+            }
+        }
+        BrokerRequest::Messages {
+            worker_id,
+            unacked,
+            sent,
+            since,
+            limit,
+            id,
+        } => {
+            let state = state.lock().await;
+            let messages = state.query_messages(
+                &worker_id,
+                unacked,
+                sent,
+                since,
+                limit,
+                id.as_deref(),
+            );
+            let messages: Vec<Message> = messages.into_iter().cloned().collect();
+            BrokerResponse::Ok {
+                payload: ResponsePayload::MessageList { messages },
             }
         }
     }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -626,9 +626,24 @@ pub async fn serve(
     // orchestrator (writes) and the monitor (reads via /api/logs/{agent}).
     let log_dir = config.project_root.join("logs");
 
+    // Compute monitor URL up front so the orchestrator can pass it to agents
+    // as DISPATCH_MONITOR_URL; the monitor server itself starts after the
+    // orchestrator is constructed so MonitorState can share it.
+    let monitor_url = monitor_port.map(|port| format!("http://localhost:{port}"));
+
+    // Set up the orchestrator (manages agent process lifecycle).
+    let orchestrator = Arc::new(Mutex::new(super::orchestrator::AgentOrchestrator::new(
+        cell_id,
+        &socket,
+        monitor_url.clone(),
+        &config.agent_cwd,
+        log_dir.clone(),
+        config.agents.clone(),
+    )));
+
     // Optionally start the HTTP monitor dashboard.
-    let monitor_url = if let Some(port) = monitor_port {
-        let url = format!("http://localhost:{port}");
+    if let Some(port) = monitor_port {
+        let url = monitor_url.clone().expect("monitor_url set when port set");
         let monitor_state = super::monitor::MonitorState {
             broker: Arc::clone(&state),
             events: event_tx.clone(),
@@ -641,6 +656,7 @@ pub async fn serve(
             heartbeats: config.heartbeats.clone(),
             log_dir: log_dir.clone(),
             monitor_url: Some(url.clone()),
+            orchestrator: Arc::clone(&orchestrator),
         };
         tokio::spawn(async move {
             if let Err(e) = super::monitor::run_monitor(port, monitor_state).await {
@@ -653,20 +669,7 @@ pub async fn serve(
                 tracing::warn!(error = %e, "failed to open monitor in browser");
             }
         }
-        Some(url)
-    } else {
-        None
-    };
-
-    // Set up the orchestrator (manages agent process lifecycle).
-    let orchestrator = Arc::new(Mutex::new(super::orchestrator::AgentOrchestrator::new(
-        cell_id,
-        &socket,
-        monitor_url.clone(),
-        &config.agent_cwd,
-        log_dir,
-        config.agents.clone(),
-    )));
+    }
 
     if launch_agents {
         // Auto-launch only agents explicitly marked `launch = true`. Agents

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -1233,21 +1233,46 @@ async fn handle_request(
         }
         BrokerRequest::AgentStop { name } => {
             let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
-            let mut orch = orchestrator.lock().await;
-            if orch.stop_by_name(&resolved).await {
-                BrokerResponse::Ok {
-                    payload: ResponsePayload::Ack {},
+            // Release the orchestrator mutex before awaiting the supervisor's
+            // shutdown so concurrent list_state / monitor polls don't stall
+            // for 500ms+ per stop.
+            let handle = {
+                let mut orch = orchestrator.lock().await;
+                orch.signal_stop_by_name(&resolved)
+            };
+            match handle {
+                Some(h) => {
+                    let _ = h.await;
+                    BrokerResponse::Ok {
+                        payload: ResponsePayload::Ack {},
+                    }
                 }
-            } else {
-                BrokerResponse::Error {
+                None => BrokerResponse::Error {
                     message: format!("agent '{resolved}' is not running"),
-                }
+                },
             }
         }
         BrokerRequest::AgentRestart { name } => {
             let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
+            // Split phases mirror api_agent_restart: lock → signal stop →
+            // unlock → await → lock → start. Avoids pinning the orchestrator
+            // mutex across the kill window.
+            let handle = {
+                let mut orch = orchestrator.lock().await;
+                if !orch.has_config(&resolved) {
+                    return BrokerResponse::Error {
+                        message: format!(
+                            "agent restart failed: failed to launch agent \"{resolved}\": no such agent in config"
+                        ),
+                    };
+                }
+                orch.signal_stop_by_name(&resolved)
+            };
+            if let Some(h) = handle {
+                let _ = h.await;
+            }
             let mut orch = orchestrator.lock().await;
-            match orch.restart_by_name(&resolved).await {
+            match orch.start_by_name(&resolved).await {
                 Ok(()) => BrokerResponse::Ok {
                     payload: ResponsePayload::Ack {},
                 },

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -11,7 +11,10 @@ use tokio::sync::{Mutex, Notify};
 use tracing::instrument;
 
 use crate::errors::DispatchError;
-use crate::protocol::{BrokerRequest, BrokerResponse, Message, ResponsePayload, Worker};
+use crate::protocol::{
+    BrokerRequest, BrokerResponse, Message, ResponsePayload, StatusEntry, Worker,
+    STATUS_HISTORY_MAX,
+};
 
 /// Default worker TTL in seconds (1 hour).
 const DEFAULT_WORKER_TTL_SECS: u64 = 3600;
@@ -230,6 +233,7 @@ impl BrokerState {
             expires_at: now + ttl,
             last_status: None,
             last_status_at: None,
+            status_history: VecDeque::new(),
         };
         self.workers.insert(id.clone(), worker);
         id
@@ -267,14 +271,33 @@ impl BrokerState {
 
     /// Renew a worker's TTL and optionally update status.
     /// Returns the new expiry timestamp, or None if not found/expired.
+    ///
+    /// When `status` differs from the worker's existing `last_status`, the
+    /// previous tagline (with its set time) is pushed onto `status_history`
+    /// so the card UI can show the last few values. Identical re-sets are
+    /// deduped so a steady heartbeat doesn't fill the buffer with copies.
     pub fn heartbeat_worker(&mut self, worker_id: &str, status: Option<String>) -> Option<u64> {
         self.evict_expired();
         if let Some(worker) = self.workers.get_mut(worker_id) {
             let now = now_secs();
             worker.expires_at = now + worker.ttl_secs;
             if let Some(s) = status {
-                worker.last_status = Some(s);
-                worker.last_status_at = Some(now);
+                let unchanged = worker.last_status.as_deref() == Some(s.as_str());
+                if !unchanged {
+                    if let (Some(prev_status), Some(prev_at)) =
+                        (worker.last_status.take(), worker.last_status_at)
+                    {
+                        push_status_history(
+                            &mut worker.status_history,
+                            StatusEntry {
+                                status: prev_status,
+                                set_at: prev_at,
+                            },
+                        );
+                    }
+                    worker.last_status = Some(s);
+                    worker.last_status_at = Some(now);
+                }
             }
             Some(worker.expires_at)
         } else {
@@ -358,7 +381,10 @@ impl BrokerState {
         }
     }
 
-    /// Clear a worker's status without affecting registration.
+    /// Clear a worker's current status tagline. Does **not** touch
+    /// `status_history` — clear is a display-level operation so the recent
+    /// taglines stay visible on the agent card after the user resets the
+    /// current state.
     pub fn clear_status(&mut self, worker_id: &str) -> Result<(), String> {
         self.evict_expired();
         if let Some(worker) = self.workers.get_mut(worker_id) {
@@ -541,6 +567,21 @@ pub fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("system clock before UNIX epoch")
         .as_secs()
+}
+
+/// Push a status entry into a worker's history ring, deduping against the
+/// most-recent entry and capping the ring at `STATUS_HISTORY_MAX`.
+///
+/// Dedupe protects the buffer from filling with duplicates when an upstream
+/// re-emits the same tagline — only transitions show up in the history.
+fn push_status_history(history: &mut VecDeque<StatusEntry>, entry: StatusEntry) {
+    if history.back().map(|e| e.status.as_str()) == Some(entry.status.as_str()) {
+        return;
+    }
+    history.push_back(entry);
+    while history.len() > STATUS_HISTORY_MAX {
+        history.pop_front();
+    }
 }
 
 /// Derive the Unix domain socket path for a given cell identity.
@@ -1761,6 +1802,83 @@ mod tests {
             state.heartbeat_worker(&id, None).is_none(),
             "heartbeat for expired worker should return None"
         );
+    }
+
+    /// Pushing 5 distinct statuses leaves the current one on `last_status`
+    /// and the most recent `STATUS_HISTORY_MAX` priors in `status_history`,
+    /// oldest first. The very first status (A) drops off when the ring caps.
+    #[test]
+    fn test_status_history_caps_at_max() {
+        let mut state = BrokerState::new();
+        let id = state.register_worker(
+            "hist".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+            false,
+        );
+        for s in ["A", "B", "C", "D", "E"] {
+            state.heartbeat_worker(&id, Some(s.into())).unwrap();
+        }
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.last_status.as_deref(), Some("E"));
+        let history: Vec<&str> = w.status_history.iter().map(|e| e.status.as_str()).collect();
+        assert_eq!(history, vec!["B", "C", "D"]);
+        assert_eq!(w.status_history.len(), STATUS_HISTORY_MAX);
+    }
+
+    /// Re-setting an identical status is a no-op for both `last_status_at`
+    /// and `status_history` — heartbeats that re-emit the same tagline must
+    /// not pollute the buffer with copies.
+    #[test]
+    fn test_status_history_dedupes_consecutive_repeats() {
+        let mut state = BrokerState::new();
+        let id = state.register_worker(
+            "dedup".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+            false,
+        );
+        state.heartbeat_worker(&id, Some("running".into())).unwrap();
+        let first_at = state.workers.get(&id).unwrap().last_status_at;
+        // Same status again — should not push, should not bump last_status_at.
+        state.heartbeat_worker(&id, Some("running".into())).unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert!(
+            w.status_history.is_empty(),
+            "no transition, no history push"
+        );
+        assert_eq!(
+            w.last_status_at, first_at,
+            "identical status must not bump last_status_at",
+        );
+    }
+
+    /// `status --clear` is a display-level reset: it nulls the current
+    /// tagline but leaves the historical buffer alone so the card still
+    /// shows the recent timeline.
+    #[test]
+    fn test_clear_status_preserves_history() {
+        let mut state = BrokerState::new();
+        let id = state.register_worker(
+            "clr".into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+            false,
+        );
+        state.heartbeat_worker(&id, Some("phase 1".into())).unwrap();
+        state.heartbeat_worker(&id, Some("phase 2".into())).unwrap();
+        state.clear_status(&id).unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert!(w.last_status.is_none());
+        assert!(w.last_status_at.is_none());
+        let history: Vec<&str> = w.status_history.iter().map(|e| e.status.as_str()).collect();
+        assert_eq!(history, vec!["phase 1"]);
     }
 
     #[tokio::test]

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -659,26 +659,24 @@ pub async fn serve(
     };
 
     // Set up the orchestrator (manages agent process lifecycle).
-    let mut orchestrator = super::orchestrator::AgentOrchestrator::new(
+    let orchestrator = Arc::new(Mutex::new(super::orchestrator::AgentOrchestrator::new(
         cell_id,
         &socket,
         monitor_url.clone(),
         &config.agent_cwd,
         log_dir,
-    );
+        config.agents.clone(),
+    )));
 
     if launch_agents {
         // Auto-launch only agents explicitly marked `launch = true`. Agents
         // with `launch = false` (the default) stay unmanaged and their
         // copy-paste launch commands are printed below instead.
-        let launchable: Vec<crate::config::ResolvedAgentConfig> =
-            config.agents.iter().filter(|a| a.launch).cloned().collect();
-        if !launchable.is_empty() {
-            orchestrator.launch_all(&launchable).await?;
-        }
+        let mut orch = orchestrator.lock().await;
+        orch.launch_all().await?;
         // Start configured heartbeat timers.
         if !config.heartbeats.is_empty() {
-            orchestrator.start_heartbeats(&config.heartbeats, &event_tx);
+            orch.start_heartbeats(&config.heartbeats, &event_tx);
         }
     }
 
@@ -713,11 +711,11 @@ pub async fn serve(
 
     // Run until shutdown signal (OS signal or monitor UI).
     let result = tokio::select! {
-        res = accept_loop(&listener, state, event_tx) => res,
+        res = accept_loop(&listener, state, event_tx, Arc::clone(&orchestrator)) => res,
         _ = shutdown_signal() => {
             tracing::info!("shutdown signal received");
             eprintln!("dispatch serve: shutting down agents...");
-            orchestrator.shutdown_all().await;
+            orchestrator.lock().await.shutdown_all().await;
             eprintln!("dispatch serve: shutting down");
             Ok(())
         }
@@ -725,7 +723,7 @@ pub async fn serve(
             tracing::info!("shutdown requested via monitor");
             eprintln!("dispatch serve: shutdown requested from monitor");
             eprintln!("dispatch serve: shutting down agents...");
-            orchestrator.shutdown_all().await;
+            orchestrator.lock().await.shutdown_all().await;
             eprintln!("dispatch serve: shutting down");
             Ok(())
         }
@@ -746,13 +744,15 @@ async fn accept_loop(
     listener: &UnixListener,
     state: Arc<Mutex<BrokerState>>,
     event_tx: broadcast::Sender<BrokerEvent>,
+    orchestrator: Arc<Mutex<super::orchestrator::AgentOrchestrator>>,
 ) -> Result<(), DispatchError> {
     loop {
         let (stream, _addr) = listener.accept().await.map_err(DispatchError::Io)?;
         let state = Arc::clone(&state);
         let event_tx = event_tx.clone();
+        let orchestrator = Arc::clone(&orchestrator);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, state, event_tx).await {
+            if let Err(e) = handle_connection(stream, state, event_tx, orchestrator).await {
                 // Broken pipe is expected when clients disconnect before reading the response.
                 let is_broken_pipe = matches!(&e, DispatchError::Io(io) if io.kind() == std::io::ErrorKind::BrokenPipe);
                 if is_broken_pipe {
@@ -772,6 +772,7 @@ async fn handle_connection(
     stream: UnixStream,
     state: Arc<Mutex<BrokerState>>,
     event_tx: broadcast::Sender<BrokerEvent>,
+    orchestrator: Arc<Mutex<super::orchestrator::AgentOrchestrator>>,
 ) -> Result<(), DispatchError> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -789,7 +790,7 @@ async fn handle_connection(
     tracing::debug!(request = %line, "received request");
 
     let response = match serde_json::from_str::<BrokerRequest>(line) {
-        Ok(request) => handle_request(request, state, &event_tx).await,
+        Ok(request) => handle_request(request, state, &event_tx, orchestrator).await,
         Err(e) => BrokerResponse::Error {
             message: format!("invalid request: {e}"),
         },
@@ -819,6 +820,7 @@ async fn handle_request(
     request: BrokerRequest,
     state: Arc<Mutex<BrokerState>>,
     event_tx: &broadcast::Sender<BrokerEvent>,
+    orchestrator: Arc<Mutex<super::orchestrator::AgentOrchestrator>>,
 ) -> BrokerResponse {
     {
         let mut s = state.lock().await;
@@ -1159,7 +1161,68 @@ async fn handle_request(
                 payload: ResponsePayload::MessageList { messages },
             }
         }
+        BrokerRequest::AgentStart { name } => {
+            let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
+            let mut orch = orchestrator.lock().await;
+            match orch.start_by_name(&resolved).await {
+                Ok(()) => BrokerResponse::Ok {
+                    payload: ResponsePayload::Ack {},
+                },
+                Err(e) => BrokerResponse::Error {
+                    message: format!("agent start failed: {e}"),
+                },
+            }
+        }
+        BrokerRequest::AgentStop { name } => {
+            let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
+            let mut orch = orchestrator.lock().await;
+            if orch.stop_by_name(&resolved).await {
+                BrokerResponse::Ok {
+                    payload: ResponsePayload::Ack {},
+                }
+            } else {
+                BrokerResponse::Error {
+                    message: format!("agent '{resolved}' is not running"),
+                }
+            }
+        }
+        BrokerRequest::AgentRestart { name } => {
+            let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
+            let mut orch = orchestrator.lock().await;
+            match orch.restart_by_name(&resolved).await {
+                Ok(()) => BrokerResponse::Ok {
+                    payload: ResponsePayload::Ack {},
+                },
+                Err(e) => BrokerResponse::Error {
+                    message: format!("agent restart failed: {e}"),
+                },
+            }
+        }
     }
+}
+
+/// Resolve an `agent` subcommand target string (agent name or worker ID) to a
+/// configured agent name. If the input already matches a configured agent
+/// name, it's returned as-is. Otherwise, treat it as a worker ID and look up
+/// the worker's name in the broker registry. Falls back to the input itself
+/// when neither lookup succeeds — the orchestrator will then surface a
+/// "no such agent in config" error.
+async fn resolve_agent_target(
+    target: &str,
+    state: &Arc<Mutex<BrokerState>>,
+    orchestrator: &Arc<Mutex<super::orchestrator::AgentOrchestrator>>,
+) -> String {
+    {
+        let orch = orchestrator.lock().await;
+        if orch.has_config(target) {
+            return target.to_string();
+        }
+    }
+    let state = state.lock().await;
+    if let Some(name) = state.worker_name(target) {
+        return name.to_string();
+    }
+    target.to_string()
 }
 
 /// Wait for a shutdown signal (SIGINT or SIGTERM).

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -550,7 +550,7 @@ pub fn now_secs() -> u64 {
 /// so no additional path components are needed. Using `/tmp` avoids the
 /// Unix domain socket `SUN_LEN` limit (104 bytes on macOS) that triggers
 /// when project paths are deeply nested.
-fn socket_path(_project_root: &Path, cell_id: &str) -> PathBuf {
+pub fn socket_path(_project_root: &Path, cell_id: &str) -> PathBuf {
     PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"))
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,6 +2,8 @@ pub mod local;
 pub mod monitor;
 pub mod orchestrator;
 
+pub use local::socket_path;
+
 use async_trait::async_trait;
 
 use crate::config::ResolvedConfig;

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -204,10 +204,10 @@
     <!-- Agent detail view -->
     <div class="agent-detail hidden" id="view-agent">
       <div class="tab-bar">
-        <div class="tab active" data-tab="config" onclick="selectAgentTab('config')">Config</div>
-        <div class="tab" data-tab="events" onclick="selectAgentTab('events')">Events</div>
-        <div class="tab" data-tab="messages" onclick="selectAgentTab('messages')">Messages</div>
-        <div class="tab" data-tab="logs" onclick="selectAgentTab('logs')">Logs</div>
+        <div class="tab active" data-tab="config">Config</div>
+        <div class="tab" data-tab="events">Events</div>
+        <div class="tab" data-tab="messages">Messages</div>
+        <div class="tab" data-tab="logs">Logs</div>
       </div>
       <div id="agent-config-panel">
         <div class="empty">Select an agent</div>
@@ -810,30 +810,32 @@ async function renderAgentEvents() {
   if (!selectedAgent) { panel.innerHTML = '<div class="empty">Select an agent</div>'; return; }
   const worker = teamWorkers.find(w => w.name === selectedAgent);
   const workerId = worker?.id;
-  if (!workerId) {
-    panel.innerHTML = '<div class="empty">Agent not registered yet — no events.</div>';
+  // Prefer the server-side history endpoint when the agent is still registered.
+  // For evicted/unregistered agents (no workerId), fall through to the SSE cache
+  // so their pre-eviction history stays visible.
+  if (workerId) {
+    try {
+      const resp = await fetch(`/api/events/history?worker=${encodeURIComponent(workerId)}&limit=200`);
+      if (resp.ok) {
+        const data = await resp.json();
+        const histEvents = (data.events || []).map(e => ({ ...e, _ts: new Date(e.timestamp * 1000) }));
+        if (histEvents.length > 0) {
+          panel.innerHTML = histEvents.map(renderEvent).join('');
+          return;
+        }
+      }
+    } catch (_e) { /* fall through to SSE cache */ }
+  }
+  // SSE-cache fallback: match on worker_id when we have one, and on worker_name
+  // in all cases so evicted agents keep their history visible by name.
+  const filtered = allEvents.filter(ev =>
+    (workerId && ev.worker_id === workerId) || ev.worker_name === selectedAgent
+  );
+  if (filtered.length === 0) {
+    panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
     return;
   }
-  // Fetch full history from API, supplemented by any SSE events not yet in history
-  try {
-    const resp = await fetch(`/api/events/history?worker=${encodeURIComponent(workerId)}&limit=200`);
-    if (!resp.ok) { panel.innerHTML = '<div class="empty">Failed to fetch events.</div>'; return; }
-    const data = await resp.json();
-    const histEvents = (data.events || []).map(e => ({ ...e, _ts: new Date(e.timestamp * 1000) }));
-    if (histEvents.length === 0) {
-      panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
-      return;
-    }
-    panel.innerHTML = histEvents.map(renderEvent).join('');
-  } catch(e) {
-    // Fallback to SSE-cached events
-    const filtered = allEvents.filter(ev => ev.worker_id === workerId);
-    if (filtered.length === 0) {
-      panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
-      return;
-    }
-    panel.innerHTML = filtered.map(renderEvent).join('');
-  }
+  panel.innerHTML = filtered.map(renderEvent).join('');
 }
 
 function configBlock(label, value, isCommand) {

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -33,6 +33,7 @@
   @keyframes pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
   .sidebar .nav-item .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .sidebar .nav-item .role-tag { font-size: 10px; color: #484f58; }
+  .sidebar .nav-item .status-tag { font-size: 9px; color: #79c0ff; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; margin-top: 1px; }
 
   /* Main content */
   .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
@@ -65,6 +66,8 @@
   .kind-deliver { color: #58a6ff; }
   .kind-heartbeat { color: #484f58; }
   .kind-expire { color: #f85149; }
+  .kind-ack { color: #a371f7; }
+  .kind-status { color: #79c0ff; }
 
   /* Agent detail view */
   .agent-detail { flex: 1; overflow-y: auto; padding: 16px; }
@@ -76,6 +79,17 @@
   .config-section .config-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 4px; }
   .config-section .config-value { font-size: 12px; color: #c9d1d9; background: #161b22; padding: 8px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
   .config-section .config-value.command { color: #d2a8ff; }
+
+  /* Message list */
+  .msg-item { font-size: 11px; padding: 8px; border-bottom: 1px solid #161b22; }
+  .msg-item .msg-header { display: flex; gap: 8px; align-items: center; margin-bottom: 4px; }
+  .msg-item .msg-id { color: #484f58; font-size: 10px; }
+  .msg-item .msg-dir { color: #8b949e; font-size: 10px; }
+  .msg-item .msg-badge { font-size: 9px; padding: 1px 5px; border-radius: 3px; font-weight: 600; }
+  .msg-item .msg-badge.sent { background: #d2992220; color: #d29922; }
+  .msg-item .msg-badge.delivered { background: #58a6ff20; color: #58a6ff; }
+  .msg-item .msg-badge.acked { background: #a371f720; color: #a371f7; }
+  .msg-item .msg-body { color: #c9d1d9; font-size: 11px; background: #0d1117; padding: 6px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow-y: auto; }
 
   /* Copy command */
   .copy-cmd { position: relative; }
@@ -143,6 +157,7 @@
       <div class="tab-bar">
         <div class="tab active" data-tab="config" onclick="selectAgentTab('config')">Config</div>
         <div class="tab" data-tab="events" onclick="selectAgentTab('events')">Events</div>
+        <div class="tab" data-tab="messages" onclick="selectAgentTab('messages')">Messages</div>
         <div class="tab" data-tab="logs" onclick="selectAgentTab('logs')">Logs</div>
       </div>
       <div id="agent-config-panel">
@@ -150,6 +165,9 @@
       </div>
       <div id="agent-events-panel" class="hidden">
         <div class="empty">No events yet</div>
+      </div>
+      <div id="agent-messages-panel" class="hidden">
+        <div class="empty">Loading messages...</div>
       </div>
       <div id="agent-logs-panel" class="hidden">
         <pre class="log-output" id="agent-log-content">Loading...</pre>
@@ -275,23 +293,25 @@ function renderSidebar() {
     seen.add(cfg.name);
     const worker = teamWorkers.find(w => w.name === cfg.name);
     const isLive = !!worker;
+    const statusText = worker?.last_status || '';
     const isActive = selectedAgent === cfg.name && currentView === 'agent';
     html += `<div class="nav-item${isActive ? ' active' : ''}" data-agent-name="${esc(cfg.name)}" onclick="selectAgentByName('${esc(cfg.name)}')">`;
     html += `<span class="dot${isLive ? ' live' : ' pending'}"></span>`;
-    html += `<span class="name">${esc(cfg.name)}</span>`;
-    html += `<span class="role-tag">${esc(cfg.role)}</span>`;
-    html += `</div>`;
+    html += `<div style="flex:1;overflow:hidden"><span class="name">${esc(cfg.name)}</span><span class="role-tag">${esc(cfg.role)}</span>`;
+    if (statusText) html += `<span class="status-tag">${esc(statusText)}</span>`;
+    html += `</div></div>`;
   }
 
   // Show any registered workers not in config (e.g. manually registered)
   for (const w of teamWorkers) {
     if (seen.has(w.name)) continue;
+    const statusText = w.last_status || '';
     const isActive = selectedAgent === w.name && currentView === 'agent';
     html += `<div class="nav-item${isActive ? ' active' : ''}" data-agent-name="${esc(w.name)}" onclick="selectAgentByName('${esc(w.name)}')">`;
     html += `<span class="dot live"></span>`;
-    html += `<span class="name">${esc(w.name)}</span>`;
-    html += `<span class="role-tag">${esc(w.role)}</span>`;
-    html += `</div>`;
+    html += `<div style="flex:1;overflow:hidden"><span class="name">${esc(w.name)}</span><span class="role-tag">${esc(w.role)}</span>`;
+    if (statusText) html += `<span class="status-tag">${esc(statusText)}</span>`;
+    html += `</div></div>`;
   }
 
   // Main agent
@@ -315,6 +335,7 @@ function selectView(view) {
   currentView = view;
   selectedAgent = null;
   if (logPollInterval) { clearInterval(logPollInterval); logPollInterval = null; }
+  if (msgPollInterval) { clearInterval(msgPollInterval); msgPollInterval = null; }
   document.querySelectorAll('.sidebar .nav-item').forEach(el => el.classList.remove('active'));
   const navEl = document.querySelector(`.sidebar .nav-item[data-view="${view}"]`);
   if (navEl) navEl.classList.add('active');
@@ -341,11 +362,13 @@ function showView(view) {
 // --- Agent detail tabs ---
 let agentTab = 'config';
 let logPollInterval = null;
+let msgPollInterval = null;
 function selectAgentTab(tab) {
   agentTab = tab;
   document.querySelectorAll('.agent-detail .tab').forEach(el => el.classList.toggle('active', el.dataset.tab === tab));
   document.getElementById('agent-config-panel').classList.toggle('hidden', tab !== 'config');
   document.getElementById('agent-events-panel').classList.toggle('hidden', tab !== 'events');
+  document.getElementById('agent-messages-panel').classList.toggle('hidden', tab !== 'messages');
   document.getElementById('agent-logs-panel').classList.toggle('hidden', tab !== 'logs');
   if (tab === 'events') renderAgentEvents();
   // Start/stop log polling
@@ -353,6 +376,12 @@ function selectAgentTab(tab) {
   if (tab === 'logs') {
     fetchAgentLogs();
     logPollInterval = setInterval(fetchAgentLogs, 2000);
+  }
+  // Start/stop message polling
+  if (msgPollInterval) { clearInterval(msgPollInterval); msgPollInterval = null; }
+  if (tab === 'messages') {
+    fetchAgentMessages();
+    msgPollInterval = setInterval(fetchAgentMessages, 3000);
   }
 }
 
@@ -379,6 +408,36 @@ async function fetchAgentLogs() {
     el.textContent = text || '(empty)';
     if (wasAtBottom) el.scrollTop = el.scrollHeight;
   } catch(e) { el.textContent = 'Failed to fetch logs.'; }
+}
+
+async function fetchAgentMessages() {
+  if (!selectedAgent) return;
+  const worker = teamWorkers.find(w => w.name === selectedAgent);
+  const panel = document.getElementById('agent-messages-panel');
+  if (!worker) { panel.innerHTML = '<div class="empty">Agent not registered yet — no messages.</div>'; return; }
+  try {
+    const resp = await fetch(`/api/messages/${encodeURIComponent(worker.id)}?limit=50`);
+    if (!resp.ok) { panel.innerHTML = '<div class="empty">Failed to fetch messages.</div>'; return; }
+    const data = await resp.json();
+    const msgs = data.messages || [];
+    if (msgs.length === 0) { panel.innerHTML = '<div class="empty">No messages yet.</div>'; return; }
+    panel.innerHTML = msgs.map(renderMessage).join('');
+  } catch(e) { panel.innerHTML = '<div class="empty">Failed to fetch messages.</div>'; }
+}
+
+function renderMessage(msg) {
+  const fromName = msg.from ? (resolveWorkerName(msg.from) || msg.from.slice(0,8) + '...') : 'anonymous';
+  const toName = resolveWorkerName(msg.to) || msg.to.slice(0,8) + '...';
+  // Determine badge
+  let badge = '<span class="msg-badge sent">sent</span>';
+  if (msg.acked_at) badge = '<span class="msg-badge acked">acked</span>';
+  else if (msg.delivered_at) badge = '<span class="msg-badge delivered">delivered</span>';
+  const ts = msg.sent_at ? new Date(msg.sent_at * 1000).toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'}) : '';
+  let html = `<div class="msg-item">`;
+  html += `<div class="msg-header"><span class="ts" style="color:#484f58;font-size:10px">${ts}</span> ${badge} <span class="msg-dir">${esc(fromName)} → ${esc(toName)}</span> <span class="msg-id">${esc(msg.message_id.slice(0,8))}</span></div>`;
+  if (msg.body) html += `<div class="msg-body">${esc(msg.body)}</div>`;
+  html += `</div>`;
+  return html;
 }
 
 // --- Rendering ---
@@ -435,6 +494,10 @@ function renderAgentDetail() {
     const ttlSecs = Math.max(0, worker.expires_at - now);
     cfgHtml += `<div class="config-section"><div class="config-label">TTL</div><div class="config-value"><span data-expires-at="${worker.expires_at}">${formatDuration(ttlSecs)}</span></div></div>`;
     cfgHtml += configBlock('Capabilities', worker.capabilities.join(', ') || 'none');
+    if (worker.last_status) {
+      const statusAge = worker.last_status_at ? formatDuration(Math.max(0, now - worker.last_status_at)) + ' ago' : '';
+      cfgHtml += `<div class="config-section"><div class="config-label">Status</div><div class="config-value" style="color:#79c0ff">${esc(worker.last_status)} <span style="color:#484f58;font-size:10px">${statusAge}</span></div></div>`;
+    }
   }
 
   if (agentCfg) {
@@ -454,18 +517,35 @@ function renderAgentDetail() {
   if (agentTab === 'events') renderAgentEvents();
 }
 
-function renderAgentEvents() {
+async function renderAgentEvents() {
   const panel = document.getElementById('agent-events-panel');
   if (!selectedAgent) { panel.innerHTML = '<div class="empty">Select an agent</div>'; return; }
-  // Find the worker ID(s) for this agent name to filter events
   const worker = teamWorkers.find(w => w.name === selectedAgent);
   const workerId = worker?.id;
-  const filtered = workerId ? allEvents.filter(ev => ev.worker_id === workerId) : [];
-  if (filtered.length === 0) {
-    panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
+  if (!workerId) {
+    panel.innerHTML = '<div class="empty">Agent not registered yet — no events.</div>';
     return;
   }
-  panel.innerHTML = filtered.map(renderEvent).join('');
+  // Fetch full history from API, supplemented by any SSE events not yet in history
+  try {
+    const resp = await fetch(`/api/events/history?worker=${encodeURIComponent(workerId)}&limit=200`);
+    if (!resp.ok) { panel.innerHTML = '<div class="empty">Failed to fetch events.</div>'; return; }
+    const data = await resp.json();
+    const histEvents = (data.events || []).map(e => ({ ...e, _ts: new Date(e.timestamp * 1000) }));
+    if (histEvents.length === 0) {
+      panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
+      return;
+    }
+    panel.innerHTML = histEvents.map(renderEvent).join('');
+  } catch(e) {
+    // Fallback to SSE-cached events
+    const filtered = allEvents.filter(ev => ev.worker_id === workerId);
+    if (filtered.length === 0) {
+      panel.innerHTML = '<div class="empty">No events for this agent yet</div>';
+      return;
+    }
+    panel.innerHTML = filtered.map(renderEvent).join('');
+  }
 }
 
 function configBlock(label, value, isCommand) {
@@ -500,6 +580,14 @@ function formatPayload(kind, p) {
   }
   if (kind === 'register') {
     return `<span class="label">name:</span> ${esc(p.name||'')} <span class="label">role:</span> ${esc(p.role||'')}`;
+  }
+  if (kind === 'ack') {
+    let s = `<span class="label">msg:</span> ${esc((p.message_id||'').slice(0,8))}`;
+    if (p.note) s += ` <span class="body-text">${esc(p.note)}</span>`;
+    return s;
+  }
+  if (kind === 'heartbeat' && p?.status) {
+    return `<span class="body-text">${esc(p.status)}</span>`;
   }
   return esc(JSON.stringify(p));
 }

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -51,6 +51,25 @@
   .sparkline .bar { background: #58a6ff40; border-radius: 1px; min-width: 4px; flex: 1; transition: height 0.3s; }
   .recent-section h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 8px; }
 
+  /* Agent cards */
+  .agents-section { margin-bottom: 20px; }
+  .agents-section h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 8px; }
+  .agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+  .agent-card { background: #161b22; border: 1px solid #21262d; border-radius: 6px; padding: 12px; cursor: pointer; transition: border-color 0.15s; }
+  .agent-card:hover { border-color: #30363d; }
+  .agent-card .ac-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+  .agent-card .ac-name { font-size: 13px; font-weight: 600; color: #c9d1d9; }
+  .agent-card .ac-role { font-size: 10px; color: #8b949e; margin-bottom: 8px; }
+  .agent-card .ac-meta { font-size: 10px; color: #6e7681; display: flex; gap: 10px; flex-wrap: wrap; }
+  .agent-card .ac-meta b { color: #8b949e; font-weight: 500; }
+  .state-pill { font-size: 10px; padding: 2px 8px; border-radius: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; white-space: nowrap; }
+  .state-pill.running { background: #3fb95020; color: #3fb950; }
+  .state-pill.starting { background: #58a6ff20; color: #58a6ff; }
+  .state-pill.restarting { background: #d2992220; color: #d29922; }
+  .state-pill.crashed { background: #f8514920; color: #f85149; }
+  .state-pill.stopped { background: #484f5830; color: #8b949e; }
+  .state-pill.unmanaged { background: #30363d50; color: #6e7681; }
+
   /* Event stream view */
   .event-stream { flex: 1; overflow-y: auto; padding: 12px; }
   .event { font-size: 12px; padding: 6px 8px; border-bottom: 1px solid #161b22; }
@@ -139,6 +158,12 @@
         <div class="stat-card"><div class="stat-label">Requests</div><div class="stat-value" id="dash-requests">0</div></div>
         <div class="stat-card"><div class="stat-label">Version</div><div class="stat-value" id="dash-version">--</div></div>
       </div>
+      <div class="agents-section">
+        <h3>Agents</h3>
+        <div class="agents-grid" id="agents-grid">
+          <div class="empty">No agents configured</div>
+        </div>
+      </div>
       <div class="sparkline-container">
         <div class="stat-label">Event Volume (last 60s)</div>
         <div class="sparkline" id="sparkline"></div>
@@ -184,6 +209,7 @@ let allEvents = []; // all events cached
 const MAX_EVENTS = 1000;
 let agentConfigs = []; // from /api/agents
 let teamWorkers = []; // from /api/team
+let agentState = {}; // name -> state object from /api/agents/state
 // Sparkline: 60 buckets, each 1 second
 const SPARK_BUCKETS = 60;
 let sparkData = new Array(SPARK_BUCKETS).fill(0);
@@ -195,10 +221,11 @@ let serverTimeDrift = 0; // server_time - client_time (to correct clock skew)
 // --- Initialization ---
 async function init() {
   setupEventListeners();
-  await Promise.all([fetchAgentConfigs(), refreshTeam(), pingServer()]);
+  await Promise.all([fetchAgentConfigs(), refreshTeam(), pingServer(), fetchAgentState()]);
   setupSSE();
   setInterval(refreshTeam, 2000);
   setInterval(pingServer, 5000);
+  setInterval(fetchAgentState, 2000);
   setInterval(tickUI, 1000); // tick uptime + TTL every second
   sparkInterval = setInterval(tickSparkline, 1000);
 }
@@ -219,6 +246,11 @@ function setupEventListeners() {
   document.getElementById('agent-list').addEventListener('click', (ev) => {
     const item = ev.target.closest('[data-agent-name]');
     if (item) selectAgentByName(item.dataset.agentName);
+  });
+  // Delegated: dashboard agent cards are re-rendered every 2s.
+  document.getElementById('agents-grid').addEventListener('click', (ev) => {
+    const card = ev.target.closest('[data-agent-name]');
+    if (card) selectAgentByName(card.dataset.agentName);
   });
   // Delegated: launch-cmd copy button is inside a re-rendered config panel.
   document.getElementById('agent-config-panel').addEventListener('click', (ev) => {
@@ -255,11 +287,24 @@ async function fetchAgentConfigs() {
   } catch(e) {}
 }
 
+async function fetchAgentState() {
+  try {
+    const resp = await fetch('/api/agents/state');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const map = {};
+    (data.agents || []).forEach(a => { map[a.name] = a.state; });
+    agentState = map;
+    renderAgentCards();
+  } catch(e) {}
+}
+
 async function refreshTeam() {
   try {
     const resp = await fetch('/api/team');
     teamWorkers = await resp.json();
     renderSidebar();
+    renderAgentCards();
   } catch(e) {}
 }
 
@@ -357,6 +402,69 @@ function renderSidebar() {
   }
 
   list.innerHTML = html || '<div class="nav-item empty" style="cursor:default">No agents configured</div>';
+}
+
+// Render the agent cards grid on the dashboard. Pulls supervisor state from
+// /api/agents/state and worker_id from /api/team. Clicking a card selects
+// that agent in the detail view via the sidebar click delegate.
+function renderAgentCards() {
+  const grid = document.getElementById('agents-grid');
+  if (!grid) return;
+  const managed = (agentConfigs || []).filter(a => !a._isMain);
+  if (managed.length === 0) {
+    grid.innerHTML = '<div class="empty">No agents configured</div>';
+    return;
+  }
+  const parts = managed.map(cfg => {
+    const st = agentState[cfg.name];
+    const { kind, label, pid, extra } = describeAgentState(st, cfg);
+    const worker = (teamWorkers || []).find(w => w.name === cfg.name);
+    const workerIdShort = worker ? worker.id.slice(0, 8) : '';
+    const meta = [];
+    if (pid) meta.push(`<span><b>pid</b> ${esc(pid)}</span>`);
+    if (workerIdShort) meta.push(`<span><b>worker</b> ${esc(workerIdShort)}</span>`);
+    if (extra) meta.push(`<span>${esc(extra)}</span>`);
+    return `
+      <div class="agent-card" data-agent-name="${esc(cfg.name)}">
+        <div class="ac-head">
+          <div class="ac-name">${esc(cfg.name)}</div>
+          <span class="state-pill ${kind}">${esc(label)}</span>
+        </div>
+        <div class="ac-role">${esc(cfg.role || '')}</div>
+        <div class="ac-meta">${meta.join('')}</div>
+      </div>`;
+  });
+  grid.innerHTML = parts.join('');
+}
+
+// Map a raw AgentState (serde-tagged JSON) + fallback config into display
+// fields. Agents absent from /api/agents/state are shown as "unmanaged" —
+// that's the expected state when launch=false or the orchestrator hasn't
+// spawned them yet.
+function describeAgentState(st, cfg) {
+  if (!st) {
+    return { kind: cfg.launch ? 'stopped' : 'unmanaged',
+             label: cfg.launch ? 'stopped' : 'unmanaged',
+             pid: null, extra: null };
+  }
+  switch (st.state) {
+    case 'running':
+      return { kind: 'running', label: 'running', pid: st.pid, extra: null };
+    case 'starting':
+      return { kind: 'starting', label: 'starting', pid: null, extra: null };
+    case 'restarting':
+      return { kind: 'restarting', label: 'restarting',
+               pid: null,
+               extra: `attempt ${st.attempt} · backoff ${st.backoff_secs}s` };
+    case 'crashed':
+      return { kind: 'crashed', label: 'crashed',
+               pid: null,
+               extra: `${st.attempts} attempts — ${st.reason || ''}`.trim() };
+    case 'stopped':
+      return { kind: 'stopped', label: 'stopped', pid: null, extra: null };
+    default:
+      return { kind: 'unmanaged', label: st.state || 'unknown', pid: null, extra: null };
+  }
 }
 
 // --- View switching ---

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -467,8 +467,10 @@ function renderAgentCard(cfg) {
   const { kind, label, pid, extra } = describeAgentState(st, cfg);
   const worker = (teamWorkers || []).find(w => w.name === cfg.name);
 
-  // Status block: current + last 2 priors (oldest first in history, so the
-  // most recent prior is at the tail).
+  // Status block: current + last 2 priors. `status_history` arrives
+  // oldest-first (most recent prior at the tail), so take the tail 2 with
+  // slice(-2) and then reverse() to render newest-prior-first below the
+  // current status line.
   const currentStatus = worker?.last_status || '';
   const history = (worker?.status_history || []).slice(-2).reverse();
   let statusBlock = '';

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -54,14 +54,27 @@
   /* Agent cards */
   .agents-section { margin-bottom: 20px; }
   .agents-section h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #484f58; margin-bottom: 8px; }
-  .agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
-  .agent-card { background: #161b22; border: 1px solid #21262d; border-radius: 6px; padding: 12px; cursor: pointer; transition: border-color 0.15s; }
+  .agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+  .agent-card { background: #161b22; border: 1px solid #21262d; border-radius: 6px; padding: 12px; cursor: pointer; transition: border-color 0.15s; display: flex; flex-direction: column; gap: 10px; }
   .agent-card:hover { border-color: #30363d; }
-  .agent-card .ac-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+  .agent-card .ac-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+  .agent-card .ac-title { flex: 1; min-width: 0; }
   .agent-card .ac-name { font-size: 13px; font-weight: 600; color: #c9d1d9; }
-  .agent-card .ac-role { font-size: 10px; color: #8b949e; margin-bottom: 8px; }
+  .agent-card .ac-role-row { display: flex; align-items: center; gap: 6px; margin-top: 2px; }
+  .agent-card .ac-role { font-size: 10px; color: #8b949e; }
+  .agent-card .ac-pills { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+  .agent-card .ac-status-block { min-height: 18px; }
+  .agent-card .ac-status-current { font-size: 12px; color: #79c0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .agent-card .ac-status-prior { font-size: 10px; color: #484f58; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 1px; }
+  .agent-card .ac-status-empty { font-size: 11px; color: #484f58; font-style: italic; }
   .agent-card .ac-meta { font-size: 10px; color: #6e7681; display: flex; gap: 10px; flex-wrap: wrap; }
   .agent-card .ac-meta b { color: #8b949e; font-weight: 500; }
+  .agent-card .ac-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+  .agent-card .ac-btn { background: transparent; border: 1px solid #30363d; color: #8b949e; font-family: inherit; font-size: 10px; padding: 3px 9px; border-radius: 4px; cursor: pointer; text-transform: uppercase; letter-spacing: 0.3px; }
+  .agent-card .ac-btn:hover:not(:disabled) { border-color: #58a6ff; color: #58a6ff; }
+  .agent-card .ac-btn.danger:hover:not(:disabled) { border-color: #f85149; color: #f85149; }
+  .agent-card .ac-btn:disabled { opacity: 0.4; cursor: default; }
+  .agent-card .ac-btn-spacer { flex: 1; }
   .state-pill { font-size: 10px; padding: 2px 8px; border-radius: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; white-space: nowrap; }
   .state-pill.running { background: #3fb95020; color: #3fb950; }
   .state-pill.starting { background: #58a6ff20; color: #58a6ff; }
@@ -69,6 +82,17 @@
   .state-pill.crashed { background: #f8514920; color: #f85149; }
   .state-pill.stopped { background: #484f5830; color: #8b949e; }
   .state-pill.unmanaged { background: #30363d50; color: #6e7681; }
+  .adapter-badge { font-size: 9px; padding: 1px 6px; border-radius: 3px; text-transform: lowercase; letter-spacing: 0.3px; font-weight: 600; }
+  .adapter-badge.adapter-codex { background: #a371f720; color: #a371f7; }
+  .adapter-badge.adapter-claude { background: #ff8c5a20; color: #ff8c5a; }
+  .adapter-badge.adapter-command { background: #484f5830; color: #8b949e; }
+
+  /* Toasts */
+  .toast-host { position: fixed; bottom: 16px; right: 16px; display: flex; flex-direction: column; gap: 6px; z-index: 1000; pointer-events: none; }
+  .toast { background: #161b22; border: 1px solid #30363d; color: #c9d1d9; padding: 8px 12px; border-radius: 6px; font-size: 12px; max-width: 320px; pointer-events: auto; animation: toast-in 0.2s ease-out; }
+  .toast.error { border-color: #f85149; color: #f85149; }
+  .toast.success { border-color: #3fb950; color: #3fb950; }
+  @keyframes toast-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
 
   /* Event stream view */
   .event-stream { flex: 1; overflow-y: auto; padding: 12px; }
@@ -200,6 +224,7 @@
     </div>
   </div>
 </div>
+<div class="toast-host" id="toast-host"></div>
 <script>
 // --- State ---
 let serverAlive = true;
@@ -249,6 +274,21 @@ function setupEventListeners() {
   });
   // Delegated: dashboard agent cards are re-rendered every 2s.
   document.getElementById('agents-grid').addEventListener('click', (ev) => {
+    // Action buttons on the card don't navigate into the detail view —
+    // each button has data-card-action and we handle it below without
+    // bubbling to the card-select logic.
+    const actionBtn = ev.target.closest('[data-card-action]');
+    if (actionBtn) {
+      ev.stopPropagation();
+      handleCardAction(actionBtn);
+      return;
+    }
+    const copyBtn = ev.target.closest('[data-card-copy]');
+    if (copyBtn) {
+      ev.stopPropagation();
+      copyCardCommand(copyBtn);
+      return;
+    }
     const card = ev.target.closest('[data-agent-name]');
     if (card) selectAgentByName(card.dataset.agentName);
   });
@@ -405,8 +445,9 @@ function renderSidebar() {
 }
 
 // Render the agent cards grid on the dashboard. Pulls supervisor state from
-// /api/agents/state and worker_id from /api/team. Clicking a card selects
-// that agent in the detail view via the sidebar click delegate.
+// /api/agents/state and /api/team worker data. Clicking a card opens the
+// detail view; clicking the per-card action buttons fires the POST endpoint
+// and suppresses the card-select handler.
 function renderAgentCards() {
   const grid = document.getElementById('agents-grid');
   if (!grid) return;
@@ -415,26 +456,135 @@ function renderAgentCards() {
     grid.innerHTML = '<div class="empty">No agents configured</div>';
     return;
   }
-  const parts = managed.map(cfg => {
-    const st = agentState[cfg.name];
-    const { kind, label, pid, extra } = describeAgentState(st, cfg);
-    const worker = (teamWorkers || []).find(w => w.name === cfg.name);
-    const workerIdShort = worker ? worker.id.slice(0, 8) : '';
-    const meta = [];
-    if (pid) meta.push(`<span><b>pid</b> ${esc(pid)}</span>`);
-    if (workerIdShort) meta.push(`<span><b>worker</b> ${esc(workerIdShort)}</span>`);
-    if (extra) meta.push(`<span>${esc(extra)}</span>`);
-    return `
-      <div class="agent-card" data-agent-name="${esc(cfg.name)}">
-        <div class="ac-head">
+  grid.innerHTML = managed.map(renderAgentCard).join('');
+  // Populate data-* driven durations immediately; otherwise they'd show "…"
+  // until the next 1s tick fires.
+  tickUI();
+}
+
+function renderAgentCard(cfg) {
+  const st = agentState[cfg.name];
+  const { kind, label, pid, extra } = describeAgentState(st, cfg);
+  const worker = (teamWorkers || []).find(w => w.name === cfg.name);
+
+  // Status block: current + last 2 priors (oldest first in history, so the
+  // most recent prior is at the tail).
+  const currentStatus = worker?.last_status || '';
+  const history = (worker?.status_history || []).slice(-2).reverse();
+  let statusBlock = '';
+  if (currentStatus) {
+    statusBlock += `<div class="ac-status-current">${esc(currentStatus)}</div>`;
+  } else {
+    statusBlock += `<div class="ac-status-empty">no status</div>`;
+  }
+  for (const entry of history) {
+    if (entry && entry.status) {
+      statusBlock += `<div class="ac-status-prior">${esc(entry.status)}</div>`;
+    }
+  }
+
+  // Meta row: pid, uptime (live-ticked), heartbeat age (live-ticked),
+  // restart/crash extras. Uptime is computed client-side from started_at;
+  // heartbeat age from expires_at - ttl_secs (= last heartbeat timestamp).
+  const meta = [];
+  if (pid) meta.push(`<span><b>pid</b> ${esc(pid)}</span>`);
+  if (st && st.state === 'running' && st.started_at) {
+    meta.push(`<span>up <span data-started-at="${esc(st.started_at)}">…</span></span>`);
+  }
+  if (worker && typeof worker.expires_at === 'number' && typeof worker.ttl_secs === 'number') {
+    const lastHb = worker.expires_at - worker.ttl_secs;
+    meta.push(`<span>hb <span data-last-hb-at="${esc(lastHb)}">…</span></span>`);
+  }
+  if (extra) meta.push(`<span>${esc(extra)}</span>`);
+
+  // Action buttons: Start when not currently supervised; Stop when alive;
+  // Restart when a config exists (always, for managed agents). Disabled
+  // states are handled client-side based on the state kind.
+  const canStop = kind === 'running' || kind === 'starting' || kind === 'restarting';
+  const canStart = kind === 'stopped' || kind === 'crashed' || kind === 'unmanaged';
+  const actions = [];
+  if (canStart) {
+    actions.push(`<button class="ac-btn" data-card-action="start" data-agent-name="${esc(cfg.name)}">Start</button>`);
+  }
+  if (canStop) {
+    actions.push(`<button class="ac-btn danger" data-card-action="stop" data-agent-name="${esc(cfg.name)}">Stop</button>`);
+  }
+  actions.push(`<button class="ac-btn" data-card-action="restart" data-agent-name="${esc(cfg.name)}">Restart</button>`);
+  if (!cfg.launch && cfg.launch_command) {
+    actions.push(`<span class="ac-btn-spacer"></span>`);
+    actions.push(`<button class="ac-btn" data-card-copy="1" data-agent-name="${esc(cfg.name)}" title="Copy launch command">Copy cmd</button>`);
+  }
+
+  const adapterName = cfg.adapter || 'command';
+
+  return `
+    <div class="agent-card" data-agent-name="${esc(cfg.name)}">
+      <div class="ac-head">
+        <div class="ac-title">
           <div class="ac-name">${esc(cfg.name)}</div>
+          <div class="ac-role-row">
+            <span class="ac-role">${esc(cfg.role || '')}</span>
+          </div>
+        </div>
+        <div class="ac-pills">
+          <span class="adapter-badge adapter-${esc(adapterName)}">${esc(adapterName)}</span>
           <span class="state-pill ${kind}">${esc(label)}</span>
         </div>
-        <div class="ac-role">${esc(cfg.role || '')}</div>
-        <div class="ac-meta">${meta.join('')}</div>
-      </div>`;
+      </div>
+      <div class="ac-status-block">${statusBlock}</div>
+      <div class="ac-meta">${meta.join('')}</div>
+      <div class="ac-actions">${actions.join('')}</div>
+    </div>`;
+}
+
+async function handleCardAction(btn) {
+  const name = btn.dataset.agentName;
+  const action = btn.dataset.cardAction;
+  if (!name || !action) return;
+  btn.disabled = true;
+  try {
+    const resp = await fetch(`/api/agents/${encodeURIComponent(name)}/${action}`, { method: 'POST' });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      showToast(data.message || `${action} failed (${resp.status})`, 'error');
+    } else {
+      showToast(`${name}: ${action} ok`, 'success');
+      // Refresh the supervisor state immediately so the pill updates without
+      // waiting for the 2-second poll.
+      fetchAgentState();
+    }
+  } catch (e) {
+    showToast(`${name}: ${action} failed (${e?.message || 'network'})`, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+function copyCardCommand(btn) {
+  const name = btn.dataset.agentName;
+  if (!name) return;
+  const cfg = agentConfigs.find(a => a.name === name);
+  if (!cfg?.launch_command) {
+    showToast(`${name}: no launch command available`, 'error');
+    return;
+  }
+  navigator.clipboard.writeText(cfg.launch_command).then(() => {
+    showToast(`${name}: command copied`, 'success');
+  }).catch(() => {
+    showToast(`${name}: clipboard unavailable`, 'error');
   });
-  grid.innerHTML = parts.join('');
+}
+
+// Show a transient toast. `kind` is 'success' | 'error' | undefined.
+// Stack naturally in the bottom-right; each toast removes itself after 3s.
+function showToast(message, kind) {
+  const host = document.getElementById('toast-host');
+  if (!host) return;
+  const el = document.createElement('div');
+  el.className = 'toast' + (kind ? ' ' + kind : '');
+  el.textContent = message;
+  host.appendChild(el);
+  setTimeout(() => { el.remove(); }, 3000);
 }
 
 // Map a raw AgentState (serde-tagged JSON) + fallback config into display
@@ -745,19 +895,38 @@ function renderSparkline() {
   }).join('');
 }
 
-// --- Client-side tick (uptime + TTL) ---
+// --- Client-side tick (uptime + TTL + card uptime + heartbeat age) ---
+// Runs every second so durations stay live between 2s polls. Everything here
+// is read from `data-*` attributes populated at render time — keeps this
+// function oblivious to the render flow.
 function tickUI() {
-  if (!serverStartedAt) return;
   const now = Math.floor(Date.now() / 1000) + serverTimeDrift;
-  // Uptime
-  const uptime = Math.max(0, now - serverStartedAt);
-  document.getElementById('dash-uptime').textContent = formatDuration(uptime);
-  // TTL countdown on sidebar agents (if visible) and agent detail
+  if (serverStartedAt) {
+    const uptime = Math.max(0, now - serverStartedAt);
+    document.getElementById('dash-uptime').textContent = formatDuration(uptime);
+  }
   document.querySelectorAll('[data-expires-at]').forEach(el => {
     const exp = parseInt(el.dataset.expiresAt, 10);
-    const ttl = Math.max(0, exp - now);
-    el.textContent = formatDuration(ttl);
+    el.textContent = formatDuration(Math.max(0, exp - now));
   });
+  document.querySelectorAll('[data-started-at]').forEach(el => {
+    const started = parseInt(el.dataset.startedAt, 10);
+    if (!Number.isFinite(started) || started <= 0) return;
+    el.textContent = formatDuration(Math.max(0, now - started));
+  });
+  document.querySelectorAll('[data-last-hb-at]').forEach(el => {
+    const last = parseInt(el.dataset.lastHbAt, 10);
+    if (!Number.isFinite(last) || last <= 0) return;
+    el.textContent = relativeAge(Math.max(0, now - last));
+  });
+}
+
+// Short-form "just now / Ns ago / Nm ago" for the heartbeat age label.
+function relativeAge(secs) {
+  if (secs < 2) return 'just now';
+  if (secs < 60) return secs + 's ago';
+  if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+  return Math.floor(secs / 3600) + 'h ago';
 }
 function formatDuration(secs) {
   if (secs >= 3600) {

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -63,6 +63,7 @@ async fn api_team(State(state): State<MonitorState>) -> axum::Json<Vec<crate::pr
     let expired = broker.evict_expired();
     for id in &expired {
         let _ = state.events.send(super::local::BrokerEvent {
+            id: uuid::Uuid::new_v4().to_string(),
             kind: "expire".to_string(),
             worker_id: id.clone(),
             worker_name: None,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -138,9 +138,12 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
                 "name": a.name,
                 "role": a.role,
                 "description": a.description,
+                "adapter": a.adapter.to_string(),
                 "command": a.command,
+                "extra_args": a.extra_args,
                 "prompt": a.prompt,
                 "ttl": a.ttl,
+                "launch": a.launch,
                 "launch_command": launch_cmd,
             })
         })

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -27,6 +27,9 @@ pub struct MonitorState {
     pub heartbeats: Vec<crate::config::HeartbeatConfig>,
     pub log_dir: PathBuf,
     pub monitor_url: Option<String>,
+    /// Orchestrator handle used to read live supervisor state for each
+    /// managed agent. Shared with the broker's request handler.
+    pub orchestrator: Arc<Mutex<super::orchestrator::AgentOrchestrator>>,
 }
 
 /// Start the HTTP monitor dashboard on the given port.
@@ -40,6 +43,7 @@ pub async fn run_monitor(
         .route("/api/events", get(api_events))
         .route("/api/health", get(api_health))
         .route("/api/agents", get(api_agents))
+        .route("/api/agents/state", get(api_agents_state))
         .route("/api/logs/{agent}", get(api_logs))
         .route("/api/events/history", get(api_events_history))
         .route("/api/messages/{worker}", get(api_messages))
@@ -176,6 +180,28 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
         "main_agent": main_agent,
         "heartbeats": heartbeats,
     }))
+}
+
+/// Live supervisor state for every managed agent.
+///
+/// The dashboard polls this to drive the agent cards view. Agents the
+/// orchestrator hasn't spawned (launch = false, or explicitly stopped) are
+/// simply absent from the response — the UI merges this with `/api/agents`
+/// configs to show unmanaged agents with a "not running" placeholder.
+async fn api_agents_state(State(state): State<MonitorState>) -> axum::Json<serde_json::Value> {
+    let orch = state.orchestrator.lock().await;
+    let entries = orch.list_state().await;
+    let states: Vec<serde_json::Value> = entries
+        .into_iter()
+        .map(|(name, role, agent_state)| {
+            serde_json::json!({
+                "name": name,
+                "role": role,
+                "state": agent_state,
+            })
+        })
+        .collect();
+    axum::Json(serde_json::json!({ "agents": states }))
 }
 
 /// Query params for the logs endpoint.

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -353,7 +353,9 @@ async fn api_agent_start(
     }
 }
 
-/// Stop a running managed agent by name.
+/// Stop a running managed agent by name. Releases the orchestrator mutex
+/// before awaiting the supervisor's shutdown so the 500ms SIGTERM→SIGKILL
+/// window doesn't stall concurrent `/api/agents/state` polls.
 async fn api_agent_stop(
     State(state): State<MonitorState>,
     Path(name): Path<String>,
@@ -361,19 +363,29 @@ async fn api_agent_stop(
     if !super::orchestrator::is_safe_name(&name) {
         return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
     }
-    let mut orch = state.orchestrator.lock().await;
-    if !orch.has_config(&name) {
-        return error_response(StatusCode::NOT_FOUND, "no such agent in config");
-    }
-    if orch.stop_by_name(&name).await {
-        ok_response()
-    } else {
-        error_response(StatusCode::CONFLICT, "agent is not running")
+
+    // Phase 1 (locked): validate + signal the supervisor to stop.
+    let handle = {
+        let mut orch = state.orchestrator.lock().await;
+        if !orch.has_config(&name) {
+            return error_response(StatusCode::NOT_FOUND, "no such agent in config");
+        }
+        orch.signal_stop_by_name(&name)
+    };
+
+    // Phase 2 (unlocked): wait for the supervisor to exit without pinning
+    // the mutex that list_state / restart / poll all contend for.
+    match handle {
+        Some(h) => {
+            let _ = h.await;
+            ok_response()
+        }
+        None => error_response(StatusCode::CONFLICT, "agent is not running"),
     }
 }
 
-/// Stop-then-start an agent by name. Succeeds even if the agent is not
-/// currently running (only the re-spawn needs to succeed).
+/// Stop-then-start an agent by name. Does not hold the orchestrator mutex
+/// across the stop's await; the respawn re-acquires the lock afterwards.
 async fn api_agent_restart(
     State(state): State<MonitorState>,
     Path(name): Path<String>,
@@ -381,8 +393,25 @@ async fn api_agent_restart(
     if !super::orchestrator::is_safe_name(&name) {
         return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
     }
+
+    // Phase 1 (locked): validate name + signal any running instance to stop.
+    let handle = {
+        let mut orch = state.orchestrator.lock().await;
+        if !orch.has_config(&name) {
+            return error_response(StatusCode::NOT_FOUND, "no such agent in config");
+        }
+        orch.signal_stop_by_name(&name)
+    };
+
+    // Phase 2 (unlocked): await the old supervisor's exit.
+    if let Some(h) = handle {
+        let _ = h.await;
+    }
+
+    // Phase 3 (locked): respawn. `start_by_name` reaps any finished
+    // supervisor entry in case one slipped through between phases.
     let mut orch = state.orchestrator.lock().await;
-    match orch.restart_by_name(&name).await {
+    match orch.start_by_name(&name).await {
         Ok(()) => ok_response(),
         Err(e) => error_response(classify_agent_error(&e), &e.to_string()),
     }

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -41,6 +41,8 @@ pub async fn run_monitor(
         .route("/api/health", get(api_health))
         .route("/api/agents", get(api_agents))
         .route("/api/logs/{agent}", get(api_logs))
+        .route("/api/events/history", get(api_events_history))
+        .route("/api/messages/{worker}", get(api_messages))
         .route("/api/shutdown", axum::routing::post(api_shutdown))
         .with_state(state);
 
@@ -216,6 +218,70 @@ async fn api_logs(
         tail,
     )
         .into_response()
+}
+
+/// Query params for the events history endpoint.
+#[derive(serde::Deserialize)]
+struct EventsQuery {
+    since: Option<u64>,
+    until: Option<u64>,
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+    worker: Option<String>,
+    limit: Option<usize>,
+}
+
+/// Return filtered event history as JSON.
+async fn api_events_history(
+    State(state): State<MonitorState>,
+    Query(query): Query<EventsQuery>,
+) -> axum::Json<serde_json::Value> {
+    let broker = state.broker.lock().await;
+    let events = broker.query_events(
+        query.since,
+        query.until,
+        query.event_type.as_deref(),
+        query.worker.as_deref(),
+        query.limit,
+    );
+    let events_json: Vec<serde_json::Value> = events
+        .into_iter()
+        .map(|e| serde_json::to_value(e).unwrap_or_default())
+        .collect();
+    axum::Json(serde_json::json!({ "events": events_json }))
+}
+
+/// Query params for the messages endpoint.
+#[derive(serde::Deserialize)]
+struct MessagesQuery {
+    #[serde(default)]
+    unacked: bool,
+    #[serde(default)]
+    sent: bool,
+    since: Option<u64>,
+    limit: Option<usize>,
+}
+
+/// Return message history for a worker as JSON.
+async fn api_messages(
+    State(state): State<MonitorState>,
+    Path(worker): Path<String>,
+    Query(query): Query<MessagesQuery>,
+) -> axum::Json<serde_json::Value> {
+    let broker = state.broker.lock().await;
+    let messages = broker.query_messages(
+        &worker,
+        query.unacked,
+        query.sent,
+        query.since,
+        query.limit,
+        None,
+    );
+    let messages: Vec<serde_json::Value> = messages
+        .into_iter()
+        .map(|m| serde_json::to_value(m).unwrap_or_default())
+        .collect();
+    axum::Json(serde_json::json!({ "messages": messages }))
 }
 
 /// Trigger a graceful server shutdown from the monitor UI.

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::Html;
+use axum::response::{Html, IntoResponse};
 use axum::routing::get;
 use axum::Router;
 use futures_util::stream::Stream;
@@ -48,6 +49,18 @@ pub async fn run_monitor(
         .route("/api/events/history", get(api_events_history))
         .route("/api/messages/{worker}", get(api_messages))
         .route("/api/shutdown", axum::routing::post(api_shutdown))
+        .route(
+            "/api/agents/{name}/start",
+            axum::routing::post(api_agent_start),
+        )
+        .route(
+            "/api/agents/{name}/stop",
+            axum::routing::post(api_agent_stop),
+        )
+        .route(
+            "/api/agents/{name}/restart",
+            axum::routing::post(api_agent_restart),
+        )
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
@@ -318,8 +331,208 @@ async fn api_messages(
 }
 
 /// Trigger a graceful server shutdown from the monitor UI.
-async fn api_shutdown(State(state): State<MonitorState>) -> axum::http::StatusCode {
+async fn api_shutdown(State(state): State<MonitorState>) -> StatusCode {
     tracing::info!("shutdown requested via monitor");
     state.shutdown.notify_one();
-    axum::http::StatusCode::OK
+    StatusCode::OK
+}
+
+/// Start a configured agent by name. Same authz posture as `/api/shutdown`:
+/// unauthenticated, intended for local-loopback use only.
+async fn api_agent_start(
+    State(state): State<MonitorState>,
+    Path(name): Path<String>,
+) -> axum::response::Response {
+    if !super::orchestrator::is_safe_name(&name) {
+        return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
+    }
+    let mut orch = state.orchestrator.lock().await;
+    match orch.start_by_name(&name).await {
+        Ok(()) => ok_response(),
+        Err(e) => error_response(classify_agent_error(&e), &e.to_string()),
+    }
+}
+
+/// Stop a running managed agent by name.
+async fn api_agent_stop(
+    State(state): State<MonitorState>,
+    Path(name): Path<String>,
+) -> axum::response::Response {
+    if !super::orchestrator::is_safe_name(&name) {
+        return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
+    }
+    let mut orch = state.orchestrator.lock().await;
+    if !orch.has_config(&name) {
+        return error_response(StatusCode::NOT_FOUND, "no such agent in config");
+    }
+    if orch.stop_by_name(&name).await {
+        ok_response()
+    } else {
+        error_response(StatusCode::CONFLICT, "agent is not running")
+    }
+}
+
+/// Stop-then-start an agent by name. Succeeds even if the agent is not
+/// currently running (only the re-spawn needs to succeed).
+async fn api_agent_restart(
+    State(state): State<MonitorState>,
+    Path(name): Path<String>,
+) -> axum::response::Response {
+    if !super::orchestrator::is_safe_name(&name) {
+        return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
+    }
+    let mut orch = state.orchestrator.lock().await;
+    match orch.restart_by_name(&name).await {
+        Ok(()) => ok_response(),
+        Err(e) => error_response(classify_agent_error(&e), &e.to_string()),
+    }
+}
+
+/// Map orchestrator launch errors to HTTP statuses. "No such agent" is 404,
+/// "already running" is 409 (resource state conflict), anything else is 400.
+fn classify_agent_error(err: &crate::errors::DispatchError) -> StatusCode {
+    let msg = err.to_string();
+    if msg.contains("no such agent in config") {
+        StatusCode::NOT_FOUND
+    } else if msg.contains("already running") {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+fn ok_response() -> axum::response::Response {
+    (
+        StatusCode::OK,
+        axum::Json(serde_json::json!({"status": "ok"})),
+    )
+        .into_response()
+}
+
+fn error_response(code: StatusCode, message: &str) -> axum::response::Response {
+    (
+        code,
+        axum::Json(serde_json::json!({"status": "error", "message": message})),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::Adapter;
+    use crate::backend::orchestrator::AgentOrchestrator;
+    use crate::config::ResolvedAgentConfig;
+
+    /// Minimal ResolvedAgentConfig that uses the `command` adapter so tests
+    /// don't need `claude` or `codex` binaries on the host.
+    fn test_agent(name: &str, command: &str) -> ResolvedAgentConfig {
+        ResolvedAgentConfig {
+            name: name.into(),
+            role: "test".into(),
+            description: "".into(),
+            adapter: Adapter::Command,
+            command: Some(command.into()),
+            extra_args: Vec::new(),
+            prompt: None,
+            prompt_file_path: None,
+            ttl: None,
+            launch: false,
+        }
+    }
+
+    /// Build a MonitorState backed by a real orchestrator loaded with
+    /// `configs` and a disposable log dir under `tmp`.
+    fn make_state(tmp: &std::path::Path, configs: Vec<ResolvedAgentConfig>) -> MonitorState {
+        let broker = Arc::new(Mutex::new(BrokerState::new()));
+        let (events, _) = broadcast::channel(16);
+        let shutdown = Arc::new(Notify::new());
+        let orchestrator = Arc::new(Mutex::new(AgentOrchestrator::new(
+            "test-cell",
+            &tmp.join("broker.sock"),
+            None,
+            tmp,
+            tmp.join("logs"),
+            configs,
+        )));
+        MonitorState {
+            broker,
+            events,
+            shutdown,
+            name: None,
+            cell_id: "test-cell".into(),
+            started_at: 0,
+            agents: vec![],
+            main_agent: None,
+            heartbeats: vec![],
+            log_dir: tmp.join("logs"),
+            monitor_url: None,
+            orchestrator,
+        }
+    }
+
+    #[tokio::test]
+    async fn start_stop_restart_happy_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![test_agent("alice", "sleep 30")]);
+
+        let resp = api_agent_start(State(state.clone()), Path("alice".into())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Let the supervisor publish its Running state before we act again.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let resp = api_agent_restart(State(state.clone()), Path("alice".into())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = api_agent_stop(State(state.clone()), Path("alice".into())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn start_unknown_agent_returns_404() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![]);
+        let resp = api_agent_start(State(state), Path("nope".into())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn start_already_running_returns_409() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![test_agent("busy", "sleep 30")]);
+
+        assert_eq!(
+            api_agent_start(State(state.clone()), Path("busy".into()))
+                .await
+                .status(),
+            StatusCode::OK
+        );
+        let resp = api_agent_start(State(state), Path("busy".into())).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn stop_not_running_returns_409() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![test_agent("idle", "sleep 30")]);
+        let resp = api_agent_stop(State(state), Path("idle".into())).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn stop_unknown_agent_returns_404() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![]);
+        let resp = api_agent_stop(State(state), Path("ghost".into())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn invalid_agent_name_returns_400() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = make_state(tmp.path(), vec![]);
+        let resp = api_agent_start(State(state), Path("../evil".into())).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -1,11 +1,23 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tokio::process::{Child, Command};
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
 
 use crate::adapter::{BuildContext, Launch};
 use crate::config::ResolvedAgentConfig;
 use crate::errors::DispatchError;
+
+/// Maximum consecutive restart attempts before marking an agent as crashed.
+/// Counter resets when the agent runs for at least `STABLE_AFTER` seconds.
+const MAX_RESTART_ATTEMPTS: u32 = 5;
+
+/// Duration an agent must stay running before its restart attempt counter
+/// resets. A process that crashes after this threshold gets a fresh budget.
+const STABLE_AFTER: Duration = Duration::from_secs(30);
 
 /// Kill an entire process group. Sends SIGTERM first, then SIGKILL after a timeout.
 async fn kill_process_group(pid: u32) {
@@ -15,28 +27,49 @@ async fn kill_process_group(pid: u32) {
         libc::kill(-pgid, libc::SIGTERM);
     }
     // Give processes a moment to exit gracefully.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     // Force kill any remaining processes.
     unsafe {
         libc::kill(-pgid, libc::SIGKILL);
     }
 }
 
-/// Info about a running agent for external queries.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct AgentInfo {
-    pub name: String,
-    pub role: String,
-    pub pid: u32,
-    pub running: bool,
+/// Exponential backoff (capped at 30s) for consecutive restart attempts.
+/// attempt=1 → 1s, 2 → 2s, 3 → 4s, 4 → 8s, 5 → 16s, 6+ → 30s.
+fn restart_backoff(attempt: u32) -> Duration {
+    let secs = 1u64
+        .checked_shl(attempt.saturating_sub(1))
+        .unwrap_or(u64::MAX);
+    Duration::from_secs(secs.min(30))
 }
 
-/// A running agent subprocess.
-struct RunningAgent {
+/// Runtime state of a supervised agent. Consumed by the monitor UI and tests.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum AgentState {
+    /// Supervisor has been created but the first spawn hasn't landed yet.
+    Starting,
+    /// A child process is alive.
+    Running { pid: u32 },
+    /// Process exited; supervisor is waiting before respawning.
+    Restarting { attempt: u32, backoff_secs: u64 },
+    /// Restart budget exhausted — supervisor has given up.
+    Crashed { reason: String, attempts: u32 },
+    /// Supervisor was asked to stop (either by the user or on shutdown).
+    Stopped,
+}
+
+/// An agent under supervisor control. The supervisor owns the `Child` handle
+/// and respawns on exit; the orchestrator only holds signaling primitives and
+/// observable state.
+struct ManagedAgent {
     name: String,
     role: String,
-    child: Child,
-    pid: u32,
+    state: Arc<Mutex<AgentState>>,
+    /// Notified when the supervisor should stop restarting. Using `notify_one`
+    /// is sufficient because each supervisor has at most one pending wait.
+    shutdown: Arc<Notify>,
+    supervisor: JoinHandle<()>,
 }
 
 /// A running heartbeat timer task.
@@ -47,7 +80,7 @@ struct RunningHeartbeat {
 
 /// Manages the lifecycle of agent subprocesses and heartbeat timers.
 pub struct AgentOrchestrator {
-    agents: Vec<RunningAgent>,
+    agents: Vec<ManagedAgent>,
     heartbeats: Vec<RunningHeartbeat>,
     cell_id: String,
     socket_path: PathBuf,
@@ -120,93 +153,56 @@ impl AgentOrchestrator {
             })
     }
 
-    /// Spawn a single agent as a subprocess.
+    /// Spawn an agent and attach a supervisor task that restarts it on exit
+    /// (with exponential backoff) until the restart budget is exhausted.
     ///
     /// Stdout/stderr go to `<log_dir>/<sanitized-agent-name>.log`. Stdin
     /// comes from the adapter's `stdin_file` (typically the prompt file) or
     /// is `/dev/null` if the adapter doesn't need one.
     pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
         let env_vars = self.env_vars(&config.name, &config.role);
-        let launch = Self::build_launch(config)?;
 
-        tracing::info!(
-            agent = %config.name,
-            role = %config.role,
-            adapter = %config.adapter,
-            program = %launch.program,
-            args = ?launch.args,
-            cwd = %self.agent_cwd.display(),
-            "launching agent"
-        );
-
-        tokio::fs::create_dir_all(&self.log_dir)
-            .await
-            .map_err(|e| DispatchError::AgentLaunchFailed {
-                name: config.name.clone(),
-                reason: format!("failed to create log dir {}: {e}", self.log_dir.display()),
-            })?;
-        let safe_name = sanitize_name(&config.name);
-        let log_path = self.log_dir.join(format!("{safe_name}.log"));
-        let log_file = tokio::fs::File::create(&log_path).await.map_err(|e| {
-            DispatchError::AgentLaunchFailed {
-                name: config.name.clone(),
-                reason: format!("failed to create log file {}: {e}", log_path.display()),
-            }
-        })?;
-        let log_file_err =
-            log_file
-                .try_clone()
-                .await
-                .map_err(|e| DispatchError::AgentLaunchFailed {
-                    name: config.name.clone(),
-                    reason: format!("failed to clone log file handle: {e}"),
-                })?;
-        let log_file_std = log_file.into_std().await;
-        let log_file_err_std = log_file_err.into_std().await;
-
-        let stdin = match &launch.stdin_file {
-            Some(path) => {
-                let f =
-                    std::fs::File::open(path).map_err(|e| DispatchError::AgentLaunchFailed {
-                        name: config.name.clone(),
-                        reason: format!("failed to open prompt file {}: {e}", path.display()),
-                    })?;
-                std::process::Stdio::from(f)
-            }
-            None => std::process::Stdio::null(),
-        };
-
-        let child = Command::new(&launch.program)
-            .args(&launch.args)
-            .envs(&env_vars)
-            .current_dir(&self.agent_cwd)
-            .stdin(stdin)
-            .stdout(std::process::Stdio::from(log_file_std))
-            .stderr(std::process::Stdio::from(log_file_err_std))
-            .process_group(0) // Own process group so we can kill the whole tree.
-            .spawn()
-            .map_err(|e| DispatchError::AgentLaunchFailed {
-                name: config.name.clone(),
-                reason: e.to_string(),
-            })?;
-
+        // Initial spawn is synchronous so the caller sees config errors
+        // (bad prompt file, missing binary) as a proper Err instead of
+        // discovering them later via AgentState::Crashed.
+        let child = spawn_child_process(config, &env_vars, &self.agent_cwd, &self.log_dir).await?;
         let pid = child.id().unwrap_or(0);
         eprintln!(
-            "dispatch serve: launched agent '{}' (role={}, pid={}, log={})",
-            config.name,
-            config.role,
-            pid,
-            log_path.display()
+            "dispatch serve: launched agent '{}' (role={}, pid={})",
+            config.name, config.role, pid
         );
 
-        self.agents.push(RunningAgent {
+        let state = Arc::new(Mutex::new(AgentState::Running { pid }));
+        let shutdown = Arc::new(Notify::new());
+
+        let supervisor = tokio::spawn(supervise_agent(
+            config.clone(),
+            env_vars,
+            self.agent_cwd.clone(),
+            self.log_dir.clone(),
+            child,
+            Arc::clone(&state),
+            Arc::clone(&shutdown),
+        ));
+
+        self.agents.push(ManagedAgent {
             name: config.name.clone(),
             role: config.role.clone(),
-            child,
-            pid,
+            state,
+            shutdown,
+            supervisor,
         });
 
         Ok(())
+    }
+
+    /// Snapshot of all managed agents' current runtime state.
+    pub async fn list_state(&self) -> Vec<(String, String, AgentState)> {
+        let mut out = Vec::with_capacity(self.agents.len());
+        for a in &self.agents {
+            out.push((a.name.clone(), a.role.clone(), a.state.lock().await.clone()));
+        }
+        out
     }
 
     /// Launch every agent marked `launch = true` in the stored configs,
@@ -261,22 +257,6 @@ impl AgentOrchestrator {
     /// Whether an agent with this name exists in the config (running or not).
     pub fn has_config(&self, name: &str) -> bool {
         self.configs.iter().any(|a| a.name == name)
-    }
-
-    /// Return info about all agents.
-    pub fn list(&mut self) -> Vec<AgentInfo> {
-        self.agents
-            .iter_mut()
-            .map(|a| {
-                let running = a.child.try_wait().ok().flatten().is_none();
-                AgentInfo {
-                    name: a.name.clone(),
-                    role: a.role.clone(),
-                    pid: a.pid,
-                    running,
-                }
-            })
-            .collect()
     }
 
     /// Start all configured heartbeat timers.
@@ -361,7 +341,8 @@ impl AgentOrchestrator {
         }
     }
 
-    /// Kill all running agent processes, cancel heartbeats, and wait for cleanup.
+    /// Signal every supervisor to stop, cancel heartbeats, and wait for
+    /// supervisors to finish reaping their children.
     pub async fn shutdown_all(&mut self) {
         // Cancel heartbeat timers.
         for hb in &self.heartbeats {
@@ -370,31 +351,215 @@ impl AgentOrchestrator {
         }
         self.heartbeats.clear();
 
-        // Kill agent processes.
-        for agent in &mut self.agents {
-            if agent.child.try_wait().ok().flatten().is_none() {
-                tracing::info!(agent = %agent.name, pid = agent.pid, "stopping agent");
-                kill_process_group(agent.pid).await;
-                // Reap the child to avoid zombies.
-                let _ = agent.child.wait().await;
-            }
+        // Signal every supervisor to stop (no respawn), then await them.
+        for agent in &self.agents {
+            tracing::info!(agent = %agent.name, "stopping agent");
+            agent.shutdown.notify_one();
         }
-        self.agents.clear();
+        for agent in self.agents.drain(..) {
+            let _ = agent.supervisor.await;
+        }
     }
 
     /// Stop a running agent by name. Returns `true` if an agent was found and
-    /// stopped, `false` if no agent by that name is currently running.
+    /// stopped, `false` if no agent by that name is currently supervised.
     pub async fn stop_by_name(&mut self, name: &str) -> bool {
         if let Some(idx) = self.agents.iter().position(|a| a.name == name) {
-            let agent = &mut self.agents[idx];
-            if agent.child.try_wait().ok().flatten().is_none() {
-                kill_process_group(agent.pid).await;
-                let _ = agent.child.wait().await;
-            }
-            self.agents.remove(idx);
+            let agent = self.agents.remove(idx);
+            agent.shutdown.notify_one();
+            let _ = agent.supervisor.await;
             true
         } else {
             false
+        }
+    }
+}
+
+/// Spawn the agent process (single attempt, no supervision).
+///
+/// Used both for the initial launch and for respawns inside the supervisor.
+/// Stdout/stderr append to `<log_dir>/<sanitized-name>.log`; restarts append
+/// to the same file so the full history is preserved across respawns.
+async fn spawn_child_process(
+    config: &ResolvedAgentConfig,
+    env_vars: &HashMap<String, String>,
+    agent_cwd: &Path,
+    log_dir: &Path,
+) -> Result<Child, DispatchError> {
+    let launch =
+        AgentOrchestrator::build_launch(config).map_err(|e| DispatchError::AgentLaunchFailed {
+            name: config.name.clone(),
+            reason: e.to_string(),
+        })?;
+
+    tracing::info!(
+        agent = %config.name,
+        role = %config.role,
+        adapter = %config.adapter,
+        program = %launch.program,
+        args = ?launch.args,
+        cwd = %agent_cwd.display(),
+        "launching agent"
+    );
+
+    tokio::fs::create_dir_all(&log_dir)
+        .await
+        .map_err(|e| DispatchError::AgentLaunchFailed {
+            name: config.name.clone(),
+            reason: format!("failed to create log dir {}: {e}", log_dir.display()),
+        })?;
+    let safe_name = sanitize_name(&config.name);
+    let log_path = log_dir.join(format!("{safe_name}.log"));
+    // Append rather than truncate so restart logs are retained.
+    let log_file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .await
+        .map_err(|e| DispatchError::AgentLaunchFailed {
+            name: config.name.clone(),
+            reason: format!("failed to open log file {}: {e}", log_path.display()),
+        })?;
+    let log_file_err =
+        log_file
+            .try_clone()
+            .await
+            .map_err(|e| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: format!("failed to clone log file handle: {e}"),
+            })?;
+    let log_file_std = log_file.into_std().await;
+    let log_file_err_std = log_file_err.into_std().await;
+
+    let stdin = match &launch.stdin_file {
+        Some(path) => {
+            let f = std::fs::File::open(path).map_err(|e| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: format!("failed to open prompt file {}: {e}", path.display()),
+            })?;
+            std::process::Stdio::from(f)
+        }
+        None => std::process::Stdio::null(),
+    };
+
+    Command::new(&launch.program)
+        .args(&launch.args)
+        .envs(env_vars)
+        .current_dir(agent_cwd)
+        .stdin(stdin)
+        .stdout(std::process::Stdio::from(log_file_std))
+        .stderr(std::process::Stdio::from(log_file_err_std))
+        .process_group(0)
+        .spawn()
+        .map_err(|e| DispatchError::AgentLaunchFailed {
+            name: config.name.clone(),
+            reason: e.to_string(),
+        })
+}
+
+/// Supervisor loop for a single agent.
+///
+/// - Waits for the initial `child` to exit or for a shutdown signal.
+/// - On exit: if the agent ran for at least `STABLE_AFTER`, reset the attempt
+///   counter (a long-lived process that dies once shouldn't exhaust the
+///   budget). Otherwise increment.
+/// - Applies `restart_backoff(attempt)` before respawning.
+/// - Gives up after `MAX_RESTART_ATTEMPTS` consecutive unstable failures and
+///   leaves `AgentState::Crashed` in place.
+async fn supervise_agent(
+    config: ResolvedAgentConfig,
+    env_vars: HashMap<String, String>,
+    agent_cwd: PathBuf,
+    log_dir: PathBuf,
+    initial_child: Child,
+    state: Arc<Mutex<AgentState>>,
+    shutdown: Arc<Notify>,
+) {
+    let mut child = initial_child;
+    let mut attempt: u32 = 0;
+    let mut started_at = Instant::now();
+
+    loop {
+        let pid = child.id().unwrap_or(0);
+        tokio::select! {
+            _ = shutdown.notified() => {
+                tracing::info!(agent = %config.name, pid, "shutdown requested");
+                kill_process_group(pid).await;
+                let _ = child.wait().await;
+                *state.lock().await = AgentState::Stopped;
+                return;
+            }
+            status = child.wait() => {
+                let ran_for = started_at.elapsed();
+                tracing::info!(
+                    agent = %config.name,
+                    ?status,
+                    ran_secs = ran_for.as_secs(),
+                    "agent exited",
+                );
+
+                if ran_for >= STABLE_AFTER {
+                    attempt = 1;
+                } else {
+                    attempt = attempt.saturating_add(1);
+                }
+
+                if attempt > MAX_RESTART_ATTEMPTS {
+                    let reason = match status {
+                        Ok(s) => format!("exited with {s}"),
+                        Err(e) => format!("wait error: {e}"),
+                    };
+                    tracing::warn!(
+                        agent = %config.name,
+                        attempts = attempt - 1,
+                        %reason,
+                        "restart budget exhausted; marking crashed",
+                    );
+                    *state.lock().await = AgentState::Crashed {
+                        reason,
+                        attempts: attempt - 1,
+                    };
+                    return;
+                }
+
+                let backoff = restart_backoff(attempt);
+                tracing::info!(
+                    agent = %config.name,
+                    attempt,
+                    backoff_secs = backoff.as_secs(),
+                    "restarting after backoff",
+                );
+                *state.lock().await = AgentState::Restarting {
+                    attempt,
+                    backoff_secs: backoff.as_secs(),
+                };
+
+                // Sleep with shutdown cancellation.
+                tokio::select! {
+                    _ = shutdown.notified() => {
+                        *state.lock().await = AgentState::Stopped;
+                        return;
+                    }
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+
+                match spawn_child_process(&config, &env_vars, &agent_cwd, &log_dir).await {
+                    Ok(new_child) => {
+                        child = new_child;
+                        started_at = Instant::now();
+                        let new_pid = child.id().unwrap_or(0);
+                        *state.lock().await = AgentState::Running { pid: new_pid };
+                    }
+                    Err(e) => {
+                        tracing::warn!(agent = %config.name, error = %e, "respawn failed");
+                        *state.lock().await = AgentState::Crashed {
+                            reason: format!("respawn failed: {e}"),
+                            attempts: attempt,
+                        };
+                        return;
+                    }
+                }
+            }
         }
     }
 }
@@ -524,4 +689,104 @@ pub(super) fn sanitize_name(s: &str) -> String {
         out.push('_');
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::Adapter;
+
+    /// Exponential doubling capped at 30s — table-driven so the intent is
+    /// obvious if anyone tunes the backoff schedule later.
+    #[test]
+    fn restart_backoff_schedule() {
+        let cases = [(1, 1), (2, 2), (3, 4), (4, 8), (5, 16), (6, 30), (10, 30)];
+        for (attempt, expected) in cases {
+            assert_eq!(
+                restart_backoff(attempt).as_secs(),
+                expected,
+                "attempt {attempt} should back off {expected}s",
+            );
+        }
+    }
+
+    /// Build a ResolvedAgentConfig that runs a short sh command under the
+    /// `command` adapter — avoids needing `claude`/`codex` binaries on the
+    /// test host.
+    fn test_config(name: &str, command: &str) -> ResolvedAgentConfig {
+        ResolvedAgentConfig {
+            name: name.into(),
+            role: "test".into(),
+            description: "".into(),
+            adapter: Adapter::Command,
+            command: Some(command.into()),
+            extra_args: Vec::new(),
+            prompt: None,
+            prompt_file_path: None,
+            ttl: None,
+            launch: true,
+        }
+    }
+
+    /// Supervisor reports Running while a long-lived child is alive, and
+    /// transitions to Stopped after `stop_by_name`.
+    #[tokio::test]
+    async fn supervisor_running_then_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+        );
+        let cfg = test_config("alice", "sleep 30");
+        orch.spawn_agent(&cfg).await.expect("spawn");
+        // Let the supervisor publish its Running state.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let states = orch.list_state().await;
+        assert_eq!(states.len(), 1);
+        assert!(matches!(states[0].2, AgentState::Running { .. }));
+
+        assert!(orch.stop_by_name("alice").await);
+        assert!(orch.list_state().await.is_empty());
+    }
+
+    /// When the child exits quickly, the supervisor moves through
+    /// Running → Restarting (attempt=1) before the first-backoff sleep
+    /// completes. We probe at 300ms — well after exit, well before the 1s
+    /// backoff elapses.
+    #[tokio::test]
+    async fn supervisor_transitions_to_restarting_after_quick_exit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+        );
+        let cfg = test_config("flaky", "exit 1");
+        orch.spawn_agent(&cfg).await.expect("spawn");
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let states = orch.list_state().await;
+        assert_eq!(states.len(), 1);
+        assert!(
+            matches!(
+                states[0].2,
+                AgentState::Restarting {
+                    attempt: 1,
+                    backoff_secs: 1
+                } | AgentState::Running { .. }
+            ),
+            "unexpected state: {:?}",
+            states[0].2
+        );
+
+        // Shutdown should cancel the backoff sleep cleanly.
+        orch.shutdown_all().await;
+        assert!(orch.list_state().await.is_empty());
+    }
 }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -57,6 +57,9 @@ pub struct AgentOrchestrator {
     /// Where per-agent log files are written. Must match the directory the
     /// monitor's `/api/logs/{agent}` endpoint reads from.
     log_dir: PathBuf,
+    /// All configured agents, used to look up an agent's config by name
+    /// when responding to `dispatch agent start/restart <name>` requests.
+    configs: Vec<ResolvedAgentConfig>,
 }
 
 impl AgentOrchestrator {
@@ -66,6 +69,7 @@ impl AgentOrchestrator {
         monitor_url: Option<String>,
         agent_cwd: &Path,
         log_dir: PathBuf,
+        configs: Vec<ResolvedAgentConfig>,
     ) -> Self {
         Self {
             agents: Vec::new(),
@@ -75,6 +79,7 @@ impl AgentOrchestrator {
             monitor_url,
             agent_cwd: agent_cwd.to_path_buf(),
             log_dir,
+            configs,
         }
     }
 
@@ -204,16 +209,58 @@ impl AgentOrchestrator {
         Ok(())
     }
 
-    /// Launch all configured agents sequentially with a brief pause between.
-    pub async fn launch_all(
-        &mut self,
-        configs: &[ResolvedAgentConfig],
-    ) -> Result<(), DispatchError> {
-        for config in configs {
+    /// Launch every agent marked `launch = true` in the stored configs,
+    /// sequentially with a brief pause between.
+    pub async fn launch_all(&mut self) -> Result<(), DispatchError> {
+        let launchable: Vec<ResolvedAgentConfig> =
+            self.configs.iter().filter(|a| a.launch).cloned().collect();
+        for config in &launchable {
             self.spawn_agent(config).await?;
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
         Ok(())
+    }
+
+    /// Start a configured agent by name. Errors if the name is unknown or
+    /// an instance is already running.
+    pub async fn start_by_name(&mut self, name: &str) -> Result<(), DispatchError> {
+        if self.agents.iter().any(|a| a.name == name) {
+            return Err(DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "already running".into(),
+            });
+        }
+        let config = self
+            .configs
+            .iter()
+            .find(|a| a.name == name)
+            .cloned()
+            .ok_or_else(|| DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "no such agent in config".into(),
+            })?;
+        self.spawn_agent(&config).await
+    }
+
+    /// Restart a running agent: stop it (if running) then spawn it again.
+    /// Errors if the agent name isn't in config.
+    pub async fn restart_by_name(&mut self, name: &str) -> Result<(), DispatchError> {
+        let config = self
+            .configs
+            .iter()
+            .find(|a| a.name == name)
+            .cloned()
+            .ok_or_else(|| DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "no such agent in config".into(),
+            })?;
+        let _ = self.stop_by_name(name).await;
+        self.spawn_agent(&config).await
+    }
+
+    /// Whether an agent with this name exists in the config (running or not).
+    pub fn has_config(&self, name: &str) -> bool {
+        self.configs.iter().any(|a| a.name == name)
     }
 
     /// Return info about all agents.
@@ -335,8 +382,9 @@ impl AgentOrchestrator {
         self.agents.clear();
     }
 
-    /// Stop a specific agent by name.
-    pub async fn stop_agent(&mut self, name: &str) -> bool {
+    /// Stop a running agent by name. Returns `true` if an agent was found and
+    /// stopped, `false` if no agent by that name is currently running.
+    pub async fn stop_by_name(&mut self, name: &str) -> bool {
         if let Some(idx) = self.agents.iter().position(|a| a.name == name) {
             let agent = &mut self.agents[idx];
             if agent.child.try_wait().ok().flatten().is_none() {

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -23,7 +23,16 @@ const MAX_RESTART_ATTEMPTS: u32 = 5;
 const STABLE_AFTER: Duration = Duration::from_secs(30);
 
 /// Kill an entire process group. Sends SIGTERM first, then SIGKILL after a timeout.
+///
+/// Refuses to signal `pid == 0`: `libc::kill(-0, …)` signals the *caller's*
+/// process group, which would tear down `dispatch serve` itself along with
+/// every sibling supervisor. A missing/zero PID means the child already
+/// exited or was never spawned, so there is nothing to kill.
 async fn kill_process_group(pid: u32) {
+    if pid == 0 {
+        tracing::warn!("kill_process_group called with pid=0; refusing to signal caller's pgid");
+        return;
+    }
     let pgid = pid as i32;
     // Send SIGTERM to the process group.
     unsafe {

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -7,7 +7,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
 
-use crate::adapter::{BuildContext, Launch};
+use crate::adapter::{shell_arg_quote, shell_escape, BuildContext, Launch};
 use crate::config::ResolvedAgentConfig;
 use crate::errors::DispatchError;
 
@@ -223,7 +223,13 @@ impl AgentOrchestrator {
 
     /// Start a configured agent by name. Errors if the name is unknown or
     /// an instance is already running.
+    ///
+    /// Before rejecting on `already running`, this reaps any ManagedAgent
+    /// whose supervisor task has already finished (Crashed or Stopped), so a
+    /// previously-failed agent can be started again without needing `restart`.
     pub async fn start_by_name(&mut self, name: &str) -> Result<(), DispatchError> {
+        self.agents.retain(|a| !a.supervisor.is_finished());
+
         if self.agents.iter().any(|a| a.name == name) {
             return Err(DispatchError::AgentLaunchFailed {
                 name: name.to_string(),
@@ -437,11 +443,13 @@ async fn spawn_child_process(
 
     let stdin = match &launch.stdin_file {
         Some(path) => {
-            let f = std::fs::File::open(path).map_err(|e| DispatchError::AgentLaunchFailed {
-                name: config.name.clone(),
-                reason: format!("failed to open prompt file {}: {e}", path.display()),
+            let f = tokio::fs::File::open(path).await.map_err(|e| {
+                DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: format!("failed to open prompt file {}: {e}", path.display()),
+                }
             })?;
-            std::process::Stdio::from(f)
+            std::process::Stdio::from(f.into_std().await)
         }
         None => std::process::Stdio::null(),
     };
@@ -621,20 +629,6 @@ fn launch_to_shell_string(launch: &Launch) -> String {
     s
 }
 
-/// Quote a shell argument only when necessary. Plain alphanumerics, dashes,
-/// dots, slashes, underscores, and equals signs pass through unquoted for
-/// paste-friendly output.
-fn shell_arg_quote(s: &str) -> String {
-    if !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || "-_/.=".contains(c))
-    {
-        s.to_string()
-    } else {
-        shell_escape(s)
-    }
-}
-
 /// Build the main agent command string for the user to paste.
 pub fn build_main_agent_command(
     main: &crate::config::MainAgentConfig,
@@ -663,11 +657,6 @@ pub fn build_main_agent_command(
 
     parts.push(cmd);
     parts.join(" ")
-}
-
-/// Shell-escape a string for use in `sh -c` commands. POSIX single-quote escaping.
-pub(super) fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Whether `s` is safe to use as a single filename component on disk and as

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -49,8 +49,9 @@ fn restart_backoff(attempt: u32) -> Duration {
 pub enum AgentState {
     /// Supervisor has been created but the first spawn hasn't landed yet.
     Starting,
-    /// A child process is alive.
-    Running { pid: u32 },
+    /// A child process is alive. `started_at` is a Unix-seconds timestamp of
+    /// the most recent spawn — the UI renders uptime as `now - started_at`.
+    Running { pid: u32, started_at: u64 },
     /// Process exited; supervisor is waiting before respawning.
     Restarting { attempt: u32, backoff_secs: u64 },
     /// Restart budget exhausted — supervisor has given up.
@@ -172,7 +173,10 @@ impl AgentOrchestrator {
             config.name, config.role, pid
         );
 
-        let state = Arc::new(Mutex::new(AgentState::Running { pid }));
+        let state = Arc::new(Mutex::new(AgentState::Running {
+            pid,
+            started_at: super::local::now_secs(),
+        }));
         let shutdown = Arc::new(Notify::new());
 
         let supervisor = tokio::spawn(supervise_agent(
@@ -548,7 +552,10 @@ async fn supervise_agent(
                         child = new_child;
                         started_at = Instant::now();
                         let new_pid = child.id().unwrap_or(0);
-                        *state.lock().await = AgentState::Running { pid: new_pid };
+                        *state.lock().await = AgentState::Running {
+                            pid: new_pid,
+                            started_at: super::local::now_secs(),
+                        };
                     }
                     Err(e) => {
                         tracing::warn!(agent = %config.name, error = %e, "respawn failed");

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -371,16 +371,33 @@ impl AgentOrchestrator {
         }
     }
 
-    /// Stop a running agent by name. Returns `true` if an agent was found and
-    /// stopped, `false` if no agent by that name is currently supervised.
+    /// Signal a running agent to shut down and return its supervisor's
+    /// `JoinHandle`. Does **not** await the handle — the caller is expected
+    /// to `.await` it after releasing the orchestrator mutex. This avoids
+    /// holding `Arc<Mutex<AgentOrchestrator>>` across the 500ms
+    /// SIGTERM→SIGKILL window inside `kill_process_group`, which would
+    /// otherwise block every concurrent read of `list_state` (e.g. the
+    /// dashboard's 2s `/api/agents/state` poll).
+    ///
+    /// Returns `None` if no agent by that name is currently supervised.
+    pub fn signal_stop_by_name(&mut self, name: &str) -> Option<JoinHandle<()>> {
+        let idx = self.agents.iter().position(|a| a.name == name)?;
+        let agent = self.agents.remove(idx);
+        agent.shutdown.notify_one();
+        Some(agent.supervisor)
+    }
+
+    /// Stop a running agent by name. Convenience wrapper around
+    /// `signal_stop_by_name` for test / non-HTTP callers that are fine
+    /// awaiting inside the critical section (e.g. the full `shutdown_all`
+    /// path). Returns `true` if an agent was found and stopped.
     pub async fn stop_by_name(&mut self, name: &str) -> bool {
-        if let Some(idx) = self.agents.iter().position(|a| a.name == name) {
-            let agent = self.agents.remove(idx);
-            agent.shutdown.notify_one();
-            let _ = agent.supervisor.await;
-            true
-        } else {
-            false
+        match self.signal_stop_by_name(name) {
+            Some(handle) => {
+                let _ = handle.await;
+                true
+            }
+            None => false,
         }
     }
 }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -16,7 +16,10 @@ use crate::errors::DispatchError;
 const MAX_RESTART_ATTEMPTS: u32 = 5;
 
 /// Duration an agent must stay running before its restart attempt counter
-/// resets. A process that crashes after this threshold gets a fresh budget.
+/// resets. A process that stayed up at least this long is treated as a
+/// fresh first-attempt restart when it next exits — the counter is set
+/// back to `1` (not `0`), so the agent gets the full `MAX_RESTART_ATTEMPTS`
+/// budget from that point forward.
 const STABLE_AFTER: Duration = Duration::from_secs(30);
 
 /// Kill an entire process group. Sends SIGTERM first, then SIGKILL after a timeout.

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -127,6 +127,8 @@ impl AgentOrchestrator {
             role = %config.role,
             adapter = %config.adapter,
             program = %launch.program,
+            args = ?launch.args,
+            cwd = %self.project_root.display(),
             "launching agent"
         );
 

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -280,6 +280,7 @@ impl AgentOrchestrator {
                         .unwrap_or_default()
                         .as_secs();
                     let _ = event_tx.send(super::local::BrokerEvent {
+                        id: uuid::Uuid::new_v4().to_string(),
                         kind: "heartbeat".into(),
                         worker_id: String::new(),
                         worker_name: None,

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use tokio::process::{Child, Command};
 
+use crate::adapter::{BuildContext, Launch};
 use crate::config::ResolvedAgentConfig;
 use crate::errors::DispatchError;
 
@@ -90,52 +91,42 @@ impl AgentOrchestrator {
         vars
     }
 
-    /// Build the full shell command for an agent.
+    /// Build the adapter's Launch spec for this agent.
     ///
-    /// If the command contains `{prompt}`, it is replaced with the shell-escaped
-    /// prompt text. If it contains `{prompt_file}`, it is replaced with the path
-    /// to a temporary file containing the prompt. Otherwise, for known LLM
-    /// commands (claude/codex), the prompt is appended as a positional argument.
-    pub(super) fn build_command(config: &ResolvedAgentConfig) -> String {
-        let base = &config.command;
-
-        if let Some(ref prompt) = config.prompt {
-            if base.contains("{prompt}") {
-                return base.replace("{prompt}", &shell_escape(prompt));
-            }
-            if base.contains("{prompt_file}") {
-                // Use the original file path if available, otherwise write to temp
-                let path = if let Some(ref p) = config.prompt_file_path {
-                    p.display().to_string()
-                } else {
-                    write_prompt_tempfile(prompt, &config.name)
-                };
-                return base.replace("{prompt_file}", &path);
-            }
-            // Fallback: append prompt as a positional argument for LLM commands
-            let is_llm = base.starts_with("claude") || base.starts_with("codex");
-            if is_llm {
-                format!("{base} {}", shell_escape(prompt))
-            } else {
-                base.clone()
-            }
-        } else {
-            base.clone()
-        }
+    /// The Launch describes the program, argv, shell-wrap hint, and optional
+    /// stdin source. Callers translate it into a concrete `Command` (for
+    /// spawning) or a shell-pasteable string (for display).
+    pub(super) fn build_launch(config: &ResolvedAgentConfig) -> Result<Launch, DispatchError> {
+        let ctx = BuildContext {
+            extra_args: &config.extra_args,
+            prompt_file: config.prompt_file_path.as_deref(),
+            prompt_inline: config.prompt.as_deref(),
+            command_string: config.command.as_deref(),
+        };
+        config
+            .adapter
+            .build(&ctx)
+            .map_err(|e| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: e.to_string(),
+            })
     }
 
     /// Spawn a single agent as a subprocess.
     ///
     /// Stdout and stderr are redirected to `logs/<agent-name>.log` relative to
     /// the project root so that agent output can be inspected after the fact.
+    /// Stdin comes from the adapter's `stdin_file` (typically the prompt file)
+    /// or is `/dev/null` if the adapter doesn't need one.
     pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
         let env_vars = self.env_vars(&config.name, &config.role);
-        let full_command = Self::build_command(config);
+        let launch = Self::build_launch(config)?;
 
         tracing::info!(
             agent = %config.name,
             role = %config.role,
-            command = %full_command,
+            adapter = %config.adapter,
+            program = %launch.program,
             "launching agent"
         );
 
@@ -145,26 +136,35 @@ impl AgentOrchestrator {
             reason: format!("failed to create log dir {}: {e}", self.log_dir.display()),
         })?;
         let log_path = self.log_dir.join(format!("{}.log", config.name));
-        let log_file = std::fs::File::create(&log_path).map_err(|e| {
-            DispatchError::AgentLaunchFailed {
+        let log_file =
+            std::fs::File::create(&log_path).map_err(|e| DispatchError::AgentLaunchFailed {
                 name: config.name.clone(),
                 reason: format!("failed to create log file {}: {e}", log_path.display()),
-            }
-        })?;
-        // Clone the file handle so stdout and stderr write to the same file.
-        let log_file_err = log_file.try_clone().map_err(|e| {
-            DispatchError::AgentLaunchFailed {
+            })?;
+        let log_file_err = log_file
+            .try_clone()
+            .map_err(|e| DispatchError::AgentLaunchFailed {
                 name: config.name.clone(),
                 reason: format!("failed to clone log file handle: {e}"),
-            }
-        })?;
+            })?;
 
-        let child = Command::new("sh")
-            .arg("-c")
-            .arg(&full_command)
+        let stdin = match &launch.stdin_file {
+            Some(path) => {
+                let f =
+                    std::fs::File::open(path).map_err(|e| DispatchError::AgentLaunchFailed {
+                        name: config.name.clone(),
+                        reason: format!("failed to open prompt file {}: {e}", path.display()),
+                    })?;
+                std::process::Stdio::from(f)
+            }
+            None => std::process::Stdio::null(),
+        };
+
+        let child = Command::new(&launch.program)
+            .args(&launch.args)
             .envs(&env_vars)
             .current_dir(&self.project_root)
-            .stdin(std::process::Stdio::null())
+            .stdin(stdin)
             .stdout(std::process::Stdio::from(log_file))
             .stderr(std::process::Stdio::from(log_file_err))
             .process_group(0) // Own process group so we can kill the whole tree.
@@ -177,7 +177,10 @@ impl AgentOrchestrator {
         let pid = child.id().unwrap_or(0);
         eprintln!(
             "dispatch serve: launched agent '{}' (role={}, pid={}, log={})",
-            config.name, config.role, pid, log_path.display()
+            config.name,
+            config.role,
+            pid,
+            log_path.display()
         );
 
         self.agents.push(RunningAgent {
@@ -340,7 +343,7 @@ impl AgentOrchestrator {
 
 /// Build an agent command string for the user to paste.
 ///
-/// Includes the dispatch env vars and the resolved command with prompt substitution.
+/// Includes the dispatch env vars and the adapter-assembled launch string.
 pub fn build_agent_command(
     config: &ResolvedAgentConfig,
     cell_id: &str,
@@ -356,8 +359,49 @@ pub fn build_agent_command(
         parts.push(format!("DISPATCH_MONITOR_URL={url}"));
     }
 
-    parts.push(AgentOrchestrator::build_command(config));
+    let cmd_str = AgentOrchestrator::build_launch(config)
+        .map(|launch| launch_to_shell_string(&launch))
+        .unwrap_or_else(|e| format!("# adapter error: {e}"));
+    parts.push(cmd_str);
     parts.join(" ")
+}
+
+/// Translate a Launch into a shell-pasteable command string.
+///
+/// For the `command` adapter, returns the user's original shell string
+/// verbatim (not wrapped in `sh -c '...'`). For claude/codex, quotes each
+/// argument as needed and appends `< <prompt_file>` if stdin is redirected.
+fn launch_to_shell_string(launch: &Launch) -> String {
+    if launch.wrap_in_shell {
+        return launch.args.get(1).cloned().unwrap_or_default();
+    }
+
+    let mut parts: Vec<String> = vec![shell_arg_quote(&launch.program)];
+    for arg in &launch.args {
+        parts.push(shell_arg_quote(arg));
+    }
+    let mut s = parts.join(" ");
+    if let Some(path) = &launch.stdin_file {
+        s.push_str(&format!(
+            " < {}",
+            shell_arg_quote(&path.display().to_string())
+        ));
+    }
+    s
+}
+
+/// Quote a shell argument only when necessary. Plain alphanumerics, dashes,
+/// dots, slashes, underscores, and equals signs pass through unquoted for
+/// paste-friendly output.
+fn shell_arg_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || "-_/.=".contains(c))
+    {
+        s.to_string()
+    } else {
+        shell_escape(s)
+    }
 }
 
 /// Build the main agent command string for the user to paste.
@@ -393,16 +437,4 @@ pub fn build_main_agent_command(
 /// Shell-escape a string for use in `sh -c` commands.
 fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
-}
-
-/// Write a prompt to a temporary file and return the path as a string.
-/// The file is placed in the OS temp directory and named by agent to aid debugging.
-fn write_prompt_tempfile(prompt: &str, agent_name: &str) -> String {
-    let path = std::env::temp_dir().join(format!("dispatch-prompt-{agent_name}.md"));
-    std::fs::write(&path, prompt).unwrap_or_else(|e| {
-        eprintln!(
-            "dispatch: warning: failed to write prompt tempfile for '{agent_name}': {e}"
-        );
-    });
-    path.display().to_string()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,10 +99,40 @@ pub enum Commands {
         timeout: u64,
     },
 
+    /// Query worker status
+    Status {
+        /// Show status for a specific worker
+        #[arg(long)]
+        worker_id: Option<String>,
+
+        /// Clear the worker's status (requires --worker-id)
+        #[arg(long)]
+        clear: bool,
+    },
+
+    /// Acknowledge receipt of a message
+    Ack {
+        /// Worker ID that received the message
+        #[arg(long)]
+        worker_id: String,
+
+        /// Message ID to acknowledge
+        #[arg(long)]
+        message_id: String,
+
+        /// Optional note (e.g. "starting implementation")
+        #[arg(long)]
+        note: Option<String>,
+    },
+
     /// Renew worker liveness TTL
     Heartbeat {
         /// Worker ID to heartbeat
         #[arg(long)]
         worker_id: String,
+
+        /// Set a status tagline (e.g. "Running e2e tests 3/10")
+        #[arg(long)]
+        status: Option<String>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,11 +109,11 @@ pub enum Commands {
         #[arg(long)]
         worker: Option<String>,
 
-        /// Show events since timestamp (RFC3339 or relative: 5m, 1h, 30s)
+        /// Show events since timestamp (Unix seconds, or relative: 30s, 5m, 1h, 2d)
         #[arg(long)]
         since: Option<String>,
 
-        /// Show events until timestamp (RFC3339 or relative)
+        /// Show events until timestamp (Unix seconds, or relative: 30s, 5m, 1h, 2d)
         #[arg(long)]
         until: Option<String>,
 
@@ -136,7 +136,7 @@ pub enum Commands {
         #[arg(long)]
         sent: bool,
 
-        /// Show messages since timestamp (RFC3339 or relative: 5m, 1h, 30s)
+        /// Show messages since timestamp (Unix seconds, or relative: 30s, 5m, 1h, 2d)
         #[arg(long)]
         since: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,56 @@ pub enum Commands {
         timeout: u64,
     },
 
+    /// Query event history
+    Events {
+        /// Filter by event type (register, send, deliver, ack, heartbeat, expire)
+        #[arg(long, name = "type")]
+        event_type: Option<String>,
+
+        /// Filter by worker ID
+        #[arg(long)]
+        worker: Option<String>,
+
+        /// Show events since timestamp (RFC3339 or relative: 5m, 1h, 30s)
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Show events until timestamp (RFC3339 or relative)
+        #[arg(long)]
+        until: Option<String>,
+
+        /// Maximum number of events to return (default: 100)
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+
+    /// Query message history (non-destructive)
+    Messages {
+        /// Worker ID to inspect messages for
+        #[arg(long)]
+        worker_id: String,
+
+        /// Show only delivered but unacked messages
+        #[arg(long)]
+        unacked: bool,
+
+        /// Show messages sent by this worker (instead of received)
+        #[arg(long)]
+        sent: bool,
+
+        /// Show messages since timestamp (RFC3339 or relative: 5m, 1h, 30s)
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Maximum number of messages to return
+        #[arg(long)]
+        limit: Option<usize>,
+
+        /// Look up a single message by ID
+        #[arg(long)]
+        id: Option<String>,
+    },
+
     /// Query worker status
     Status {
         /// Show status for a specific worker

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,4 +185,29 @@ pub enum Commands {
         #[arg(long)]
         status: Option<String>,
     },
+
+    /// Manage the lifecycle of configured agents (start, stop, restart)
+    Agent {
+        #[command(subcommand)]
+        action: AgentAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AgentAction {
+    /// Start a configured agent by name or worker ID
+    Start {
+        /// Agent name from config, or worker ID of a registered agent
+        name: String,
+    },
+    /// Stop a running agent by name or worker ID
+    Stop {
+        /// Agent name from config, or worker ID of a registered agent
+        name: String,
+    },
+    /// Restart a running agent by name or worker ID
+    Restart {
+        /// Agent name from config, or worker ID of a registered agent
+        name: String,
+    },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,6 +191,18 @@ pub enum Commands {
         #[command(subcommand)]
         action: AgentAction,
     },
+
+    /// Codex CLI hook integration (stop handler, install, uninstall)
+    CodexHook {
+        #[command(subcommand)]
+        action: HookAction,
+    },
+
+    /// Claude Code CLI hook integration (stop handler, install, uninstall)
+    ClaudeHook {
+        #[command(subcommand)]
+        action: HookAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -210,4 +222,15 @@ pub enum AgentAction {
         /// Agent name from config, or worker ID of a registered agent
         name: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum HookAction {
+    /// Handler invoked by the vendor CLI's Stop hook. Prints a JSON block
+    /// decision on stdout so the agent stays alive to wait for more messages.
+    Stop,
+    /// Register the dispatch stop hook in this project's vendor config files
+    Install,
+    /// Remove the dispatch stop hook from this project's vendor config files
+    Uninstall,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,7 +102,7 @@ pub enum Commands {
     /// Query event history
     Events {
         /// Filter by event type (register, send, deliver, ack, heartbeat, expire)
-        #[arg(long, name = "type")]
+        #[arg(long = "type", value_name = "type")]
         event_type: Option<String>,
 
         /// Filter by worker ID

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,22 @@ fn resolve_agent_config(
         });
     }
 
+    // Claude/codex adapters pipe prompts as stdin from `prompt_file`. An
+    // inline `prompt = "..."` would be silently dropped, launching the agent
+    // with empty stdin; reject it up front so the misconfiguration surfaces.
+    if matches!(agent.adapter, Adapter::Claude | Adapter::Codex)
+        && agent.prompt.is_some()
+        && agent.prompt_file.is_none()
+    {
+        return Err(DispatchError::AgentConfigError {
+            name: agent.name.clone(),
+            reason: format!(
+                "adapter = \"{}\" requires `prompt_file = \"...\"` (inline `prompt` is not supported on this adapter)",
+                agent.adapter
+            ),
+        });
+    }
+
     let (prompt, prompt_file_path) = match (&agent.prompt, &agent.prompt_file) {
         (Some(_), Some(_)) => {
             return Err(DispatchError::AgentConfigError {
@@ -602,6 +618,8 @@ backend = "https://example.com"
     #[test]
     fn agent_config_parses_claude_adapter() {
         let tmp = TempDir::new().unwrap();
+        let prompt_path = tmp.path().join("reviewer.md");
+        fs::write(&prompt_path, "you are a reviewer").unwrap();
         let config_path = tmp.path().join("dispatch.config.toml");
         fs::write(
             &config_path,
@@ -612,7 +630,7 @@ role = "reviewer"
 description = "reviews"
 adapter = "claude"
 extra_args = ["--model", "sonnet"]
-prompt = "you are a reviewer"
+prompt_file = "reviewer.md"
 launch = true
 "#,
         )
@@ -625,6 +643,53 @@ launch = true
         assert_eq!(a.extra_args, vec!["--model", "sonnet"]);
         assert!(a.launch);
         assert!(a.command.is_none());
+        assert!(a.prompt_file_path.is_some());
+    }
+
+    #[test]
+    fn agent_config_rejects_claude_adapter_with_inline_prompt() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "reviewer"
+role = "reviewer"
+description = "reviews"
+adapter = "claude"
+prompt = "you are a reviewer"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("prompt_file") && msg.contains("claude"),
+            "expected prompt_file-required error for claude, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn agent_config_rejects_codex_adapter_with_inline_prompt() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "worker"
+role = "worker"
+description = "codex"
+adapter = "codex"
+prompt = "be helpful"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("prompt_file"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,13 +40,19 @@ pub struct ResolvedAgentConfig {
     pub name: String,
     pub role: String,
     pub description: String,
-    pub command: String,
+    pub adapter: crate::adapter::Adapter,
+    /// Full shell command — set only for `adapter = Command`.
+    pub command: Option<String>,
+    /// Extra args appended to the adapter-assembled argv (claude/codex).
+    pub extra_args: Vec<String>,
     pub prompt: Option<String>,
     /// The resolved absolute path to the prompt file, if one was specified.
-    /// Used by `{prompt_file}` substitution to reference the file directly
-    /// instead of writing to a temp file.
+    /// Used by adapters as stdin source (claude/codex) or for `{prompt_file}`
+    /// substitution in command-adapter shell strings.
     pub prompt_file_path: Option<PathBuf>,
     pub ttl: Option<u64>,
+    /// Whether `dispatch serve` should auto-launch and supervise this agent.
+    pub launch: bool,
 }
 
 /// On-disk config file shape.
@@ -109,10 +115,19 @@ pub struct AgentConfig {
     pub name: String,
     pub role: String,
     pub description: String,
-    pub command: String,
+    /// Which adapter to use: `command`, `claude`, or `codex`.
+    pub adapter: crate::adapter::Adapter,
+    /// Full shell command — required when `adapter = "command"`, ignored otherwise.
+    pub command: Option<String>,
+    /// Extra args appended to the adapter-assembled argv (claude/codex).
+    #[serde(default)]
+    pub extra_args: Vec<String>,
     pub prompt: Option<String>,
     pub prompt_file: Option<String>,
     pub ttl: Option<u64>,
+    /// Whether `dispatch serve --launch` should auto-start this agent.
+    #[serde(default)]
+    pub launch: bool,
 }
 
 /// On-disk main agent definition.
@@ -125,11 +140,21 @@ pub struct MainAgentConfig {
     pub prompt_file: Option<String>,
 }
 
-/// Resolve an agent config by reading prompt_file if specified.
+/// Resolve an agent config by reading prompt_file if specified and validating
+/// adapter-specific requirements.
 fn resolve_agent_config(
     agent: &AgentConfig,
     project_root: &Path,
 ) -> Result<ResolvedAgentConfig, DispatchError> {
+    use crate::adapter::Adapter;
+
+    if agent.adapter == Adapter::Command && agent.command.is_none() {
+        return Err(DispatchError::AgentConfigError {
+            name: agent.name.clone(),
+            reason: "adapter = \"command\" requires `command = \"...\"`".into(),
+        });
+    }
+
     let (prompt, prompt_file_path) = match (&agent.prompt, &agent.prompt_file) {
         (Some(_), Some(_)) => {
             return Err(DispatchError::AgentConfigError {
@@ -146,7 +171,6 @@ fn resolve_agent_config(
                     path: full_path.clone(),
                 }
             })?;
-            // Canonicalize to absolute path so {prompt_file} works regardless of agent cwd
             let abs_path = full_path.canonicalize().unwrap_or(full_path);
             (Some(content), Some(abs_path))
         }
@@ -157,14 +181,15 @@ fn resolve_agent_config(
         name: agent.name.clone(),
         role: agent.role.clone(),
         description: agent.description.clone(),
+        adapter: agent.adapter,
         command: agent.command.clone(),
+        extra_args: agent.extra_args.clone(),
         prompt,
         prompt_file_path,
         ttl: agent.ttl,
+        launch: agent.launch,
     })
 }
-
-
 
 /// Find `dispatch.config.toml` in the current directory.
 /// Returns the path to the config file and the directory containing it.
@@ -220,14 +245,25 @@ const CONFIG_TEMPLATE: &str = "\
 # port = 8384
 # open = true  # open the dashboard in your default browser
 
-# Agent definitions — launched automatically by `dispatch serve`
+# Agent definitions — auto-started by `dispatch serve --launch` when launch = true
 # [[agents]]
 # name = \"reviewer\"
 # role = \"code-reviewer\"
 # description = \"Reviews code changes\"
-# command = \"claude --model sonnet\"
+# adapter = \"claude\"                            # one of: command | claude | codex
+# extra_args = [\"--model\", \"sonnet\"]          # appended to the adapter's argv
 # prompt_file = \"prompts/reviewer.md\"
+# launch = true
 # ttl = 3600
+#
+# # `command` adapter — for bash-script / non-LLM workers:
+# [[agents]]
+# name = \"bash-worker\"
+# role = \"worker\"
+# description = \"Scripted worker\"
+# adapter = \"command\"
+# command = \"scripts/worker.sh --verbose\"
+# launch = true
 
 # Main interactive agent — printed as a ready-to-paste command
 # [main_agent]
@@ -308,20 +344,28 @@ fn resolve_config_inner(
     };
 
     // Extract fields from config file
-    let (name, backend, default_ttl, config_cwd, monitor_config, raw_agents, main_agent_config, heartbeats) =
-        match config_file {
-            Some(c) => (
-                c.name,
-                c.backend,
-                c.default_ttl,
-                c.cwd,
-                c.monitor,
-                c.agents,
-                c.main_agent,
-                c.heartbeats,
-            ),
-            None => (None, None, None, None, None, vec![], None, vec![]),
-        };
+    let (
+        name,
+        backend,
+        default_ttl,
+        config_cwd,
+        monitor_config,
+        raw_agents,
+        main_agent_config,
+        heartbeats,
+    ) = match config_file {
+        Some(c) => (
+            c.name,
+            c.backend,
+            c.default_ttl,
+            c.cwd,
+            c.monitor,
+            c.agents,
+            c.main_agent,
+            c.heartbeats,
+        ),
+        None => (None, None, None, None, None, vec![], None, vec![]),
+    };
 
     // Resolve agent working directory: config cwd (relative to project_root) or project_root
     let agent_cwd = if let Some(ref cwd_path) = config_cwd {
@@ -553,5 +597,123 @@ backend = "https://example.com"
         let resolved = resolve_config_inner(None, None, Some(&config_path), tmp.path()).unwrap();
         assert_eq!(resolved.cell_id, "explicit");
         assert_eq!(resolved.project_root, config_dir);
+    }
+
+    #[test]
+    fn agent_config_parses_claude_adapter() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "reviewer"
+role = "reviewer"
+description = "reviews"
+adapter = "claude"
+extra_args = ["--model", "sonnet"]
+prompt = "you are a reviewer"
+launch = true
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        assert_eq!(resolved.agents.len(), 1);
+        let a = &resolved.agents[0];
+        assert_eq!(a.adapter, crate::adapter::Adapter::Claude);
+        assert_eq!(a.extra_args, vec!["--model", "sonnet"]);
+        assert!(a.launch);
+        assert!(a.command.is_none());
+    }
+
+    #[test]
+    fn agent_config_parses_command_adapter() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "worker"
+role = "worker"
+description = "bash worker"
+adapter = "command"
+command = "./worker.sh --verbose"
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        let a = &resolved.agents[0];
+        assert_eq!(a.adapter, crate::adapter::Adapter::Command);
+        assert_eq!(a.command.as_deref(), Some("./worker.sh --verbose"));
+        assert!(!a.launch);
+        assert!(a.extra_args.is_empty());
+    }
+
+    #[test]
+    fn agent_config_rejects_command_adapter_without_command() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "broken"
+role = "worker"
+description = "no command"
+adapter = "command"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("adapter = \"command\""),
+            "expected command-required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn agent_config_rejects_missing_adapter_field() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "legacy"
+role = "worker"
+description = "old shape"
+command = "./worker.sh"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("adapter"),
+            "expected adapter-related parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn agent_config_rejects_unknown_adapter_value() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "x"
+role = "r"
+description = "d"
+adapter = "gpt"
+"#,
+        )
+        .unwrap();
+
+        assert!(resolve_config_inner(None, None, None, tmp.path()).is_err());
     }
 }

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -42,8 +42,8 @@ pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
             path: path.clone(),
             reason: "expected a JSON object at the top level of settings.json".into(),
         })?;
-    let hooks = ensure_object(obj, "hooks");
-    let stop = ensure_array(hooks, "Stop");
+    let hooks = require_object(obj, "hooks", &path)?;
+    let stop = require_array(hooks, "Stop", &path, "hooks.Stop")?;
 
     // Skip if any existing matcher contains our command.
     let already = stop.iter().any(|entry| {
@@ -137,27 +137,37 @@ async fn tokio_file_exists(path: &Path) -> bool {
     tokio::fs::metadata(path).await.is_ok()
 }
 
-/// Ensure `map[key]` is a JSON object and return a mutable reference to it.
-/// Overwrites non-object values at `key` — callers should have validated the
-/// surrounding shape before invoking this.
-fn ensure_object<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<String, Value> {
-    let current = map.get(key);
-    if !matches!(current, Some(Value::Object(_))) {
-        map.insert(key.to_string(), Value::Object(Map::new()));
-    }
-    map.get_mut(key)
-        .and_then(Value::as_object_mut)
-        .expect("just inserted an object")
+/// Return a mutable reference to `map[key]` as a JSON object. Inserts an
+/// empty object when the key is absent; surfaces `ConfigInvalid` when the
+/// key is present but of the wrong type, so user-authored config isn't
+/// silently clobbered.
+fn require_object<'a>(
+    map: &'a mut Map<String, Value>,
+    key: &str,
+    path: &Path,
+) -> Result<&'a mut Map<String, Value>, DispatchError> {
+    map.entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: path.to_path_buf(),
+            reason: format!("expected `{key}` to be a JSON object in settings.json"),
+        })
 }
 
-fn ensure_array<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Vec<Value> {
-    let current = map.get(key);
-    if !matches!(current, Some(Value::Array(_))) {
-        map.insert(key.to_string(), Value::Array(Vec::new()));
-    }
-    map.get_mut(key)
-        .and_then(Value::as_array_mut)
-        .expect("just inserted an array")
+fn require_array<'a>(
+    map: &'a mut Map<String, Value>,
+    key: &str,
+    path: &Path,
+    json_pointer: &str,
+) -> Result<&'a mut Vec<Value>, DispatchError> {
+    map.entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: path.to_path_buf(),
+            reason: format!("expected `{json_pointer}` to be a JSON array in settings.json"),
+        })
 }
 
 #[cfg(test)]
@@ -253,6 +263,43 @@ mod tests {
         tokio::fs::write(dir.path().join(".claude/settings.json"), b"[]")
             .await
             .unwrap();
+        let err = install(dir.path()).await.unwrap_err();
+        assert!(matches!(err, DispatchError::ConfigInvalid { .. }));
+    }
+
+    /// If `hooks` exists but isn't a JSON object, don't clobber it — surface
+    /// `ConfigInvalid` so the user notices their settings file is malformed
+    /// (or holds a type they didn't intend).
+    #[tokio::test]
+    async fn install_rejects_non_object_hooks() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".claude"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            dir.path().join(".claude/settings.json"),
+            b"{\"hooks\": \"oops\"}",
+        )
+        .await
+        .unwrap();
+        let err = install(dir.path()).await.unwrap_err();
+        assert!(matches!(err, DispatchError::ConfigInvalid { .. }));
+    }
+
+    /// Same for `hooks.Stop`: a pre-existing non-array value must not be
+    /// silently replaced with our Stop entry.
+    #[tokio::test]
+    async fn install_rejects_non_array_stop() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".claude"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            dir.path().join(".claude/settings.json"),
+            b"{\"hooks\": {\"Stop\": {\"not\": \"an-array\"}}}",
+        )
+        .await
+        .unwrap();
         let err = install(dir.path()).await.unwrap_err();
         assert!(matches!(err, DispatchError::ConfigInvalid { .. }));
     }

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -1,0 +1,211 @@
+//! Claude Code CLI hook integration.
+//!
+//! Claude Code reads `<repo>/.claude/settings.json` (or `settings.local.json`)
+//! for hook registration. We install a Stop hook that runs
+//! `dispatch claude-hook stop`, which prints a block decision to keep the
+//! agent alive for the next dispatch message.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::errors::DispatchError;
+
+const HOOK_COMMAND: &str = "dispatch claude-hook stop";
+
+/// Prefer `settings.local.json` because Claude Code treats it as user-private
+/// (not committed). If the user has an existing `settings.json`, we still
+/// merge our Stop hook into that file.
+fn settings_path(cwd: &Path) -> PathBuf {
+    let shared = cwd.join(".claude").join("settings.json");
+    if shared.exists() {
+        shared
+    } else {
+        cwd.join(".claude").join("settings.local.json")
+    }
+}
+
+/// Install the Stop hook into `.claude/settings*.json`. Existing keys outside
+/// our hook entry are preserved. Idempotent: re-running does not duplicate
+/// the entry.
+pub fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
+    std::fs::create_dir_all(cwd.join(".claude")).map_err(DispatchError::Io)?;
+    let path = settings_path(cwd);
+
+    let mut root = load_json(&path)?;
+    let hooks = ensure_object(&mut root, "hooks");
+    let stop = ensure_array(hooks, "Stop");
+
+    // Skip if any existing matcher contains our command.
+    let already = stop.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .any(|h| h.get("command").and_then(Value::as_str) == Some(HOOK_COMMAND))
+            })
+            .unwrap_or(false)
+    });
+
+    if !already {
+        stop.push(serde_json::json!({
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": HOOK_COMMAND,
+            }],
+        }));
+    }
+
+    std::fs::write(&path, serde_json::to_string_pretty(&root).unwrap() + "\n")
+        .map_err(DispatchError::Io)?;
+    Ok(path)
+}
+
+/// Remove our Stop hook entry. Leaves other hooks, matchers, and settings
+/// untouched. Returns `Ok(None)` if no entry was found.
+pub fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
+    let path = settings_path(cwd);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut root = load_json(&path)?;
+    let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return Ok(None);
+    };
+    let Some(stop) = hooks.get_mut("Stop").and_then(Value::as_array_mut) else {
+        return Ok(None);
+    };
+
+    let before = stop.len();
+    stop.retain(|entry| {
+        let has_ours = entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .any(|h| h.get("command").and_then(Value::as_str) == Some(HOOK_COMMAND))
+            })
+            .unwrap_or(false);
+        !has_ours
+    });
+    let removed_any = stop.len() != before;
+
+    // Clean up empty keys so we don't leave dangling "hooks": {} behind.
+    if stop.is_empty() {
+        hooks.remove("Stop");
+    }
+    if hooks.is_empty() {
+        root.as_object_mut().unwrap().remove("hooks");
+    }
+
+    if !removed_any {
+        return Ok(None);
+    }
+
+    if root.as_object().map(|obj| obj.is_empty()).unwrap_or(false) {
+        std::fs::remove_file(&path).map_err(DispatchError::Io)?;
+    } else {
+        std::fs::write(&path, serde_json::to_string_pretty(&root).unwrap() + "\n")
+            .map_err(DispatchError::Io)?;
+    }
+    Ok(Some(path))
+}
+
+fn load_json(path: &Path) -> Result<Value, DispatchError> {
+    if !path.exists() {
+        return Ok(Value::Object(Map::new()));
+    }
+    let text = std::fs::read_to_string(path).map_err(DispatchError::Io)?;
+    if text.trim().is_empty() {
+        return Ok(Value::Object(Map::new()));
+    }
+    serde_json::from_str(&text).map_err(DispatchError::Serialization)
+}
+
+fn ensure_object<'a>(root: &'a mut Value, key: &str) -> &'a mut Map<String, Value> {
+    let obj = root.as_object_mut().expect("root must be a JSON object");
+    obj.entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    obj.get_mut(key).unwrap().as_object_mut().unwrap()
+}
+
+fn ensure_array<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Vec<Value> {
+    map.entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    map.get_mut(key).unwrap().as_array_mut().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn install_creates_settings_local() {
+        let dir = tempdir().unwrap();
+        let path = install(dir.path()).unwrap();
+        assert!(path.ends_with(".claude/settings.local.json"));
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("claude-hook"));
+        assert!(content.contains("\"Stop\""));
+    }
+
+    #[test]
+    fn install_merges_into_existing_settings() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        let original =
+            "{\n  \"model\": \"sonnet\",\n  \"permissions\": {\"defaultMode\": \"bypass\"}\n}\n";
+        std::fs::write(dir.path().join(".claude/settings.json"), original).unwrap();
+        let path = install(dir.path()).unwrap();
+        assert!(path.ends_with(".claude/settings.json"));
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(value["model"], "sonnet");
+        assert_eq!(value["permissions"]["defaultMode"], "bypass");
+        assert!(value["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).unwrap();
+        install(dir.path()).unwrap();
+        let path = dir.path().join(".claude/settings.local.json");
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(value["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn uninstall_leaves_other_settings() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/settings.json"),
+            "{\n  \"model\": \"sonnet\"\n}\n",
+        )
+        .unwrap();
+        install(dir.path()).unwrap();
+        uninstall(dir.path()).unwrap();
+        let path = dir.path().join(".claude/settings.json");
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(value["model"], "sonnet");
+        assert!(value.get("hooks").is_none());
+    }
+
+    #[test]
+    fn uninstall_removes_empty_file() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).unwrap();
+        uninstall(dir.path()).unwrap();
+        assert!(!dir.path().join(".claude/settings.local.json").exists());
+    }
+
+    #[test]
+    fn uninstall_noop_when_absent() {
+        let dir = tempdir().unwrap();
+        let result = uninstall(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -28,12 +28,21 @@ fn settings_path(cwd: &Path) -> PathBuf {
 /// Install the Stop hook into `.claude/settings*.json`. Existing keys outside
 /// our hook entry are preserved. Idempotent: re-running does not duplicate
 /// the entry.
-pub fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
-    std::fs::create_dir_all(cwd.join(".claude")).map_err(DispatchError::Io)?;
+///
+/// Refuses to modify a settings file whose top-level JSON isn't an object —
+/// the caller gets a `ConfigInvalid` error instead of a panic.
+pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
+    tokio::fs::create_dir_all(cwd.join(".claude")).await?;
     let path = settings_path(cwd);
 
-    let mut root = load_json(&path)?;
-    let hooks = ensure_object(&mut root, "hooks");
+    let mut root = load_json(&path).await?;
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: path.clone(),
+            reason: "expected a JSON object at the top level of settings.json".into(),
+        })?;
+    let hooks = ensure_object(obj, "hooks");
     let stop = ensure_array(hooks, "Stop");
 
     // Skip if any existing matcher contains our command.
@@ -58,20 +67,22 @@ pub fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
         }));
     }
 
-    std::fs::write(&path, serde_json::to_string_pretty(&root).unwrap() + "\n")
-        .map_err(DispatchError::Io)?;
+    tokio::fs::write(&path, serde_json::to_string_pretty(&root)? + "\n").await?;
     Ok(path)
 }
 
 /// Remove our Stop hook entry. Leaves other hooks, matchers, and settings
 /// untouched. Returns `Ok(None)` if no entry was found.
-pub fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
+pub async fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     let path = settings_path(cwd);
-    if !path.exists() {
+    if !tokio_file_exists(&path).await {
         return Ok(None);
     }
-    let mut root = load_json(&path)?;
-    let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
+    let mut root = load_json(&path).await?;
+    let Some(root_obj) = root.as_object_mut() else {
+        return Ok(None);
+    };
+    let Some(hooks) = root_obj.get_mut("hooks").and_then(Value::as_object_mut) else {
         return Ok(None);
     };
     let Some(stop) = hooks.get_mut("Stop").and_then(Value::as_array_mut) else {
@@ -96,45 +107,57 @@ pub fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     if stop.is_empty() {
         hooks.remove("Stop");
     }
-    if hooks.is_empty() {
-        root.as_object_mut().unwrap().remove("hooks");
+    let hooks_empty = hooks.is_empty();
+    if hooks_empty {
+        root_obj.remove("hooks");
     }
 
     if !removed_any {
         return Ok(None);
     }
 
-    if root.as_object().map(|obj| obj.is_empty()).unwrap_or(false) {
-        std::fs::remove_file(&path).map_err(DispatchError::Io)?;
+    if root_obj.is_empty() {
+        tokio::fs::remove_file(&path).await?;
     } else {
-        std::fs::write(&path, serde_json::to_string_pretty(&root).unwrap() + "\n")
-            .map_err(DispatchError::Io)?;
+        tokio::fs::write(&path, serde_json::to_string_pretty(&root)? + "\n").await?;
     }
     Ok(Some(path))
 }
 
-fn load_json(path: &Path) -> Result<Value, DispatchError> {
-    if !path.exists() {
-        return Ok(Value::Object(Map::new()));
+async fn load_json(path: &Path) -> Result<Value, DispatchError> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(s) if s.trim().is_empty() => Ok(Value::Object(Map::new())),
+        Ok(s) => serde_json::from_str(&s).map_err(DispatchError::Serialization),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Value::Object(Map::new())),
+        Err(e) => Err(DispatchError::Io(e)),
     }
-    let text = std::fs::read_to_string(path).map_err(DispatchError::Io)?;
-    if text.trim().is_empty() {
-        return Ok(Value::Object(Map::new()));
-    }
-    serde_json::from_str(&text).map_err(DispatchError::Serialization)
 }
 
-fn ensure_object<'a>(root: &'a mut Value, key: &str) -> &'a mut Map<String, Value> {
-    let obj = root.as_object_mut().expect("root must be a JSON object");
-    obj.entry(key.to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    obj.get_mut(key).unwrap().as_object_mut().unwrap()
+async fn tokio_file_exists(path: &Path) -> bool {
+    tokio::fs::metadata(path).await.is_ok()
+}
+
+/// Ensure `map[key]` is a JSON object and return a mutable reference to it.
+/// Overwrites non-object values at `key` — callers should have validated the
+/// surrounding shape before invoking this.
+fn ensure_object<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<String, Value> {
+    let current = map.get(key);
+    if !matches!(current, Some(Value::Object(_))) {
+        map.insert(key.to_string(), Value::Object(Map::new()));
+    }
+    map.get_mut(key)
+        .and_then(Value::as_object_mut)
+        .expect("just inserted an object")
 }
 
 fn ensure_array<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Vec<Value> {
-    map.entry(key.to_string())
-        .or_insert_with(|| Value::Array(Vec::new()));
-    map.get_mut(key).unwrap().as_array_mut().unwrap()
+    let current = map.get(key);
+    if !matches!(current, Some(Value::Array(_))) {
+        map.insert(key.to_string(), Value::Array(Vec::new()));
+    }
+    map.get_mut(key)
+        .and_then(Value::as_array_mut)
+        .expect("just inserted an array")
 }
 
 #[cfg(test)]
@@ -142,70 +165,95 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    #[test]
-    fn install_creates_settings_local() {
+    #[tokio::test]
+    async fn install_creates_settings_local() {
         let dir = tempdir().unwrap();
-        let path = install(dir.path()).unwrap();
+        let path = install(dir.path()).await.unwrap();
         assert!(path.ends_with(".claude/settings.local.json"));
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(content.contains("claude-hook"));
         assert!(content.contains("\"Stop\""));
     }
 
-    #[test]
-    fn install_merges_into_existing_settings() {
+    #[tokio::test]
+    async fn install_merges_into_existing_settings() {
         let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".claude"))
+            .await
+            .unwrap();
         let original =
             "{\n  \"model\": \"sonnet\",\n  \"permissions\": {\"defaultMode\": \"bypass\"}\n}\n";
-        std::fs::write(dir.path().join(".claude/settings.json"), original).unwrap();
-        let path = install(dir.path()).unwrap();
+        tokio::fs::write(dir.path().join(".claude/settings.json"), original)
+            .await
+            .unwrap();
+        let path = install(dir.path()).await.unwrap();
         assert!(path.ends_with(".claude/settings.json"));
-        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let value: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(value["model"], "sonnet");
         assert_eq!(value["permissions"]["defaultMode"], "bypass");
         assert!(value["hooks"]["Stop"].is_array());
     }
 
-    #[test]
-    fn install_is_idempotent() {
+    #[tokio::test]
+    async fn install_is_idempotent() {
         let dir = tempdir().unwrap();
-        install(dir.path()).unwrap();
-        install(dir.path()).unwrap();
+        install(dir.path()).await.unwrap();
+        install(dir.path()).await.unwrap();
         let path = dir.path().join(".claude/settings.local.json");
-        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let value: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(value["hooks"]["Stop"].as_array().unwrap().len(), 1);
     }
 
-    #[test]
-    fn uninstall_leaves_other_settings() {
+    #[tokio::test]
+    async fn uninstall_leaves_other_settings() {
         let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
-        std::fs::write(
+        tokio::fs::create_dir_all(dir.path().join(".claude"))
+            .await
+            .unwrap();
+        tokio::fs::write(
             dir.path().join(".claude/settings.json"),
             "{\n  \"model\": \"sonnet\"\n}\n",
         )
+        .await
         .unwrap();
-        install(dir.path()).unwrap();
-        uninstall(dir.path()).unwrap();
+        install(dir.path()).await.unwrap();
+        uninstall(dir.path()).await.unwrap();
         let path = dir.path().join(".claude/settings.json");
-        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let value: Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(value["model"], "sonnet");
         assert!(value.get("hooks").is_none());
     }
 
-    #[test]
-    fn uninstall_removes_empty_file() {
+    #[tokio::test]
+    async fn uninstall_removes_empty_file() {
         let dir = tempdir().unwrap();
-        install(dir.path()).unwrap();
-        uninstall(dir.path()).unwrap();
+        install(dir.path()).await.unwrap();
+        uninstall(dir.path()).await.unwrap();
         assert!(!dir.path().join(".claude/settings.local.json").exists());
     }
 
-    #[test]
-    fn uninstall_noop_when_absent() {
+    #[tokio::test]
+    async fn uninstall_noop_when_absent() {
         let dir = tempdir().unwrap();
-        let result = uninstall(dir.path()).unwrap();
+        let result = uninstall(dir.path()).await.unwrap();
         assert!(result.is_none());
+    }
+
+    /// A settings.json whose root is a JSON array (not an object) must
+    /// surface as `ConfigInvalid` rather than panicking via unwrap.
+    #[tokio::test]
+    async fn install_rejects_non_object_root() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".claude"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join(".claude/settings.json"), b"[]")
+            .await
+            .unwrap();
+        let err = install(dir.path()).await.unwrap_err();
+        assert!(matches!(err, DispatchError::ConfigInvalid { .. }));
     }
 }

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -186,13 +186,22 @@ fn ensure_codex_hooks_feature(existing: &str) -> String {
             if trimmed == "[features]" {
                 in_features = true;
             }
-        } else if in_features && trimmed.starts_with("codex_hooks") {
-            // Accept `codex_hooks = <value>` with any spacing. Value is the
-            // substring after `=`, stripped and with trailing comment removed.
-            if let Some((_, rhs)) = trimmed.split_once('=') {
-                let value = rhs.split('#').next().unwrap_or("").trim();
-                let is_true = value == "true";
-                existing_key = Some((offset, offset + segment.len(), is_true));
+        } else if in_features {
+            // Match the exact `codex_hooks` key: next char must be `=` or
+            // whitespace so lookalikes such as `codex_hooks_extra = ...` are
+            // left untouched.
+            if let Some(rest) = trimmed.strip_prefix("codex_hooks") {
+                let boundary_ok = rest
+                    .chars()
+                    .next()
+                    .is_none_or(|c| c == '=' || c.is_whitespace());
+                if boundary_ok {
+                    if let Some((_, rhs)) = trimmed.split_once('=') {
+                        let value = rhs.split('#').next().unwrap_or("").trim();
+                        let is_true = value == "true";
+                        existing_key = Some((offset, offset + segment.len(), is_true));
+                    }
+                }
             }
         }
         offset += segment.len();
@@ -467,6 +476,27 @@ mod tests {
         let out = ensure_codex_hooks_feature(input);
         assert!(out.contains("codex_hooks = true\r\n"));
         assert!(!out.contains("codex_hooks = false"));
+    }
+
+    /// A similarly-prefixed key such as `codex_hooks_extra = "foo"` inside
+    /// `[features]` must NOT be rewritten as the feature flag — the match
+    /// is only for the exact `codex_hooks` key.
+    #[test]
+    fn does_not_rewrite_similar_prefixed_key() {
+        let input = "[features]\ncodex_hooks_extra = \"foo\"\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert!(out.contains("codex_hooks_extra = \"foo\""));
+        assert!(out.contains("codex_hooks = true"));
+        // Remains valid TOML with both keys intact.
+        let parsed: toml::Value = toml::from_str(&out).expect("merge must yield valid TOML");
+        assert_eq!(
+            parsed["features"]["codex_hooks"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(
+            parsed["features"]["codex_hooks_extra"],
+            toml::Value::String("foo".to_string())
+        );
     }
 
     /// Rejects a hooks.json whose top-level JSON is not an object (array,

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -1,0 +1,192 @@
+//! Codex CLI hook integration.
+//!
+//! Codex reads `<repo>/.codex/hooks.json` when `features.codex_hooks = true`
+//! is set in `<repo>/.codex/config.toml`. The Stop hook we register runs
+//! `dispatch codex-hook stop` which prints a block decision — keeping the
+//! agent alive for the next dispatch message.
+
+use std::path::{Path, PathBuf};
+
+use crate::errors::DispatchError;
+
+const HOOK_COMMAND: [&str; 3] = ["dispatch", "codex-hook", "stop"];
+
+/// Location of the hooks manifest relative to the project root.
+fn hooks_path(cwd: &Path) -> PathBuf {
+    cwd.join(".codex").join("hooks.json")
+}
+
+/// Location of the codex config file where the hooks feature flag lives.
+fn config_path(cwd: &Path) -> PathBuf {
+    cwd.join(".codex").join("config.toml")
+}
+
+/// Write `.codex/hooks.json` and enable `features.codex_hooks = true` in
+/// `.codex/config.toml`. Creates `.codex/` if it doesn't exist. Existing
+/// config.toml content is preserved; we only insert/update the feature flag.
+pub fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
+    let codex_dir = cwd.join(".codex");
+    std::fs::create_dir_all(&codex_dir).map_err(DispatchError::Io)?;
+
+    let hooks = serde_json::json!({
+        "Stop": [
+            { "command": HOOK_COMMAND }
+        ],
+    });
+    let hooks_path = hooks_path(cwd);
+    std::fs::write(
+        &hooks_path,
+        serde_json::to_string_pretty(&hooks).unwrap() + "\n",
+    )
+    .map_err(DispatchError::Io)?;
+
+    let config_path = config_path(cwd);
+    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    let updated = ensure_codex_hooks_feature(&existing);
+    if updated != existing {
+        std::fs::write(&config_path, updated).map_err(DispatchError::Io)?;
+    }
+
+    Ok(hooks_path)
+}
+
+/// Remove `.codex/hooks.json` if it exists. Leaves `config.toml` alone so the
+/// user can keep the feature flag enabled for their own hooks. Returns
+/// `Ok(None)` if nothing was there to remove.
+pub fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
+    let path = hooks_path(cwd);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(DispatchError::Io)?;
+        Ok(Some(path))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Append `[features] codex_hooks = true` to `config.toml` if the flag isn't
+/// already present. Uses a simple string merge rather than round-tripping the
+/// TOML AST — so comments, ordering, and formatting of unrelated config are
+/// preserved.
+fn ensure_codex_hooks_feature(existing: &str) -> String {
+    if existing
+        .lines()
+        .any(|l| l.trim_start().starts_with("codex_hooks") && l.contains("true"))
+    {
+        return existing.to_string();
+    }
+
+    // Walk sections to see if `[features]` already exists.
+    let mut in_features = false;
+    let mut features_end: Option<usize> = None; // byte offset
+    let mut offset = 0usize;
+    for line in existing.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if in_features {
+                features_end = Some(offset);
+                break;
+            }
+            if trimmed == "[features]" {
+                in_features = true;
+            }
+        }
+        offset += line.len() + 1; // +1 for the \n we'll re-add
+    }
+    if in_features && features_end.is_none() {
+        features_end = Some(existing.len());
+    }
+
+    match (in_features, features_end) {
+        (true, Some(end)) => {
+            let mut out = String::with_capacity(existing.len() + 24);
+            out.push_str(&existing[..end]);
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str("codex_hooks = true\n");
+            out.push_str(&existing[end..]);
+            out
+        }
+        _ => {
+            let mut out = existing.to_string();
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str("[features]\ncodex_hooks = true\n");
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn install_creates_both_files() {
+        let dir = tempdir().unwrap();
+        let hooks_path = install(dir.path()).unwrap();
+        assert!(hooks_path.ends_with(".codex/hooks.json"));
+        let content = std::fs::read_to_string(&hooks_path).unwrap();
+        assert!(content.contains("codex-hook"));
+        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        assert!(cfg.contains("[features]"));
+        assert!(cfg.contains("codex_hooks = true"));
+    }
+
+    #[test]
+    fn install_preserves_existing_config() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".codex")).unwrap();
+        let original = "# user comment\n[profile]\nmodel = \"gpt-5\"\n";
+        std::fs::write(dir.path().join(".codex/config.toml"), original).unwrap();
+        install(dir.path()).unwrap();
+        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        assert!(cfg.contains("# user comment"));
+        assert!(cfg.contains("[profile]"));
+        assert!(cfg.contains("codex_hooks = true"));
+    }
+
+    #[test]
+    fn install_is_idempotent_on_feature_flag() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".codex")).unwrap();
+        let original = "[features]\ncodex_hooks = true\n";
+        std::fs::write(dir.path().join(".codex/config.toml"), original).unwrap();
+        install(dir.path()).unwrap();
+        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        // Should contain only one occurrence, not duplicated.
+        assert_eq!(cfg.matches("codex_hooks").count(), 1);
+    }
+
+    #[test]
+    fn uninstall_removes_hooks_file_only() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).unwrap();
+        let removed = uninstall(dir.path()).unwrap();
+        assert!(removed.is_some());
+        assert!(!dir.path().join(".codex/hooks.json").exists());
+        // config.toml kept intentionally.
+        assert!(dir.path().join(".codex/config.toml").exists());
+    }
+
+    #[test]
+    fn uninstall_noop_when_nothing_to_remove() {
+        let dir = tempdir().unwrap();
+        let removed = uninstall(dir.path()).unwrap();
+        assert!(removed.is_none());
+    }
+
+    #[test]
+    fn inserts_flag_into_existing_features_section() {
+        let input = "[features]\nother = true\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert!(out.contains("[features]"));
+        assert!(out.contains("other = true"));
+        assert!(out.contains("codex_hooks = true"));
+    }
+}

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -7,6 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
+use serde_json::{Map, Value};
+
 use crate::errors::DispatchError;
 
 const HOOK_COMMAND: [&str; 3] = ["dispatch", "codex-hook", "stop"];
@@ -21,52 +23,141 @@ fn config_path(cwd: &Path) -> PathBuf {
     cwd.join(".codex").join("config.toml")
 }
 
-/// Write `.codex/hooks.json` and enable `features.codex_hooks = true` in
-/// `.codex/config.toml`. Creates `.codex/` if it doesn't exist. Existing
-/// config.toml content is preserved; we only insert/update the feature flag.
-pub fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
+/// Merge the dispatch Stop hook into `.codex/hooks.json` (preserving any
+/// other Stop entries and any other top-level hook categories the user has
+/// registered) and enable `features.codex_hooks = true` in
+/// `.codex/config.toml`. Creates `.codex/` if it doesn't exist.
+///
+/// Idempotent: re-running does not duplicate our Stop entry and does not
+/// duplicate the `codex_hooks = true` line.
+pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
     let codex_dir = cwd.join(".codex");
-    std::fs::create_dir_all(&codex_dir).map_err(DispatchError::Io)?;
+    tokio::fs::create_dir_all(&codex_dir).await?;
 
-    let hooks = serde_json::json!({
-        "Stop": [
-            { "command": HOOK_COMMAND }
-        ],
-    });
     let hooks_path = hooks_path(cwd);
-    std::fs::write(
-        &hooks_path,
-        serde_json::to_string_pretty(&hooks).unwrap() + "\n",
-    )
-    .map_err(DispatchError::Io)?;
+    let mut root = load_json(&hooks_path).await?;
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: hooks_path.clone(),
+            reason: "expected a JSON object at the top level".into(),
+        })?;
+
+    let stop = obj
+        .entry("Stop".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let stop_arr = stop
+        .as_array_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: hooks_path.clone(),
+            reason: "expected \"Stop\" to be an array".into(),
+        })?;
+
+    if !stop_arr.iter().any(entry_is_dispatch_hook) {
+        stop_arr.push(serde_json::json!({ "command": HOOK_COMMAND }));
+    }
+
+    tokio::fs::write(&hooks_path, serde_json::to_string_pretty(&root)? + "\n").await?;
 
     let config_path = config_path(cwd);
-    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    let existing = match tokio::fs::read_to_string(&config_path).await {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(DispatchError::Io(e)),
+    };
     let updated = ensure_codex_hooks_feature(&existing);
     if updated != existing {
-        std::fs::write(&config_path, updated).map_err(DispatchError::Io)?;
+        tokio::fs::write(&config_path, updated).await?;
     }
 
     Ok(hooks_path)
 }
 
-/// Remove `.codex/hooks.json` if it exists. Leaves `config.toml` alone so the
-/// user can keep the feature flag enabled for their own hooks. Returns
-/// `Ok(None)` if nothing was there to remove.
-pub fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
+/// Remove the dispatch Stop entry from `.codex/hooks.json`. If that leaves
+/// the Stop array empty, drop the key; if the file is empty afterwards,
+/// delete it. Leaves `config.toml` alone so the user can keep the feature
+/// flag enabled for their own hooks. Returns `Ok(None)` when nothing
+/// dispatch-owned was present.
+pub async fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     let path = hooks_path(cwd);
-    if path.exists() {
-        std::fs::remove_file(&path).map_err(DispatchError::Io)?;
-        Ok(Some(path))
+    if !tokio_file_exists(&path).await {
+        return Ok(None);
+    }
+
+    let mut root = load_json(&path).await?;
+    let Some(obj) = root.as_object_mut() else {
+        return Ok(None);
+    };
+    let Some(stop) = obj.get_mut("Stop").and_then(Value::as_array_mut) else {
+        return Ok(None);
+    };
+
+    let before = stop.len();
+    stop.retain(|entry| !entry_is_dispatch_hook(entry));
+    let removed = stop.len() != before;
+
+    if stop.is_empty() {
+        obj.remove("Stop");
+    }
+
+    if !removed {
+        return Ok(None);
+    }
+
+    if obj.is_empty() {
+        tokio::fs::remove_file(&path).await?;
     } else {
-        Ok(None)
+        tokio::fs::write(&path, serde_json::to_string_pretty(&root)? + "\n").await?;
+    }
+    Ok(Some(path))
+}
+
+/// Whether a hook entry is the one dispatch owns. Tolerates alternate
+/// representations: `command` as an array (the shape we write) or as the
+/// single-string form some examples in codex docs use.
+fn entry_is_dispatch_hook(entry: &Value) -> bool {
+    let Some(cmd) = entry.get("command") else {
+        return false;
+    };
+    if let Some(arr) = cmd.as_array() {
+        if arr.len() != HOOK_COMMAND.len() {
+            return false;
+        }
+        return arr
+            .iter()
+            .zip(HOOK_COMMAND.iter())
+            .all(|(a, b)| a.as_str() == Some(*b));
+    }
+    if let Some(s) = cmd.as_str() {
+        return s == HOOK_COMMAND.join(" ");
+    }
+    false
+}
+
+/// Read `path` into a JSON value. Missing files and empty files both parse
+/// as an empty object so callers can treat the "no existing config" path
+/// symmetrically with "existing config".
+async fn load_json(path: &Path) -> Result<Value, DispatchError> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(s) if s.trim().is_empty() => Ok(Value::Object(Map::new())),
+        Ok(s) => serde_json::from_str(&s).map_err(DispatchError::Serialization),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Value::Object(Map::new())),
+        Err(e) => Err(DispatchError::Io(e)),
     }
 }
 
+/// Non-throwing existence check — avoids a TOCTOU race with the caller's
+/// subsequent read, which handles `NotFound` itself.
+async fn tokio_file_exists(path: &Path) -> bool {
+    tokio::fs::metadata(path).await.is_ok()
+}
+
 /// Append `[features] codex_hooks = true` to `config.toml` if the flag isn't
-/// already present. Uses a simple string merge rather than round-tripping the
-/// TOML AST — so comments, ordering, and formatting of unrelated config are
-/// preserved.
+/// already present. Uses a simple string merge rather than round-tripping
+/// the TOML AST — so comments, ordering, and formatting of unrelated config
+/// are preserved. Line-ending agnostic: walks `split_inclusive('\n')` so
+/// CRLF-terminated files aren't split mid-pair when we compute the
+/// insertion offset.
 fn ensure_codex_hooks_feature(existing: &str) -> String {
     if existing
         .lines()
@@ -75,12 +166,13 @@ fn ensure_codex_hooks_feature(existing: &str) -> String {
         return existing.to_string();
     }
 
-    // Walk sections to see if `[features]` already exists.
+    // Walk sections, preserving the original line terminators so byte
+    // offsets stay correct on both LF and CRLF files.
     let mut in_features = false;
-    let mut features_end: Option<usize> = None; // byte offset
+    let mut features_end: Option<usize> = None;
     let mut offset = 0usize;
-    for line in existing.lines() {
-        let trimmed = line.trim();
+    for segment in existing.split_inclusive('\n') {
+        let trimmed = segment.trim_end_matches(['\r', '\n']).trim();
         if trimmed.starts_with('[') && trimmed.ends_with(']') {
             if in_features {
                 features_end = Some(offset);
@@ -90,7 +182,7 @@ fn ensure_codex_hooks_feature(existing: &str) -> String {
                 in_features = true;
             }
         }
-        offset += line.len() + 1; // +1 for the \n we'll re-add
+        offset += segment.len();
     }
     if in_features && features_end.is_none() {
         features_end = Some(existing.len());
@@ -126,58 +218,149 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    #[test]
-    fn install_creates_both_files() {
+    #[tokio::test]
+    async fn install_creates_both_files() {
         let dir = tempdir().unwrap();
-        let hooks_path = install(dir.path()).unwrap();
+        let hooks_path = install(dir.path()).await.unwrap();
         assert!(hooks_path.ends_with(".codex/hooks.json"));
-        let content = std::fs::read_to_string(&hooks_path).unwrap();
+        let content = tokio::fs::read_to_string(&hooks_path).await.unwrap();
         assert!(content.contains("codex-hook"));
-        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        let cfg = tokio::fs::read_to_string(dir.path().join(".codex/config.toml"))
+            .await
+            .unwrap();
         assert!(cfg.contains("[features]"));
         assert!(cfg.contains("codex_hooks = true"));
     }
 
-    #[test]
-    fn install_preserves_existing_config() {
+    #[tokio::test]
+    async fn install_preserves_existing_config() {
         let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".codex")).unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
         let original = "# user comment\n[profile]\nmodel = \"gpt-5\"\n";
-        std::fs::write(dir.path().join(".codex/config.toml"), original).unwrap();
-        install(dir.path()).unwrap();
-        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
+        tokio::fs::write(dir.path().join(".codex/config.toml"), original)
+            .await
+            .unwrap();
+        install(dir.path()).await.unwrap();
+        let cfg = tokio::fs::read_to_string(dir.path().join(".codex/config.toml"))
+            .await
+            .unwrap();
         assert!(cfg.contains("# user comment"));
         assert!(cfg.contains("[profile]"));
         assert!(cfg.contains("codex_hooks = true"));
     }
 
-    #[test]
-    fn install_is_idempotent_on_feature_flag() {
+    #[tokio::test]
+    async fn install_is_idempotent_on_feature_flag() {
         let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".codex")).unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
         let original = "[features]\ncodex_hooks = true\n";
-        std::fs::write(dir.path().join(".codex/config.toml"), original).unwrap();
-        install(dir.path()).unwrap();
-        let cfg = std::fs::read_to_string(dir.path().join(".codex/config.toml")).unwrap();
-        // Should contain only one occurrence, not duplicated.
+        tokio::fs::write(dir.path().join(".codex/config.toml"), original)
+            .await
+            .unwrap();
+        install(dir.path()).await.unwrap();
+        let cfg = tokio::fs::read_to_string(dir.path().join(".codex/config.toml"))
+            .await
+            .unwrap();
         assert_eq!(cfg.matches("codex_hooks").count(), 1);
     }
 
-    #[test]
-    fn uninstall_removes_hooks_file_only() {
+    /// Pre-existing Stop entries (different command) and other top-level
+    /// hook categories must survive a dispatch install.
+    #[tokio::test]
+    async fn install_preserves_unrelated_hook_entries() {
         let dir = tempdir().unwrap();
-        install(dir.path()).unwrap();
-        let removed = uninstall(dir.path()).unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        let pre = serde_json::json!({
+            "PreCompact": [
+                { "command": ["echo", "user-hook"] }
+            ],
+            "Stop": [
+                { "command": ["echo", "existing-stop"] }
+            ]
+        });
+        tokio::fs::write(
+            dir.path().join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&pre).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        install(dir.path()).await.unwrap();
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        // User's PreCompact hook intact.
+        assert_eq!(value["PreCompact"][0]["command"][0], "echo");
+        // User's existing Stop entry still present, ours appended.
+        let stops = value["Stop"].as_array().unwrap();
+        assert_eq!(stops.len(), 2);
+        assert!(stops.iter().any(entry_is_dispatch_hook));
+    }
+
+    #[tokio::test]
+    async fn install_is_idempotent_on_stop_entry() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).await.unwrap();
+        install(dir.path()).await.unwrap();
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(value["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn uninstall_removes_dispatch_entry_only() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        let pre = serde_json::json!({
+            "Stop": [
+                { "command": ["echo", "user-stop"] }
+            ]
+        });
+        tokio::fs::write(
+            dir.path().join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&pre).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        install(dir.path()).await.unwrap();
+        uninstall(dir.path()).await.unwrap();
+
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        let stops = value["Stop"].as_array().unwrap();
+        assert_eq!(stops.len(), 1);
+        assert_eq!(stops[0]["command"][0], "echo");
+    }
+
+    #[tokio::test]
+    async fn uninstall_removes_hooks_file_when_empty() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).await.unwrap();
+        let removed = uninstall(dir.path()).await.unwrap();
         assert!(removed.is_some());
         assert!(!dir.path().join(".codex/hooks.json").exists());
         // config.toml kept intentionally.
         assert!(dir.path().join(".codex/config.toml").exists());
     }
 
-    #[test]
-    fn uninstall_noop_when_nothing_to_remove() {
+    #[tokio::test]
+    async fn uninstall_noop_when_nothing_to_remove() {
         let dir = tempdir().unwrap();
-        let removed = uninstall(dir.path()).unwrap();
+        let removed = uninstall(dir.path()).await.unwrap();
         assert!(removed.is_none());
     }
 
@@ -188,5 +371,38 @@ mod tests {
         assert!(out.contains("[features]"));
         assert!(out.contains("other = true"));
         assert!(out.contains("codex_hooks = true"));
+    }
+
+    /// CRLF-terminated config.toml must produce valid TOML after the
+    /// merge — the offset walk must consume `\r\n` as a single line
+    /// terminator rather than splitting mid-pair.
+    #[test]
+    fn handles_crlf_line_endings() {
+        let input = "[profile]\r\nmodel = \"gpt-5\"\r\n[features]\r\nother = true\r\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert!(out.contains("codex_hooks = true"));
+        // Round-trip the result through a TOML parser to prove the file
+        // is still syntactically valid.
+        let parsed: toml::Value = toml::from_str(&out).expect("CRLF merge must yield valid TOML");
+        assert_eq!(
+            parsed["features"]["codex_hooks"],
+            toml::Value::Boolean(true)
+        );
+        assert_eq!(parsed["features"]["other"], toml::Value::Boolean(true));
+    }
+
+    /// Rejects a hooks.json whose top-level JSON is not an object (array,
+    /// scalar, etc.) rather than panicking via unwrap.
+    #[tokio::test]
+    async fn install_rejects_non_object_root() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join(".codex/hooks.json"), b"[]")
+            .await
+            .unwrap();
+        let err = install(dir.path()).await.unwrap_err();
+        assert!(matches!(err, DispatchError::ConfigInvalid { .. }));
     }
 }

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -152,34 +152,47 @@ async fn tokio_file_exists(path: &Path) -> bool {
     tokio::fs::metadata(path).await.is_ok()
 }
 
-/// Append `[features] codex_hooks = true` to `config.toml` if the flag isn't
-/// already present. Uses a simple string merge rather than round-tripping
-/// the TOML AST — so comments, ordering, and formatting of unrelated config
-/// are preserved. Line-ending agnostic: walks `split_inclusive('\n')` so
-/// CRLF-terminated files aren't split mid-pair when we compute the
-/// insertion offset.
+/// Ensure `[features] codex_hooks = true` is present in `config.toml`.
+///
+/// Cases (in order):
+/// 1. File already has `codex_hooks = true` somewhere → no change.
+/// 2. File has `codex_hooks = <anything-else>` (e.g. `false`) → the existing
+///    line is rewritten to `= true` in place. Avoids inserting a duplicate
+///    key that would make the TOML invalid.
+/// 3. `[features]` section exists but no `codex_hooks` key → append the key
+///    at the end of the section.
+/// 4. No `[features]` section → append a fresh section.
+///
+/// Uses a simple string merge rather than round-tripping the TOML AST — so
+/// comments, ordering, and formatting of unrelated config are preserved.
+/// Line-ending agnostic: walks `split_inclusive('\n')` so CRLF-terminated
+/// files aren't split mid-pair when we compute offsets.
 fn ensure_codex_hooks_feature(existing: &str) -> String {
-    if existing
-        .lines()
-        .any(|l| l.trim_start().starts_with("codex_hooks") && l.contains("true"))
-    {
-        return existing.to_string();
-    }
-
-    // Walk sections, preserving the original line terminators so byte
-    // offsets stay correct on both LF and CRLF files.
+    // Single pass: note whether we're inside `[features]`, find the end of
+    // that section (start of the next `[header]` or EOF), and capture the
+    // byte range of any existing `codex_hooks = …` line so we can rewrite
+    // it in place instead of appending a duplicate.
     let mut in_features = false;
     let mut features_end: Option<usize> = None;
+    let mut existing_key: Option<(usize, usize, bool)> = None; // (start, end, is_true)
     let mut offset = 0usize;
     for segment in existing.split_inclusive('\n') {
         let trimmed = segment.trim_end_matches(['\r', '\n']).trim();
         if trimmed.starts_with('[') && trimmed.ends_with(']') {
             if in_features {
                 features_end = Some(offset);
-                break;
+                in_features = false;
             }
             if trimmed == "[features]" {
                 in_features = true;
+            }
+        } else if in_features && trimmed.starts_with("codex_hooks") {
+            // Accept `codex_hooks = <value>` with any spacing. Value is the
+            // substring after `=`, stripped and with trailing comment removed.
+            if let Some((_, rhs)) = trimmed.split_once('=') {
+                let value = rhs.split('#').next().unwrap_or("").trim();
+                let is_true = value == "true";
+                existing_key = Some((offset, offset + segment.len(), is_true));
             }
         }
         offset += segment.len();
@@ -188,8 +201,31 @@ fn ensure_codex_hooks_feature(existing: &str) -> String {
         features_end = Some(existing.len());
     }
 
-    match (in_features, features_end) {
-        (true, Some(end)) => {
+    // Case 1 + 2: an existing `codex_hooks = …` line — short-circuit if
+    // already true, otherwise rewrite in place (preserving the original
+    // line terminator).
+    if let Some((start, end, is_true)) = existing_key {
+        if is_true {
+            return existing.to_string();
+        }
+        let terminator = if existing[start..end].ends_with("\r\n") {
+            "\r\n"
+        } else if existing[start..end].ends_with('\n') {
+            "\n"
+        } else {
+            ""
+        };
+        let mut out = String::with_capacity(existing.len());
+        out.push_str(&existing[..start]);
+        out.push_str("codex_hooks = true");
+        out.push_str(terminator);
+        out.push_str(&existing[end..]);
+        return out;
+    }
+
+    match features_end {
+        // Case 3: [features] section exists, no codex_hooks key.
+        Some(end) => {
             let mut out = String::with_capacity(existing.len() + 24);
             out.push_str(&existing[..end]);
             if !out.ends_with('\n') {
@@ -199,7 +235,8 @@ fn ensure_codex_hooks_feature(existing: &str) -> String {
             out.push_str(&existing[end..]);
             out
         }
-        _ => {
+        // Case 4: no [features] section at all.
+        None => {
             let mut out = existing.to_string();
             if !out.is_empty() && !out.ends_with('\n') {
                 out.push('\n');
@@ -389,6 +426,47 @@ mod tests {
             toml::Value::Boolean(true)
         );
         assert_eq!(parsed["features"]["other"], toml::Value::Boolean(true));
+    }
+
+    /// A pre-existing `codex_hooks = false` inside `[features]` must be
+    /// rewritten to `= true` in place, NOT appended after — appending
+    /// would produce a duplicate key and make the TOML invalid.
+    #[test]
+    fn rewrites_existing_false_value_in_place() {
+        let input = "[features]\ncodex_hooks = false\nother = true\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert_eq!(out.matches("codex_hooks").count(), 1);
+        assert!(out.contains("codex_hooks = true"));
+        assert!(!out.contains("codex_hooks = false"));
+        assert!(out.contains("other = true"));
+        // Must remain parseable TOML.
+        let parsed: toml::Value = toml::from_str(&out).expect("merge must yield valid TOML");
+        assert_eq!(
+            parsed["features"]["codex_hooks"],
+            toml::Value::Boolean(true)
+        );
+    }
+
+    /// Non-boolean / unexpected values (e.g. a string) should also be
+    /// rewritten to the canonical `= true` rather than appended after.
+    #[test]
+    fn rewrites_unexpected_value_in_place() {
+        let input = "[features]\ncodex_hooks = \"yes\"\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert_eq!(out.matches("codex_hooks").count(), 1);
+        assert!(out.contains("codex_hooks = true"));
+        assert!(!out.contains("\"yes\""));
+    }
+
+    /// When the in-place rewrite hits a CRLF-terminated line, the new line
+    /// must also end with CRLF so the rest of the file's terminator style
+    /// is preserved.
+    #[test]
+    fn in_place_rewrite_preserves_crlf() {
+        let input = "[features]\r\ncodex_hooks = false\r\n";
+        let out = ensure_codex_hooks_feature(input);
+        assert!(out.contains("codex_hooks = true\r\n"));
+        assert!(!out.contains("codex_hooks = false"));
     }
 
     /// Rejects a hooks.json whose top-level JSON is not an object (array,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -67,9 +67,17 @@ pub async fn run_stop_hook(cwd: &Path) {
 /// to the config-derived path. Returns `None` if neither source yields a
 /// path (e.g. config resolution fails outside a project).
 fn resolve_socket_path(cwd: &Path) -> Option<PathBuf> {
-    if let Ok(env_path) = std::env::var("DISPATCH_SOCKET_PATH") {
-        if !env_path.is_empty() {
-            return Some(PathBuf::from(env_path));
+    let env = std::env::var("DISPATCH_SOCKET_PATH").ok();
+    resolve_socket_path_with_env(env.as_deref(), cwd)
+}
+
+/// Internal helper that separates the process-global `DISPATCH_SOCKET_PATH`
+/// read from the resolution logic so tests can exercise the env-precedence
+/// branch without mutating `std::env` (which races across parallel tests).
+fn resolve_socket_path_with_env(env_path: Option<&str>, cwd: &Path) -> Option<PathBuf> {
+    if let Some(p) = env_path {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
         }
     }
     match resolve_config(None, None, cwd) {
@@ -120,21 +128,31 @@ mod tests {
         assert!(!probe_broker(&sock).await);
     }
 
+    /// Env-var precedence: when DISPATCH_SOCKET_PATH is set, resolution
+    /// returns it verbatim without touching the config file. Exercises
+    /// `resolve_socket_path_with_env` so tests don't race on the
+    /// process-global env (which `std::env::set_var` is documented to
+    /// require serialising across threads).
     #[tokio::test]
     async fn resolve_socket_path_prefers_env_var() {
         let tmp = tempfile::tempdir().unwrap();
         let explicit = tmp.path().join("from-env.sock");
-        // Use a test-local env mutation guard; std::env is process-global so
-        // we set and then unset within the same test. Serial in practice
-        // because tokio::test uses the current_thread runtime.
-        // SAFETY: tests are single-threaded within a single `#[tokio::test]`.
-        unsafe {
-            std::env::set_var("DISPATCH_SOCKET_PATH", &explicit);
-        }
-        let resolved = resolve_socket_path(tmp.path());
-        unsafe {
-            std::env::remove_var("DISPATCH_SOCKET_PATH");
-        }
+        let resolved =
+            resolve_socket_path_with_env(Some(&explicit.display().to_string()), tmp.path());
         assert_eq!(resolved, Some(explicit));
+    }
+
+    /// Empty env value falls through to config-derived resolution, same as
+    /// an unset variable.
+    #[tokio::test]
+    async fn resolve_socket_path_empty_env_falls_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_socket_path_with_env(Some(""), tmp.path());
+        // No config in tmp → config resolver derives cell_id from the path,
+        // so we still get *some* path back (not the empty-string one).
+        match resolved {
+            Some(p) => assert!(!p.as_os_str().is_empty()),
+            None => panic!("expected a derived path, not None"),
+        }
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,6 +6,14 @@
 //! stdout we tell the agent to stay alive and keep polling dispatch for new
 //! messages instead of exiting at the end of a turn.
 
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::net::UnixStream;
+
+use crate::backend::socket_path;
+use crate::config::resolve_config;
+
 pub mod claude;
 pub mod codex;
 
@@ -16,6 +24,11 @@ pub mod codex;
 /// instruction rather than conversational text.
 pub const CONTINUE_REASON: &str = "The dispatch broker may still have work queued for you. Do not stop yet — call `dispatch listen` again with your registered worker_id and a timeout (e.g. 600) to wait for the next message. When a message arrives, process it and then return to this listen step.";
 
+/// How long the stop hook waits for a connection to the broker socket
+/// before treating it as unreachable. Kept short because the hook is in
+/// the critical path of every agent turn.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+
 /// JSON body every stop hook emits on stdout. Both vendors accept this shape.
 pub fn stop_decision_json() -> String {
     serde_json::json!({
@@ -23,4 +36,105 @@ pub fn stop_decision_json() -> String {
         "reason": CONTINUE_REASON,
     })
     .to_string()
+}
+
+/// Handler for both `dispatch codex-hook stop` and `dispatch claude-hook stop`.
+///
+/// Probes the broker socket; if a broker is reachable, prints the block
+/// decision so the vendor keeps the agent alive. If the broker is
+/// unreachable (dispatch shutdown, never started, config missing) we
+/// print nothing and exit 0 — the vendor treats that as "allow stop".
+///
+/// Never returns an error: probe failures map to "allow stop".
+pub async fn run_stop_hook(cwd: &Path) {
+    match resolve_socket_path(cwd) {
+        Some(path) => {
+            if probe_broker(&path).await {
+                tracing::debug!(path = %path.display(), "broker reachable; blocking stop");
+                println!("{}", stop_decision_json());
+            } else {
+                tracing::debug!(path = %path.display(), "broker unreachable; allowing stop");
+            }
+        }
+        None => {
+            tracing::debug!("no socket path resolvable; allowing stop");
+        }
+    }
+}
+
+/// Resolve the broker socket path using the same precedence the regular
+/// client uses: `DISPATCH_SOCKET_PATH` env var wins, otherwise fall back
+/// to the config-derived path. Returns `None` if neither source yields a
+/// path (e.g. config resolution fails outside a project).
+fn resolve_socket_path(cwd: &Path) -> Option<PathBuf> {
+    if let Ok(env_path) = std::env::var("DISPATCH_SOCKET_PATH") {
+        if !env_path.is_empty() {
+            return Some(PathBuf::from(env_path));
+        }
+    }
+    match resolve_config(None, None, cwd) {
+        Ok(cfg) => Some(socket_path(&cfg.project_root, &cfg.cell_id)),
+        Err(e) => {
+            tracing::debug!(error = %e, "config resolution failed during hook probe");
+            None
+        }
+    }
+}
+
+/// Attempt a short-timeout connect to the broker's Unix socket.
+/// Returns `true` only if a connection succeeds within `PROBE_TIMEOUT`.
+async fn probe_broker(path: &Path) -> bool {
+    matches!(
+        tokio::time::timeout(PROBE_TIMEOUT, UnixStream::connect(path)).await,
+        Ok(Ok(_))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::UnixListener;
+
+    #[tokio::test]
+    async fn probe_returns_true_when_broker_listens() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("live.sock");
+        let _listener = UnixListener::bind(&sock).unwrap();
+        assert!(probe_broker(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_when_socket_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("missing.sock");
+        assert!(!probe_broker(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_when_socket_stale() {
+        // File exists but nothing is bound — UnixStream::connect fails with
+        // ConnectionRefused. We treat that as "broker unreachable".
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("stale.sock");
+        std::fs::write(&sock, b"").unwrap();
+        assert!(!probe_broker(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn resolve_socket_path_prefers_env_var() {
+        let tmp = tempfile::tempdir().unwrap();
+        let explicit = tmp.path().join("from-env.sock");
+        // Use a test-local env mutation guard; std::env is process-global so
+        // we set and then unset within the same test. Serial in practice
+        // because tokio::test uses the current_thread runtime.
+        // SAFETY: tests are single-threaded within a single `#[tokio::test]`.
+        unsafe {
+            std::env::set_var("DISPATCH_SOCKET_PATH", &explicit);
+        }
+        let resolved = resolve_socket_path(tmp.path());
+        unsafe {
+            std::env::remove_var("DISPATCH_SOCKET_PATH");
+        }
+        assert_eq!(resolved, Some(explicit));
+    }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,26 @@
+//! Hook subcommands for Codex and Claude Code CLIs.
+//!
+//! The `codex-hook` and `claude-hook` subcommand families let an agent's
+//! vendor CLI call back into dispatch on lifecycle events. The Stop hook is
+//! the important one: by printing `{"decision":"block","reason":"..."}` on
+//! stdout we tell the agent to stay alive and keep polling dispatch for new
+//! messages instead of exiting at the end of a turn.
+
+pub mod claude;
+pub mod codex;
+
+/// Reason string returned to the vendor CLI telling the agent to keep
+/// listening for more dispatch messages instead of stopping.
+///
+/// Kept short and imperative so the LLM treats it as a continuation
+/// instruction rather than conversational text.
+pub const CONTINUE_REASON: &str = "The dispatch broker may still have work queued for you. Do not stop yet — call `dispatch listen` again with your registered worker_id and a timeout (e.g. 600) to wait for the next message. When a message arrives, process it and then return to this listen step.";
+
+/// JSON body every stop hook emits on stdout. Both vendors accept this shape.
+pub fn stop_decision_json() -> String {
+    serde_json::json!({
+        "decision": "block",
+        "reason": CONTINUE_REASON,
+    })
+    .to_string()
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -22,7 +22,12 @@ pub mod codex;
 ///
 /// Kept short and imperative so the LLM treats it as a continuation
 /// instruction rather than conversational text.
-pub const CONTINUE_REASON: &str = "The dispatch broker may still have work queued for you. Do not stop yet — call `dispatch listen` again with your registered worker_id and a timeout (e.g. 600) to wait for the next message. When a message arrives, process it and then return to this listen step.";
+///
+/// Prefixed with an "if you are a dispatch agent" guard because both vendor
+/// stop hooks fire for *every* claude/codex session inside a repo where the
+/// hook is installed — including ad-hoc sessions the user runs by hand. A
+/// non-dispatch session that reads this should treat it as a no-op.
+pub const CONTINUE_REASON: &str = "If you are a dispatch agent (you have a registered worker_id from `dispatch register`): the dispatch broker may still have work queued for you. Do not stop yet — call `dispatch listen` again with your worker_id and a timeout (e.g. 600) to wait for the next message. When a message arrives, process it and then return to this listen step.\n\nIf you are NOT a dispatch agent (you have no worker_id and the user did not start you via dispatch), ignore this notice and stop normally.";
 
 /// How long the stop hook waits for a connection to the broker socket
 /// before treating it as unreachable. Kept short because the hook is in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ pub mod backend;
 pub mod cli;
 pub mod config;
 pub mod errors;
+pub mod hooks;
 pub mod logging;
 pub mod protocol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adapter;
 pub mod backend;
 pub mod cli;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use clap::Parser;
 
 use dispatch::backend::create_backend;
-use dispatch::cli::{AgentAction, Cli, Commands};
+use dispatch::cli::{AgentAction, Cli, Commands, HookAction};
 use dispatch::config::resolve_config;
+use dispatch::hooks;
 use dispatch::logging::init_tracing;
 use dispatch::protocol::BrokerRequest;
 
@@ -76,6 +77,14 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         println!("{}", path.display());
         eprintln!("Created dispatch.config.toml");
         return Ok(());
+    }
+
+    // Hook subcommands are local file operations / stdout — no broker, no config.
+    if let Commands::CodexHook { action } = &cli.command {
+        return run_codex_hook(action, &cwd);
+    }
+    if let Commands::ClaudeHook { action } = &cli.command {
+        return run_claude_hook(action, &cwd);
     }
 
     let config = resolve_config(cli.cell_id.as_deref(), cli.config.as_deref(), &cwd)?;
@@ -197,6 +206,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     AgentAction::Stop { name } => BrokerRequest::AgentStop { name },
                     AgentAction::Restart { name } => BrokerRequest::AgentRestart { name },
                 },
+                Commands::CodexHook { .. } | Commands::ClaudeHook { .. } => unreachable!(),
             };
             let response = backend.send_request(&request).await?;
             let json = serde_json::to_string(&response)?;
@@ -204,5 +214,48 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         }
     }
 
+    Ok(())
+}
+
+fn run_codex_hook(
+    action: &HookAction,
+    cwd: &std::path::Path,
+) -> Result<(), dispatch::errors::DispatchError> {
+    match action {
+        HookAction::Stop => {
+            println!("{}", hooks::stop_decision_json());
+        }
+        HookAction::Install => {
+            let path = hooks::codex::install(cwd)?;
+            eprintln!(
+                "installed codex hook at {}\nensure features.codex_hooks = true is set in .codex/config.toml (already added if missing)",
+                path.display()
+            );
+        }
+        HookAction::Uninstall => match hooks::codex::uninstall(cwd)? {
+            Some(path) => eprintln!("removed {}", path.display()),
+            None => eprintln!("no codex hook installed"),
+        },
+    }
+    Ok(())
+}
+
+fn run_claude_hook(
+    action: &HookAction,
+    cwd: &std::path::Path,
+) -> Result<(), dispatch::errors::DispatchError> {
+    match action {
+        HookAction::Stop => {
+            println!("{}", hooks::stop_decision_json());
+        }
+        HookAction::Install => {
+            let path = hooks::claude::install(cwd)?;
+            eprintln!("installed claude hook at {}", path.display());
+        }
+        HookAction::Uninstall => match hooks::claude::uninstall(cwd)? {
+            Some(path) => eprintln!("removed entry from {}", path.display()),
+            None => eprintln!("no claude hook installed"),
+        },
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,29 +18,18 @@ fn parse_timestamp(s: &str) -> Result<u64, String> {
         .unwrap_or_default()
         .as_secs();
 
-    // Try relative duration: number + suffix (s/m/h/d)
-    if let Some(num_str) = s.strip_suffix('s') {
-        if let Ok(n) = num_str.parse::<u64>() {
-            return Ok(now.saturating_sub(n));
-        }
-    }
-    if let Some(num_str) = s.strip_suffix('m') {
-        if let Ok(n) = num_str.parse::<u64>() {
-            return Ok(now.saturating_sub(n * 60));
-        }
-    }
-    if let Some(num_str) = s.strip_suffix('h') {
-        if let Ok(n) = num_str.parse::<u64>() {
-            return Ok(now.saturating_sub(n * 3600));
-        }
-    }
-    if let Some(num_str) = s.strip_suffix('d') {
-        if let Ok(n) = num_str.parse::<u64>() {
-            return Ok(now.saturating_sub(n * 86400));
+    let relative = [('s', 1u64), ('m', 60), ('h', 3600), ('d', 86400)];
+    for (suffix, factor) in relative {
+        if let Some(num_str) = s.strip_suffix(suffix) {
+            if let Ok(n) = num_str.parse::<u64>() {
+                let secs = n.checked_mul(factor).ok_or_else(|| {
+                    format!("invalid timestamp: {s} (relative duration overflows)")
+                })?;
+                return Ok(now.saturating_sub(secs));
+            }
         }
     }
 
-    // Try absolute Unix timestamp
     if let Ok(ts) = s.parse::<u64>() {
         return Ok(ts);
     }
@@ -259,4 +248,28 @@ async fn run_claude_hook(
         },
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_timestamp_accepts_unix_seconds() {
+        assert_eq!(parse_timestamp("1700000000").unwrap(), 1700000000);
+    }
+
+    #[test]
+    fn parse_timestamp_relative_does_not_overflow() {
+        // u64::MAX followed by a suffix must not panic in debug or wrap in
+        // release — it should return a readable error.
+        let input = format!("{}m", u64::MAX);
+        let err = parse_timestamp(&input).unwrap_err();
+        assert!(err.contains("overflow"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_timestamp_rejects_garbage() {
+        assert!(parse_timestamp("not-a-timestamp").is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
 
@@ -7,6 +8,44 @@ use dispatch::cli::{Cli, Commands};
 use dispatch::config::resolve_config;
 use dispatch::logging::init_tracing;
 use dispatch::protocol::BrokerRequest;
+
+/// Parse a timestamp string as either a relative duration (e.g. "5m", "1h", "30s")
+/// or an absolute Unix timestamp. Returns a Unix timestamp in seconds.
+fn parse_timestamp(s: &str) -> Result<u64, String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // Try relative duration: number + suffix (s/m/h/d)
+    if let Some(num_str) = s.strip_suffix('s') {
+        if let Ok(n) = num_str.parse::<u64>() {
+            return Ok(now.saturating_sub(n));
+        }
+    }
+    if let Some(num_str) = s.strip_suffix('m') {
+        if let Ok(n) = num_str.parse::<u64>() {
+            return Ok(now.saturating_sub(n * 60));
+        }
+    }
+    if let Some(num_str) = s.strip_suffix('h') {
+        if let Ok(n) = num_str.parse::<u64>() {
+            return Ok(now.saturating_sub(n * 3600));
+        }
+    }
+    if let Some(num_str) = s.strip_suffix('d') {
+        if let Ok(n) = num_str.parse::<u64>() {
+            return Ok(now.saturating_sub(n * 86400));
+        }
+    }
+
+    // Try absolute Unix timestamp
+    if let Ok(ts) = s.parse::<u64>() {
+        return Ok(ts);
+    }
+
+    Err(format!("invalid timestamp: {s} (use relative like 5m/1h/30s or a Unix timestamp)"))
+}
 
 #[tokio::main]
 async fn main() {
@@ -85,6 +124,59 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     worker_id,
                     timeout_secs: timeout,
                 },
+                Commands::Events {
+                    event_type,
+                    worker,
+                    since,
+                    until,
+                    limit,
+                } => {
+                    let since = since
+                        .map(|s| parse_timestamp(&s))
+                        .transpose()
+                        .unwrap_or_else(|e| {
+                            eprintln!("dispatch: {e}");
+                            process::exit(2);
+                        });
+                    let until = until
+                        .map(|s| parse_timestamp(&s))
+                        .transpose()
+                        .unwrap_or_else(|e| {
+                            eprintln!("dispatch: {e}");
+                            process::exit(2);
+                        });
+                    BrokerRequest::Events {
+                        since,
+                        until,
+                        event_type,
+                        worker,
+                        limit,
+                    }
+                }
+                Commands::Messages {
+                    worker_id,
+                    unacked,
+                    sent,
+                    since,
+                    limit,
+                    id,
+                } => {
+                    let since = since
+                        .map(|s| parse_timestamp(&s))
+                        .transpose()
+                        .unwrap_or_else(|e| {
+                            eprintln!("dispatch: {e}");
+                            process::exit(2);
+                        });
+                    BrokerRequest::Messages {
+                        worker_id,
+                        unacked,
+                        sent,
+                        since,
+                        limit,
+                        id,
+                    }
+                }
                 Commands::Status { worker_id, clear } => {
                     BrokerRequest::Status { worker_id, clear }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,13 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         return Ok(());
     }
 
-    // Hook subcommands are local file operations / stdout — no broker, no config.
+    // Hook subcommands run without resolving a config up front — Stop probes
+    // the broker itself, install/uninstall touch vendor files only.
     if let Commands::CodexHook { action } = &cli.command {
-        return run_codex_hook(action, &cwd);
+        return run_codex_hook(action, &cwd).await;
     }
     if let Commands::ClaudeHook { action } = &cli.command {
-        return run_claude_hook(action, &cwd);
+        return run_claude_hook(action, &cwd).await;
     }
 
     let config = resolve_config(cli.cell_id.as_deref(), cli.config.as_deref(), &cwd)?;
@@ -217,13 +218,13 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
     Ok(())
 }
 
-fn run_codex_hook(
+async fn run_codex_hook(
     action: &HookAction,
     cwd: &std::path::Path,
 ) -> Result<(), dispatch::errors::DispatchError> {
     match action {
         HookAction::Stop => {
-            println!("{}", hooks::stop_decision_json());
+            hooks::run_stop_hook(cwd).await;
         }
         HookAction::Install => {
             let path = hooks::codex::install(cwd)?;
@@ -240,13 +241,13 @@ fn run_codex_hook(
     Ok(())
 }
 
-fn run_claude_hook(
+async fn run_claude_hook(
     action: &HookAction,
     cwd: &std::path::Path,
 ) -> Result<(), dispatch::errors::DispatchError> {
     match action {
         HookAction::Stop => {
-            println!("{}", hooks::stop_decision_json());
+            hooks::run_stop_hook(cwd).await;
         }
         HookAction::Install => {
             let path = hooks::claude::install(cwd)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,21 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     worker_id,
                     timeout_secs: timeout,
                 },
-                Commands::Heartbeat { worker_id } => BrokerRequest::Heartbeat { worker_id },
+                Commands::Status { worker_id, clear } => {
+                    BrokerRequest::Status { worker_id, clear }
+                }
+                Commands::Ack {
+                    worker_id,
+                    message_id,
+                    note,
+                } => BrokerRequest::Ack {
+                    worker_id,
+                    message_id,
+                    note,
+                },
+                Commands::Heartbeat { worker_id, status } => {
+                    BrokerRequest::Heartbeat { worker_id, status }
+                }
             };
             let response = backend.send_request(&request).await?;
             let json = serde_json::to_string(&response)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,13 +216,13 @@ async fn run_codex_hook(
             hooks::run_stop_hook(cwd).await;
         }
         HookAction::Install => {
-            let path = hooks::codex::install(cwd)?;
+            let path = hooks::codex::install(cwd).await?;
             eprintln!(
                 "installed codex hook at {}\nensure features.codex_hooks = true is set in .codex/config.toml (already added if missing)",
                 path.display()
             );
         }
-        HookAction::Uninstall => match hooks::codex::uninstall(cwd)? {
+        HookAction::Uninstall => match hooks::codex::uninstall(cwd).await? {
             Some(path) => eprintln!("removed {}", path.display()),
             None => eprintln!("no codex hook installed"),
         },
@@ -239,10 +239,10 @@ async fn run_claude_hook(
             hooks::run_stop_hook(cwd).await;
         }
         HookAction::Install => {
-            let path = hooks::claude::install(cwd)?;
+            let path = hooks::claude::install(cwd).await?;
             eprintln!("installed claude hook at {}", path.display());
         }
-        HookAction::Uninstall => match hooks::claude::uninstall(cwd)? {
+        HookAction::Uninstall => match hooks::claude::uninstall(cwd).await? {
             Some(path) => eprintln!("removed entry from {}", path.display()),
             None => eprintln!("no claude hook installed"),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use clap::Parser;
 
 use dispatch::backend::create_backend;
-use dispatch::cli::{Cli, Commands};
+use dispatch::cli::{AgentAction, Cli, Commands};
 use dispatch::config::resolve_config;
 use dispatch::logging::init_tracing;
 use dispatch::protocol::BrokerRequest;
@@ -192,6 +192,11 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                 Commands::Heartbeat { worker_id, status } => {
                     BrokerRequest::Heartbeat { worker_id, status }
                 }
+                Commands::Agent { action } => match action {
+                    AgentAction::Start { name } => BrokerRequest::AgentStart { name },
+                    AgentAction::Stop { name } => BrokerRequest::AgentStop { name },
+                    AgentAction::Restart { name } => BrokerRequest::AgentRestart { name },
+                },
             };
             let response = backend.send_request(&request).await?;
             let json = serde_json::to_string(&response)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,17 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+
+/// Maximum number of historical status taglines retained per worker.
+/// Current tagline is `Worker.last_status`; this cap bounds the ring that
+/// backs the "last N" strip on the agent card.
+pub const STATUS_HISTORY_MAX: usize = 3;
+
+/// A prior status tagline plus when it was set. Oldest first in the ring.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusEntry {
+    pub status: String,
+    pub set_at: u64,
+}
 
 /// A message queued in a worker's mailbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,6 +164,11 @@ pub struct Worker {
     /// Unix timestamp when `last_status` was last set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_status_at: Option<u64>,
+    /// Recent status taglines, oldest first. Capped at `STATUS_HISTORY_MAX`.
+    /// The current `last_status` is **not** included here — it lives on its
+    /// own field. Skipped when empty so older clients see the same shape.
+    #[serde(default, skip_serializing_if = "VecDeque::is_empty")]
+    pub status_history: VecDeque<StatusEntry>,
 }
 
 /// The payload inside a successful response, varies by request type.
@@ -272,6 +289,7 @@ mod tests {
                     expires_at: 1000,
                     last_status: None,
                     last_status_at: None,
+                    status_history: VecDeque::new(),
                 }],
             },
             ResponsePayload::HeartbeatAck {
@@ -300,6 +318,47 @@ mod tests {
                 serde_json::to_value(&back).unwrap(),
             );
         }
+    }
+
+    /// Worker round-trips with a populated status_history; the empty field
+    /// is omitted from JSON so older clients keep parsing the response.
+    #[test]
+    fn worker_status_history_round_trip() {
+        let mut history = VecDeque::new();
+        history.push_back(StatusEntry {
+            status: "starting".into(),
+            set_at: 100,
+        });
+        history.push_back(StatusEntry {
+            status: "running tests".into(),
+            set_at: 105,
+        });
+        let worker = Worker {
+            id: "w1".into(),
+            name: "worker-1".into(),
+            role: "builder".into(),
+            description: "test".into(),
+            capabilities: vec![],
+            ttl_secs: 300,
+            expires_at: 2000,
+            last_status: Some("waiting on review".into()),
+            last_status_at: Some(110),
+            status_history: history.clone(),
+        };
+        let json = serde_json::to_string(&worker).unwrap();
+        assert!(json.contains("status_history"));
+        let back: Worker = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.status_history, history);
+
+        // Empty history is omitted from JSON and absent fields default to empty.
+        let empty = Worker {
+            status_history: VecDeque::new(),
+            ..worker
+        };
+        let json = serde_json::to_string(&empty).unwrap();
+        assert!(!json.contains("status_history"));
+        let back: Worker = serde_json::from_str(&json).unwrap();
+        assert!(back.status_history.is_empty());
     }
 
     /// BrokerResponse::Error round-trips correctly.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -98,6 +98,12 @@ pub enum BrokerRequest {
         #[serde(default)]
         clear: bool,
     },
+    /// Start a configured agent by name.
+    AgentStart { name: String },
+    /// Stop a managed agent by name.
+    AgentStop { name: String },
+    /// Restart a managed agent by name (stop then start).
+    AgentRestart { name: String },
 }
 
 /// Summary of a worker's status for the status query response.
@@ -222,6 +228,15 @@ mod tests {
             BrokerRequest::Heartbeat {
                 worker_id: "w1".into(),
                 status: None,
+            },
+            BrokerRequest::AgentStart {
+                name: "reviewer".into(),
+            },
+            BrokerRequest::AgentStop {
+                name: "reviewer".into(),
+            },
+            BrokerRequest::AgentRestart {
+                name: "reviewer".into(),
             },
         ];
         for req in &cases {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -192,14 +192,16 @@ pub enum ResponsePayload {
     WorkerList { workers: Vec<Worker> },
     /// A worker was registered; returns the assigned worker ID.
     WorkerRegistered { worker_id: String },
-    /// A message delivered or queued.
-    MessageAck { message_id: String },
-    /// Message acknowledgement confirmed. The `ack_confirmed` field distinguishes
-    /// this from `MessageAck` during untagged deserialization.
+    /// Message acknowledgement confirmed. MUST appear before `MessageAck`:
+    /// serde's untagged deserializer tries variants in declaration order and
+    /// ignores unknown fields, so an `AckConfirm` payload would otherwise
+    /// silently deserialize as `MessageAck` and drop `ack_confirmed`.
     AckConfirm {
         message_id: String,
         ack_confirmed: bool,
     },
+    /// A message delivered or queued.
+    MessageAck { message_id: String },
     /// Worker status query result.
     StatusResult { workers: Vec<WorkerStatus> },
     /// Event history query result.
@@ -244,7 +246,31 @@ mod tests {
             },
             BrokerRequest::Heartbeat {
                 worker_id: "w1".into(),
-                status: None,
+                status: Some("running tests".into()),
+            },
+            BrokerRequest::Ack {
+                worker_id: "w1".into(),
+                message_id: "m1".into(),
+                note: Some("starting impl".into()),
+            },
+            BrokerRequest::Events {
+                since: Some(100),
+                until: Some(200),
+                event_type: Some("send".into()),
+                worker: Some("w1".into()),
+                limit: Some(10),
+            },
+            BrokerRequest::Messages {
+                worker_id: "w1".into(),
+                unacked: true,
+                sent: false,
+                since: None,
+                limit: Some(50),
+                id: None,
+            },
+            BrokerRequest::Status {
+                worker_id: Some("w1".into()),
+                clear: false,
             },
             BrokerRequest::AgentStart {
                 name: "reviewer".into(),
@@ -305,6 +331,10 @@ mod tests {
             ResponsePayload::Timeout {
                 worker_id: "w1".into(),
             },
+            ResponsePayload::AckConfirm {
+                message_id: "msg-2".into(),
+                ack_confirmed: true,
+            },
             ResponsePayload::Ack {},
         ];
         for payload in payloads {
@@ -359,6 +389,31 @@ mod tests {
         assert!(!json.contains("status_history"));
         let back: Worker = serde_json::from_str(&json).unwrap();
         assert!(back.status_history.is_empty());
+    }
+
+    /// Regression: `AckConfirm` is structurally a superset of `MessageAck`.
+    /// Because serde's untagged enum ignores unknown fields, `AckConfirm` MUST
+    /// be declared before `MessageAck` or its payload silently degrades and
+    /// `ack_confirmed` is dropped on deserialize.
+    #[test]
+    fn ack_confirm_does_not_degrade_to_message_ack() {
+        let payload = ResponsePayload::AckConfirm {
+            message_id: "m1".into(),
+            ack_confirmed: true,
+        };
+        let resp = BrokerResponse::Ok { payload };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            json.contains("\"ack_confirmed\":true"),
+            "serialized form must include ack_confirmed: {json}"
+        );
+        let back: BrokerResponse = serde_json::from_str(&json).unwrap();
+        match back {
+            BrokerResponse::Ok {
+                payload: ResponsePayload::AckConfirm { ack_confirmed, .. },
+            } => assert!(ack_confirmed),
+            other => panic!("expected AckConfirm, got {other:?}"),
+        }
     }
 
     /// BrokerResponse::Error round-trips correctly.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -42,8 +42,38 @@ pub enum BrokerRequest {
         worker_id: String,
         timeout_secs: u64,
     },
-    /// Renew a worker's liveness TTL.
-    Heartbeat { worker_id: String },
+    /// Renew a worker's liveness TTL, optionally updating status.
+    Heartbeat {
+        worker_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+    },
+    /// Acknowledge receipt of a message.
+    Ack {
+        worker_id: String,
+        message_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    },
+    /// Query worker status or clear a worker's status.
+    Status {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        worker_id: Option<String>,
+        #[serde(default)]
+        clear: bool,
+    },
+}
+
+/// Summary of a worker's status for the status query response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerStatus {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status_at: Option<u64>,
 }
 
 /// A response sent from the broker back to the client.
@@ -71,6 +101,12 @@ pub struct Worker {
     pub ttl_secs: u64,
     /// Unix timestamp (seconds) when this worker's TTL expires.
     pub expires_at: u64,
+    /// Human-readable status tagline (e.g. "Running e2e tests 3/10").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status: Option<String>,
+    /// Unix timestamp when `last_status` was last set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status_at: Option<u64>,
 }
 
 /// The payload inside a successful response, varies by request type.
@@ -96,6 +132,14 @@ pub enum ResponsePayload {
     WorkerRegistered { worker_id: String },
     /// A message delivered or queued.
     MessageAck { message_id: String },
+    /// Message acknowledgement confirmed. The `ack_confirmed` field distinguishes
+    /// this from `MessageAck` during untagged deserialization.
+    AckConfirm {
+        message_id: String,
+        ack_confirmed: bool,
+    },
+    /// Worker status query result.
+    StatusResult { workers: Vec<WorkerStatus> },
     /// Listen timed out with no messages.
     Timeout { worker_id: String },
     /// Map of arbitrary key-value data (used as a flexible response shape).
@@ -134,6 +178,7 @@ mod tests {
             },
             BrokerRequest::Heartbeat {
                 worker_id: "w1".into(),
+                status: None,
             },
         ];
         for req in &cases {
@@ -167,6 +212,8 @@ mod tests {
                     capabilities: vec![],
                     ttl_secs: 300,
                     expires_at: 1000,
+                    last_status: None,
+                    last_status_at: None,
                 }],
             },
             ResponsePayload::HeartbeatAck {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,6 +8,15 @@ pub struct Message {
     pub from: Option<String>,
     pub to: String,
     pub body: String,
+    /// When the message was sent (queued by the broker).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_at: Option<u64>,
+    /// When the message was delivered to the recipient via listen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivered_at: Option<u64>,
+    /// When the message was acknowledged by the recipient.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acked_at: Option<u64>,
 }
 
 /// A request sent from a client to the broker over the Unix socket.
@@ -54,6 +63,33 @@ pub enum BrokerRequest {
         message_id: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         note: Option<String>,
+    },
+    /// Query event history.
+    Events {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        since: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        until: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        event_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        worker: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        limit: Option<usize>,
+    },
+    /// Query message history.
+    Messages {
+        worker_id: String,
+        #[serde(default)]
+        unacked: bool,
+        #[serde(default)]
+        sent: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        since: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        limit: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
     },
     /// Query worker status or clear a worker's status.
     Status {
@@ -140,6 +176,12 @@ pub enum ResponsePayload {
     },
     /// Worker status query result.
     StatusResult { workers: Vec<WorkerStatus> },
+    /// Event history query result.
+    EventList {
+        events: Vec<serde_json::Value>,
+    },
+    /// Message history query result.
+    MessageList { messages: Vec<Message> },
     /// Listen timed out with no messages.
     Timeout { worker_id: String },
     /// Map of arbitrary key-value data (used as a flexible response shape).

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -511,7 +511,7 @@ fn events_command_filters_by_type() {
         .success();
 
     let output = dispatch_cmd(&dir, cell_id)
-        .args(["events", "--event-type", "send"])
+        .args(["events", "--type", "send"])
         .assert()
         .success()
         .get_output()
@@ -524,10 +524,14 @@ fn events_command_filters_by_type() {
     assert!(events.iter().all(|e| e["kind"] == "send"));
 }
 
+/// Default `dispatch messages --worker-id <id>` (no `--sent` flag) queries
+/// the worker's *inbox* — messages delivered **to** that worker. Named
+/// accordingly so the assertion (`to == worker_id`) and the test intent
+/// line up.
 #[test]
-fn messages_command_returns_sent_messages() {
+fn messages_command_returns_worker_inbox() {
     let dir = TempDir::new().unwrap();
-    let cell_id = "test-messages-history";
+    let cell_id = "test-messages-inbox";
     let _broker = start_broker(&dir, cell_id);
     let worker_id = register_worker(&dir, cell_id, "msg-worker", "tester");
     dispatch_cmd(&dir, cell_id)
@@ -557,6 +561,45 @@ fn messages_command_returns_sent_messages() {
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0]["body"], "payload-body");
     assert_eq!(messages[0]["to"], worker_id);
+}
+
+/// `--sent` flips the query to the worker's *outbox* — messages the worker
+/// sent to others. Covers the flag branch the inbox test above does not.
+#[test]
+fn messages_command_with_sent_flag_returns_outbox() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-messages-sent";
+    let _broker = start_broker(&dir, cell_id);
+    let sender_id = register_worker(&dir, cell_id, "sender-worker", "sender");
+    let recipient_id = register_worker(&dir, cell_id, "recipient-worker", "recipient");
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "send",
+            "--to",
+            &recipient_id,
+            "--body",
+            "outbound-payload",
+            "--from",
+            &sender_id,
+        ])
+        .assert()
+        .success();
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args(["messages", "--worker-id", &sender_id, "--sent"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["status"], "ok");
+    let messages = json["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["body"], "outbound-payload");
+    assert_eq!(messages[0]["from"], sender_id);
+    assert_eq!(messages[0]["to"], recipient_id);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -450,6 +450,221 @@ fn codex_hook_stop_blocks_when_broker_alive() {
     );
 }
 
+// ── Introspection commands (events / messages / status / ack) ────────
+
+/// Helper: register a worker and return its ID.
+fn register_worker(dir: &TempDir, cell_id: &str, name: &str, role: &str) -> String {
+    let out = dispatch_cmd(dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            name,
+            "--role",
+            role,
+            "--description",
+            "integration test worker",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    json["worker_id"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn events_command_returns_event_history() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-events-history";
+    let _broker = start_broker(&dir, cell_id);
+    let _worker = register_worker(&dir, cell_id, "ev-worker", "tester");
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args(["events", "--limit", "10"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["status"], "ok");
+    let events = json["events"].as_array().expect("events array");
+    assert!(
+        events.iter().any(|e| e["kind"] == "register"),
+        "expected at least one register event, got: {json}"
+    );
+}
+
+#[test]
+fn events_command_filters_by_type() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-events-filter";
+    let _broker = start_broker(&dir, cell_id);
+    let worker_id = register_worker(&dir, cell_id, "ev-filter", "tester");
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "send", "--to", &worker_id, "--body", "ping", "--from", "harness",
+        ])
+        .assert()
+        .success();
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args(["events", "--event-type", "send"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    let events = json["events"].as_array().unwrap();
+    assert!(!events.is_empty(), "expected at least one send event");
+    assert!(events.iter().all(|e| e["kind"] == "send"));
+}
+
+#[test]
+fn messages_command_returns_sent_messages() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-messages-history";
+    let _broker = start_broker(&dir, cell_id);
+    let worker_id = register_worker(&dir, cell_id, "msg-worker", "tester");
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "send",
+            "--to",
+            &worker_id,
+            "--body",
+            "payload-body",
+            "--from",
+            "harness",
+        ])
+        .assert()
+        .success();
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args(["messages", "--worker-id", &worker_id])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["status"], "ok");
+    let messages = json["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["body"], "payload-body");
+    assert_eq!(messages[0]["to"], worker_id);
+}
+
+#[test]
+fn status_command_returns_worker_status() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-status";
+    let _broker = start_broker(&dir, cell_id);
+    let worker_id = register_worker(&dir, cell_id, "status-worker", "tester");
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "heartbeat",
+            "--worker-id",
+            &worker_id,
+            "--status",
+            "running e2e tests 3/10",
+        ])
+        .assert()
+        .success();
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args(["status", "--worker-id", &worker_id])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["status"], "ok");
+    let workers = json["workers"].as_array().expect("workers array");
+    assert_eq!(workers.len(), 1);
+    assert_eq!(workers[0]["last_status"], "running e2e tests 3/10");
+}
+
+#[test]
+fn ack_command_records_acknowledgement() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-ack";
+    let _broker = start_broker(&dir, cell_id);
+    let worker_id = register_worker(&dir, cell_id, "ack-worker", "tester");
+
+    // Send a message so there's a real message_id in history.
+    let send_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "send", "--to", &worker_id, "--body", "ack me", "--from", "harness",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let send_json: serde_json::Value = serde_json::from_slice(&send_out).unwrap();
+    let message_id = send_json["message_id"].as_str().unwrap().to_string();
+
+    let ack_out = dispatch_cmd(&dir, cell_id)
+        .args([
+            "ack",
+            "--worker-id",
+            &worker_id,
+            "--message-id",
+            &message_id,
+            "--note",
+            "starting impl",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&ack_out).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["message_id"], message_id);
+    assert_eq!(json["ack_confirmed"], true);
+}
+
+#[test]
+fn ack_command_rejects_unknown_message() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-ack-unknown";
+    let _broker = start_broker(&dir, cell_id);
+    let worker_id = register_worker(&dir, cell_id, "ack-unknown", "tester");
+
+    let output = dispatch_cmd(&dir, cell_id)
+        .args([
+            "ack",
+            "--worker-id",
+            &worker_id,
+            "--message-id",
+            "fabricated-message-id",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["status"], "error");
+    assert!(
+        json["message"]
+            .as_str()
+            .unwrap()
+            .contains("message not found"),
+        "expected message-not-found error, got: {json}"
+    );
+}
+
 // ── stdout/stderr separation ──────────────────────────────────────────
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -370,6 +370,86 @@ fn listen_times_out_with_no_messages() {
     );
 }
 
+// ── Stop-hook broker-liveness probe ───────────────────────────────────
+
+/// With the broker unreachable (env points at a nonexistent socket, no
+/// config in cwd), the stop hook must emit nothing and exit 0 — the
+/// vendor CLI treats empty stdout as "allow stop" so a shutting-down
+/// dispatch doesn't strand the agent in a listen loop.
+#[test]
+fn codex_hook_stop_is_silent_when_broker_unreachable() {
+    let dir = TempDir::new().unwrap();
+    let fake_socket = dir.path().join("does-not-exist.sock");
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("codex-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &fake_socket)
+        .env_remove("DISPATCH_CELL_ID")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout when broker unreachable, got: {stdout:?}",
+    );
+}
+
+#[test]
+fn claude_hook_stop_is_silent_when_broker_unreachable() {
+    let dir = TempDir::new().unwrap();
+    let fake_socket = dir.path().join("does-not-exist.sock");
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("claude-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &fake_socket)
+        .env_remove("DISPATCH_CELL_ID")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout when broker unreachable, got: {stdout:?}",
+    );
+}
+
+/// With a live broker, the stop hook prints the block-decision JSON so
+/// the agent keeps listening for the next dispatch message.
+#[test]
+fn codex_hook_stop_blocks_when_broker_alive() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-codex-hook-alive";
+    let _broker = start_broker(&dir, cell_id);
+    let socket =
+        std::path::PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"));
+
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("codex-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &socket)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("stop hook stdout should be JSON: {stdout:?}"));
+    assert_eq!(json["decision"], "block");
+    assert!(
+        json["reason"].as_str().is_some_and(|s| !s.is_empty()),
+        "block decision must carry a non-empty reason",
+    );
+}
+
 // ── stdout/stderr separation ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes the adapter + managed-lifecycle plan (`tasks/adapters_plan.md`, local-only) on top of the issue #25 introspection work. Big bundle; see below for what ships and the breaking change.

## What ships

### Adapter abstraction
- New `src/adapter/` module: `Adapter` enum + file-per-variant (`command.rs`, `claude.rs`, `codex.rs`) producing a typed `Launch` spec (program, argv, stdin hint).
- `[[agents]]` now requires `adapter = "command" | "claude" | "codex"` plus an optional `extra_args = [...]` appended to the adapter-assembled argv.
- Prompt files pipe as stdin for the `claude` and `codex` adapters — no more `< {prompt_file}` shell redirect.

### Agent lifecycle
- Per-agent `launch = true/false` (default false). `dispatch serve --launch` auto-spawns only `launch = true` agents; the rest are printed as copy-paste commands.
- `dispatch agent {start,stop,restart} <name|worker-id>` over the broker socket. Name and worker ID both accepted (broker resolves ID → name via registry).
- Supervisor-per-agent task that owns the child handle and re-spawns on exit with exponential backoff (1s → 30s cap). Five consecutive unstable failures mark the agent `crashed`; the counter resets once the agent has run for ≥ 30s.

### Vendor hooks
- `dispatch codex-hook {stop,install,uninstall}` — writes `.codex/hooks.json` + enables `features.codex_hooks` in `.codex/config.toml`, preserving unrelated config.
- `dispatch claude-hook {stop,install,uninstall}` — merges a Stop entry into `.claude/settings.json` (or `settings.local.json`), idempotent.
- Stop handler prints \`{\"decision\":\"block\",\"reason\":\"...\"}\` on stdout — the vendor CLI keeps the agent alive and points it back at \`dispatch listen\`.

### Monitor dashboard
- New \`GET /api/agents/state\` — live supervisor state per managed agent.
- Dashboard gains an agent cards grid with color-coded state pills (starting / running / restarting / crashed / stopped), PID, short worker ID, and backoff metadata for restarting agents.

### Introspection (issue #25 phase 1 + 2, carried forward)
- \`dispatch ack\`, \`dispatch status\` (with \`--clear\`), \`dispatch heartbeat --status\`, \`dispatch events\`, \`dispatch messages\`.
- Bounded event history (10k default) and message history with sent_at / delivered_at / acked_at timestamps.
- Monitor UI: events history drawer, messages tab, status taglines, ack-aware row colors.

### Docs
- README: agent lifecycle + vendor hooks command tables; Agent Orchestration section covering adapter schema, supervisor/backoff, and hook install.
- \`examples/dispatch-comms.md\` (auto-prepended to LLM prompts): new \"The listen loop\" section making the long-lived worker pattern explicit.

## Breaking change

\`[[agents]]\` entries now require \`adapter = \"...\"\`. The old \`command = \"...\"\` shell one-liner shape no longer parses — migrate existing configs (still works for \`adapter = \"command\"\`, where \`command\` stays required).

## Test plan

- [x] \`cargo fmt --check\`, \`cargo clippy -D warnings\`, \`cargo build --all-targets\`, \`cargo test\` (93 lib + 10 integration pass)
- [x] Adapter pipeline end-to-end in ai-barometer (4 agents spawned via codex/claude adapters, all registered)
- [ ] \`dispatch agent start/stop/restart\` via CLI + hook-aware listen loop for the \`implementer\` codex agent
- [ ] Dashboard cards reflect state transitions (start → running → crash → restarting → crashed) in real time
- [ ] \`dispatch {codex,claude}-hook install\` produces the expected files; \`uninstall\` removes cleanly without clobbering user settings

## Follow-ups (filing as separate issues)

- Interactive adapter mode + terminal launcher (tmux first)
- \`dispatch doctor\`
- \`dispatch serve --dry-run\`
- Agent groups (\`--group\`)