### PR TITLE
feat: phase 2 — close adapter-plan gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-worker status history on `Worker.status_history` — up to 3 most recent prior status entries (each `{status, set_at}`), oldest first. Updated automatically on `heartbeat --status <...>`; surfaced on `/api/team` so the dashboard can render a "prior statuses" strip next to the current tagline. Dedupes repeated same-status heartbeats; `dispatch status --clear` clears only the current entry and leaves history intact.
+
 ### Changed
 - `dispatch {codex,claude}-hook stop` now probes the broker socket before deciding. If the broker is reachable, it emits the block decision as before. If the socket is missing, refused, or times out (≤250ms), it exits 0 with empty stdout so the vendor CLI is free to stop the agent cleanly. Lets dispatch shut down without holding vendor agents hostage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `dispatch {codex,claude}-hook stop` now probes the broker socket before deciding. If the broker is reachable, it emits the block decision as before. If the socket is missing, refused, or times out (≤250ms), it exits 0 with empty stdout so the vendor CLI is free to stop the agent cleanly. Lets dispatch shut down without holding vendor agents hostage.
+
 ## [0.4.1] - 2026-04-19
 
 ### Added

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -550,7 +550,7 @@ pub fn now_secs() -> u64 {
 /// so no additional path components are needed. Using `/tmp` avoids the
 /// Unix domain socket `SUN_LEN` limit (104 bytes on macOS) that triggers
 /// when project paths are deeply nested.
-fn socket_path(_project_root: &Path, cell_id: &str) -> PathBuf {
+pub(crate) fn socket_path(_project_root: &Path, cell_id: &str) -> PathBuf {
     PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"))
 }
 

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -22,6 +22,12 @@ const DEFAULT_LISTEN_TIMEOUT_SECS: u64 = 30;
 /// Default maximum number of events retained in history.
 const DEFAULT_EVENT_HISTORY_MAX: usize = 10_000;
 
+/// How many *prior* status entries to keep per worker, on top of the
+/// current `last_status`. The dashboard's "previous statuses" strip shows
+/// up to two, so three total (current + two prior) with a bit of headroom
+/// feels right; bump later if the UI wants more.
+const STATUS_HISTORY_MAX: usize = 3;
+
 /// Event emitted by the broker for the monitor dashboard.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct BrokerEvent {
@@ -230,6 +236,7 @@ impl BrokerState {
             expires_at: now + ttl,
             last_status: None,
             last_status_at: None,
+            status_history: Vec::new(),
         };
         self.workers.insert(id.clone(), worker);
         id
@@ -267,19 +274,40 @@ impl BrokerState {
 
     /// Renew a worker's TTL and optionally update status.
     /// Returns the new expiry timestamp, or None if not found/expired.
+    ///
+    /// When `status` is `Some(...)` and differs from `last_status`, the prior
+    /// status (if any) is pushed onto `status_history` and the buffer is
+    /// truncated to `STATUS_HISTORY_MAX`. Setting the same status twice in
+    /// a row is a no-op for history so repeated heartbeats from a polling
+    /// loop don't poison the ring.
     pub fn heartbeat_worker(&mut self, worker_id: &str, status: Option<String>) -> Option<u64> {
         self.evict_expired();
-        if let Some(worker) = self.workers.get_mut(worker_id) {
-            let now = now_secs();
-            worker.expires_at = now + worker.ttl_secs;
-            if let Some(s) = status {
-                worker.last_status = Some(s);
+        let worker = self.workers.get_mut(worker_id)?;
+        let now = now_secs();
+        worker.expires_at = now + worker.ttl_secs;
+        if let Some(new_status) = status {
+            let unchanged = worker.last_status.as_deref() == Some(new_status.as_str());
+            if !unchanged {
+                if let (Some(prev_status), Some(prev_set_at)) =
+                    (worker.last_status.take(), worker.last_status_at)
+                {
+                    worker.status_history.push(crate::protocol::StatusEntry {
+                        status: prev_status,
+                        set_at: prev_set_at,
+                    });
+                    let len = worker.status_history.len();
+                    if len > STATUS_HISTORY_MAX {
+                        worker.status_history.drain(..len - STATUS_HISTORY_MAX);
+                    }
+                }
+                worker.last_status = Some(new_status);
+                worker.last_status_at = Some(now);
+            } else {
+                // Same status as before — just refresh the timestamp.
                 worker.last_status_at = Some(now);
             }
-            Some(worker.expires_at)
-        } else {
-            None
         }
+        Some(worker.expires_at)
     }
 
     /// Get status summaries for all active workers or a specific worker.
@@ -1760,6 +1788,99 @@ mod tests {
         assert!(
             state.heartbeat_worker(&id, None).is_none(),
             "heartbeat for expired worker should return None"
+        );
+    }
+
+    /// Helper: short-name worker registration for status-history tests.
+    fn register_simple(state: &mut BrokerState, name: &str) -> String {
+        state.register_worker(
+            name.into(),
+            "role".into(),
+            "desc".into(),
+            vec![],
+            None,
+            false,
+        )
+    }
+
+    #[test]
+    fn test_status_history_first_heartbeat_leaves_history_empty() {
+        let mut state = BrokerState::new();
+        let id = register_simple(&mut state, "hist-empty");
+        state
+            .heartbeat_worker(&id, Some("running tests 1/10".into()))
+            .unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.last_status.as_deref(), Some("running tests 1/10"));
+        assert!(
+            w.status_history.is_empty(),
+            "no prior status means history stays empty"
+        );
+    }
+
+    #[test]
+    fn test_status_history_retains_last_n_in_order() {
+        let mut state = BrokerState::new();
+        let id = register_simple(&mut state, "hist-ring");
+        for s in ["s1", "s2", "s3", "s4", "s5"] {
+            state.heartbeat_worker(&id, Some(s.into())).unwrap();
+        }
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.last_status.as_deref(), Some("s5"));
+        let prior: Vec<&str> = w.status_history.iter().map(|e| e.status.as_str()).collect();
+        assert_eq!(
+            prior,
+            vec!["s2", "s3", "s4"],
+            "ring keeps the most recent STATUS_HISTORY_MAX prior entries, oldest first"
+        );
+    }
+
+    #[test]
+    fn test_status_history_dedupes_same_status_in_a_row() {
+        let mut state = BrokerState::new();
+        let id = register_simple(&mut state, "hist-dedupe");
+        state.heartbeat_worker(&id, Some("working".into())).unwrap();
+        state.heartbeat_worker(&id, Some("working".into())).unwrap();
+        state.heartbeat_worker(&id, Some("working".into())).unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.last_status.as_deref(), Some("working"));
+        assert!(
+            w.status_history.is_empty(),
+            "same status repeated should not poison the ring"
+        );
+    }
+
+    #[test]
+    fn test_heartbeat_without_status_does_not_touch_history() {
+        let mut state = BrokerState::new();
+        let id = register_simple(&mut state, "hist-notouch");
+        state.heartbeat_worker(&id, Some("a".into())).unwrap();
+        state.heartbeat_worker(&id, Some("b".into())).unwrap();
+        // Several plain ttl heartbeats — must not shift history.
+        state.heartbeat_worker(&id, None).unwrap();
+        state.heartbeat_worker(&id, None).unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.last_status.as_deref(), Some("b"));
+        let prior: Vec<&str> = w.status_history.iter().map(|e| e.status.as_str()).collect();
+        assert_eq!(prior, vec!["a"]);
+    }
+
+    #[test]
+    fn test_clear_status_preserves_history() {
+        let mut state = BrokerState::new();
+        let id = register_simple(&mut state, "hist-clear");
+        state.heartbeat_worker(&id, Some("a".into())).unwrap();
+        state.heartbeat_worker(&id, Some("b".into())).unwrap();
+        state.heartbeat_worker(&id, Some("c".into())).unwrap();
+        state.clear_status(&id).unwrap();
+        let w = state.workers.get(&id).unwrap();
+        assert!(w.last_status.is_none());
+        assert!(w.last_status_at.is_none());
+        let prior: Vec<&str> = w.status_history.iter().map(|e| e.status.as_str()).collect();
+        assert_eq!(
+            prior,
+            vec!["a", "b"],
+            "clear_status clears current only; history remains for the card's prior-status strip"
         );
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -5,6 +5,16 @@
 //! the important one: by printing `{"decision":"block","reason":"..."}` on
 //! stdout we tell the agent to stay alive and keep polling dispatch for new
 //! messages instead of exiting at the end of a turn.
+//!
+//! The stop handler is broker-liveness-aware: if the socket is unreachable
+//! (dispatch is shutting down / was never started / the user exited serve),
+//! the hook emits nothing and exits 0 so the vendor CLI is free to stop the
+//! agent cleanly. Only a connectable broker earns the block decision.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::net::UnixStream;
 
 pub mod claude;
 pub mod codex;
@@ -16,6 +26,11 @@ pub mod codex;
 /// instruction rather than conversational text.
 pub const CONTINUE_REASON: &str = "The dispatch broker may still have work queued for you. Do not stop yet — call `dispatch listen` again with your registered worker_id and a timeout (e.g. 600) to wait for the next message. When a message arrives, process it and then return to this listen step.";
 
+/// Upper bound on how long the stop hook waits for a connect before giving
+/// up. Short enough that a dead broker doesn't stall the vendor CLI, long
+/// enough that an alive broker under light contention still answers.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+
 /// JSON body every stop hook emits on stdout. Both vendors accept this shape.
 pub fn stop_decision_json() -> String {
     serde_json::json!({
@@ -23,4 +38,111 @@ pub fn stop_decision_json() -> String {
         "reason": CONTINUE_REASON,
     })
     .to_string()
+}
+
+/// Resolve the broker socket path for the stop hook.
+///
+/// Precedence mirrors the regular CLI client:
+/// 1. `DISPATCH_SOCKET_PATH` env var — set by the orchestrator when it
+///    spawns managed agents, so hooks invoked from a managed vendor CLI
+///    always land on the right socket.
+/// 2. Config-derived default — find `dispatch.config.toml` from `cwd`,
+///    derive the cell ID, and compute the standard socket path. Covers
+///    hooks invoked from manually-launched (`launch = false`) agents that
+///    inherit the shell's env but not the orchestrator's.
+/// 3. `None` — caller treats as "broker unreachable" and allows the stop.
+pub fn resolve_socket_path(cwd: &Path) -> Option<PathBuf> {
+    if let Ok(explicit) = std::env::var("DISPATCH_SOCKET_PATH") {
+        return Some(PathBuf::from(explicit));
+    }
+    let (_, project_root) = crate::config::find_config_file(cwd)?;
+    let cell_id = crate::config::derive_cell_id(&project_root);
+    Some(crate::backend::local::socket_path(&project_root, &cell_id))
+}
+
+/// Check whether a dispatch broker is accepting connections at `path`.
+///
+/// Returns `true` only if a connect lands within `PROBE_TIMEOUT`. Every
+/// failure mode (`NotFound`, `ConnectionRefused`, timeout, permission
+/// denied, etc.) collapses to `false` — the stop hook treats any inability
+/// to reach the broker as "allow stop" so the vendor CLI isn't held hostage
+/// by a dead socket.
+pub async fn broker_is_alive(path: &Path) -> bool {
+    matches!(
+        tokio::time::timeout(PROBE_TIMEOUT, UnixStream::connect(path)).await,
+        Ok(Ok(_))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+
+    #[tokio::test]
+    async fn broker_is_alive_true_for_listening_socket() {
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp.path().join("alive.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        assert!(broker_is_alive(&sock).await);
+        drop(listener);
+    }
+
+    #[tokio::test]
+    async fn broker_is_alive_false_for_missing_socket() {
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp.path().join("nope.sock");
+        assert!(!broker_is_alive(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn broker_is_alive_false_after_listener_drops() {
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp.path().join("stale.sock");
+        {
+            let _listener = UnixListener::bind(&sock).unwrap();
+            // listener drops here; kernel refuses subsequent connects
+        }
+        assert!(!broker_is_alive(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn broker_is_alive_false_for_non_socket_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("just-a-file.txt");
+        std::fs::write(&path, b"not a socket").unwrap();
+        assert!(!broker_is_alive(&path).await);
+    }
+
+    #[test]
+    fn resolve_socket_path_prefers_env_var() {
+        let tmp = TempDir::new().unwrap();
+        let expected = tmp.path().join("override.sock");
+        // Env tests run serialised via the ENV_LOCK to keep concurrent test
+        // threads from clobbering each other's DISPATCH_SOCKET_PATH.
+        let _guard = env_lock();
+        std::env::set_var("DISPATCH_SOCKET_PATH", &expected);
+        let resolved = resolve_socket_path(tmp.path());
+        std::env::remove_var("DISPATCH_SOCKET_PATH");
+        assert_eq!(resolved, Some(expected));
+    }
+
+    #[test]
+    fn resolve_socket_path_returns_none_without_config_or_env() {
+        let tmp = TempDir::new().unwrap();
+        let _guard = env_lock();
+        std::env::remove_var("DISPATCH_SOCKET_PATH");
+        assert_eq!(resolve_socket_path(tmp.path()), None);
+    }
+
+    /// Serialise env-touching tests in this module so parallel threads
+    /// don't clobber each other's `DISPATCH_SOCKET_PATH`.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,14 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
         return Ok(());
     }
 
-    // Hook subcommands are local file operations / stdout — no broker, no config.
+    // Hook subcommands don't go through the broker as a client; the Stop
+    // handler probes the socket directly so it can fall back to "allow stop"
+    // when the broker is unreachable.
     if let Commands::CodexHook { action } = &cli.command {
-        return run_codex_hook(action, &cwd);
+        return run_codex_hook(action, &cwd).await;
     }
     if let Commands::ClaudeHook { action } = &cli.command {
-        return run_claude_hook(action, &cwd);
+        return run_claude_hook(action, &cwd).await;
     }
 
     let config = resolve_config(cli.cell_id.as_deref(), cli.config.as_deref(), &cwd)?;
@@ -217,45 +219,79 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
     Ok(())
 }
 
-fn run_codex_hook(
+async fn run_codex_hook(
     action: &HookAction,
     cwd: &std::path::Path,
 ) -> Result<(), dispatch::errors::DispatchError> {
     match action {
-        HookAction::Stop => {
-            println!("{}", hooks::stop_decision_json());
-        }
+        HookAction::Stop => run_stop_hook("codex-hook", cwd).await,
         HookAction::Install => {
             let path = hooks::codex::install(cwd)?;
             eprintln!(
                 "installed codex hook at {}\nensure features.codex_hooks = true is set in .codex/config.toml (already added if missing)",
                 path.display()
             );
+            Ok(())
         }
-        HookAction::Uninstall => match hooks::codex::uninstall(cwd)? {
-            Some(path) => eprintln!("removed {}", path.display()),
-            None => eprintln!("no codex hook installed"),
-        },
+        HookAction::Uninstall => {
+            match hooks::codex::uninstall(cwd)? {
+                Some(path) => eprintln!("removed {}", path.display()),
+                None => eprintln!("no codex hook installed"),
+            }
+            Ok(())
+        }
     }
-    Ok(())
 }
 
-fn run_claude_hook(
+async fn run_claude_hook(
     action: &HookAction,
     cwd: &std::path::Path,
 ) -> Result<(), dispatch::errors::DispatchError> {
     match action {
-        HookAction::Stop => {
-            println!("{}", hooks::stop_decision_json());
-        }
+        HookAction::Stop => run_stop_hook("claude-hook", cwd).await,
         HookAction::Install => {
             let path = hooks::claude::install(cwd)?;
             eprintln!("installed claude hook at {}", path.display());
+            Ok(())
         }
-        HookAction::Uninstall => match hooks::claude::uninstall(cwd)? {
-            Some(path) => eprintln!("removed entry from {}", path.display()),
-            None => eprintln!("no claude hook installed"),
-        },
+        HookAction::Uninstall => {
+            match hooks::claude::uninstall(cwd)? {
+                Some(path) => eprintln!("removed entry from {}", path.display()),
+                None => eprintln!("no claude hook installed"),
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Stop-hook body shared by both vendor handlers.
+///
+/// Probes the broker socket (env var or config-derived); prints the block
+/// JSON only when the broker answers. A missing / refused / timed-out
+/// socket means dispatch isn't available to do anything with this agent, so
+/// we emit nothing and let the vendor CLI stop the agent cleanly.
+async fn run_stop_hook(
+    kind: &'static str,
+    cwd: &std::path::Path,
+) -> Result<(), dispatch::errors::DispatchError> {
+    let socket = hooks::resolve_socket_path(cwd);
+    let alive = match socket.as_deref() {
+        Some(path) => hooks::broker_is_alive(path).await,
+        None => false,
+    };
+    if alive {
+        tracing::debug!(
+            hook = kind,
+            socket = ?socket,
+            "stop hook: broker alive, blocking stop"
+        );
+        println!("{}", hooks::stop_decision_json());
+    } else {
+        tracing::debug!(
+            hook = kind,
+            socket = ?socket,
+            "stop hook: broker unreachable, allowing stop"
+        );
     }
     Ok(())
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -131,6 +131,18 @@ pub enum BrokerResponse {
     Error { message: String },
 }
 
+/// One entry in a worker's status history.
+///
+/// Captured when `heartbeat --status <...>` mutates `last_status`. Newest
+/// entry lives on `Worker.last_status` / `last_status_at`; the last two
+/// prior entries (oldest first) are held in `Worker.status_history` for
+/// the dashboard's "previous statuses" strip.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusEntry {
+    pub status: String,
+    pub set_at: u64,
+}
+
 /// A registered worker in the broker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Worker {
@@ -152,6 +164,12 @@ pub struct Worker {
     /// Unix timestamp when `last_status` was last set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_status_at: Option<u64>,
+    /// Prior status entries (oldest first), excluding the current
+    /// `last_status`. Bounded to the most recent N prior entries — see
+    /// `BrokerState::STATUS_HISTORY_MAX`. Elided when empty so older
+    /// clients parsing a response without this field stay compatible.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status_history: Vec<StatusEntry>,
 }
 
 /// The payload inside a successful response, varies by request type.
@@ -270,8 +288,12 @@ mod tests {
                     capabilities: vec![],
                     ttl_secs: 300,
                     expires_at: 1000,
-                    last_status: None,
-                    last_status_at: None,
+                    last_status: Some("running".into()),
+                    last_status_at: Some(900),
+                    status_history: vec![StatusEntry {
+                        status: "starting".into(),
+                        set_at: 800,
+                    }],
                 }],
             },
             ResponsePayload::HeartbeatAck {
@@ -300,6 +322,46 @@ mod tests {
                 serde_json::to_value(&back).unwrap(),
             );
         }
+    }
+
+    /// Worker.status_history round-trips through JSON and survives empty
+    /// payloads from older brokers (skip-if-empty + #[serde(default)]).
+    #[test]
+    fn worker_status_history_round_trip() {
+        let full = Worker {
+            id: "w1".into(),
+            name: "n".into(),
+            role: "r".into(),
+            description: "d".into(),
+            capabilities: vec![],
+            ttl_secs: 60,
+            expires_at: 10_000,
+            last_status: Some("current".into()),
+            last_status_at: Some(9_999),
+            status_history: vec![
+                StatusEntry {
+                    status: "earlier".into(),
+                    set_at: 9_990,
+                },
+                StatusEntry {
+                    status: "even-earlier".into(),
+                    set_at: 9_980,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&full).unwrap();
+        assert!(
+            json.contains("\"status_history\""),
+            "non-empty history must be present on the wire: {json}"
+        );
+        let back: Worker = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.status_history, full.status_history);
+
+        // An older broker's response without the field must still deserialize.
+        let legacy_json = r#"{"id":"w1","name":"n","role":"r","description":"d","capabilities":[],"ttl_secs":60,"expires_at":10000}"#;
+        let legacy: Worker = serde_json::from_str(legacy_json).unwrap();
+        assert!(legacy.status_history.is_empty());
+        assert!(legacy.last_status.is_none());
     }
 
     /// BrokerResponse::Error round-trips correctly.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -370,6 +370,91 @@ fn listen_times_out_with_no_messages() {
     );
 }
 
+// ── Stop-hook broker-liveness probe ───────────────────────────────────
+
+/// With no broker reachable (env points at a nonexistent socket and no
+/// config in cwd), the stop hook must emit nothing and exit 0 — the vendor
+/// CLI treats empty stdout as "allow stop".
+#[test]
+fn codex_hook_stop_is_silent_when_broker_unreachable() {
+    let dir = TempDir::new().unwrap();
+    let fake_socket = dir.path().join("does-not-exist.sock");
+
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("codex-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &fake_socket)
+        .env_remove("DISPATCH_CELL_ID")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout when broker unreachable, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn claude_hook_stop_is_silent_when_broker_unreachable() {
+    let dir = TempDir::new().unwrap();
+    let fake_socket = dir.path().join("does-not-exist.sock");
+
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("claude-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &fake_socket)
+        .env_remove("DISPATCH_CELL_ID")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty stdout when broker unreachable, got: {stdout:?}"
+    );
+}
+
+/// With a live broker socket (env var points at it), the stop hook must
+/// print the block-decision JSON so the agent stays alive for the next
+/// dispatch message.
+#[test]
+fn codex_hook_stop_blocks_when_broker_alive() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-codex-hook-alive";
+    let _broker = start_broker(&dir, cell_id);
+    let socket =
+        std::path::PathBuf::from("/tmp/dispatch-cli/sockets").join(format!("{cell_id}.sock"));
+
+    let output = assert_cmd::Command::cargo_bin("dispatch")
+        .unwrap()
+        .arg("codex-hook")
+        .arg("stop")
+        .current_dir(dir.path())
+        .env("DISPATCH_SOCKET_PATH", &socket)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("stop hook stdout should be JSON: {stdout:?}"));
+    assert_eq!(json["decision"], "block");
+    assert!(
+        json["reason"].as_str().is_some_and(|s| !s.is_empty()),
+        "block decision must carry a non-empty reason"
+    );
+}
+
 // ── stdout/stderr separation ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Phase 2 of `tasks/adapters_plan.md` — closing the three material gaps flagged in the Phase 1 (PR #28) audit. One PR; each item is its own commit so pieces can be reviewed in isolation.

Base is `feat/adapters` so the diff stays focused on Phase 2. Will retarget to `main` once PR #28 merges.

## Scope (out, confirmed)

- No events drawer; events stays as a sidebar nav item.
- Stability-window reset stays at 30s (no change to the plan's old 60s).
- `/api/agents/state` stays polled every 2s; no SSE upgrade.

## Checklist

- [x] **1. Hook broker-liveness probe** — `9abd48d`
  - `dispatch {codex,claude}-hook stop` probes the socket (≤250 ms); emits the block decision only when the broker answers. On NotFound / ConnectionRefused / timeout it exits 0 with empty stdout so the vendor CLI is free to stop the agent cleanly.
  - Socket resolution mirrors the regular CLI client: `DISPATCH_SOCKET_PATH` env → `find_config_file` → `derive_cell_id` → standard socket path → None.
  - `tracing::debug` on both branches for troubleshooting.
  - Tests: `broker_is_alive` against live / missing / dropped / non-socket paths; `resolve_socket_path` env precedence; end-to-end `codex-hook stop` + `claude-hook stop` through the real binary covering both branches.
- [x] **2. Status history retention** — `ec305fd`
  - `Worker.status_history: Vec<StatusEntry>` on the wire, oldest-first, bounded to `STATUS_HISTORY_MAX = 3` prior entries.
  - Populated from `heartbeat --status`; same-status-twice dedupes; TTL-only heartbeats leave history untouched; `clear_status` clears current only, preserving history.
  - Field is `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so old brokers' payloads still parse and empty histories don't bloat the wire.
  - Tests: empty-on-first, 5-distinct → last-3-prior ring, dedupe, TTL-only no-op, `clear_status` preservation, JSON round-trip + legacy-payload parse.
- [ ] **3. Card action endpoints + `started_at`**
  - `started_at: u64` on `AgentState::Running` so the UI can tick uptime client-side.
  - `POST /api/agents/{name}/{start|stop|restart}` on the monitor, forwarding into the orchestrator via the existing `Arc<Mutex<AgentOrchestrator>>` handle. Keeps the UI pure HTTP.
  - 200 on success, 4xx on "no such agent", ack JSON on response.
- [ ] **4. Expanded agent cards**
  - Two-row card layout: header (name + role + adapter badge + state pill) / body (status block, meta, actions).
  - Current status tagline (large) + last 2 prior statuses (faded, from the new ring buffer).
  - Uptime from `started_at`; heartbeat age derived from `Worker.expires_at - ttl_secs`. Client-side ticker matches the existing `tickUI` pattern.
  - Start / Stop / Restart buttons gated by state; "Copy command" icon for `launch = false`.
  - Buttons disabled while their request is in flight; toast on failure.

## Test plan

- [x] `cargo test` passes on every commit
- [x] `dispatch codex-hook stop` prints block JSON when broker alive, nothing when dead
- [x] Status history round-trips through the protocol + survives legacy payloads; reflects correctly across dedupe / TTL-only / clear scenarios
- [ ] Status history renders on the dashboard via `/api/team`
- [ ] `POST /api/agents/{name}/start` spawns the agent; `stop` signals shutdown; `restart` stops then spawns
- [ ] Card uptime ticks every second even while the 2s poll is idle
- [ ] Card heartbeat age shows "just now" / "4s ago" / "2m ago" correctly
- [ ] `launch = false` agent card exposes a copy-command action; clicking copies to clipboard
- [ ] Full listen → message → ack cycle still works end-to-end on ai-barometer after all items land