### PR TITLE
feat(#43): pre-register agents to eliminate register hallucination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-21
+
+### Added
+- Dispatch now pre-registers `launch = true` agents with a `prompt_file` server-side at spawn time, injects `DISPATCH_WORKER_ID` into the agent's environment, and feeds the model a one-line boot prompt (`Run: dispatch register --worker-id "$DISPATCH_WORKER_ID" ... --for-agent`). The model's first observable action is a real tool call by construction — eliminates a class of hallucination where agents skipped `dispatch register` and emitted fabricated status messages (issue #43).
+- `BrokerRequest::Register` accepts `worker_id: Option<String>` and `role_prompt: Option<String>`. Re-registering an existing id with a matching name+role is an idempotent claim (same id returned, TTL renewed); a mismatched claim is rejected. The broker stores the supplied prompt keyed by worker id and returns it in the `WorkerRegistered` response so a spawned agent can fetch its role prompt as its first tool result.
+- `dispatch register --worker-id <id>` — CLI flag for claiming a pre-assigned worker id.
+- `dispatch register --role-prompt <body>` — CLI flag used by the orchestrator to ship prompt content into the broker.
+- `dispatch register --for-agent` — routes the role prompt body to stdout and the JSON envelope to stderr. Exits nonzero when no prompt is stored so the supervisor can restart.
+- `stream_json = true` on `[[agents]]` entries — launches the claude adapter with `--output-format stream-json --verbose` so per-tool-use entries appear in the agent log. Verification mechanism for the pre-register work: without it, hallucinated and real `dispatch register` calls are indistinguishable in the log.
+- Supervisor re-registers managed workers on every respawn (idempotent claim renews TTL, fresh-creates if the record was garbage-collected during downtime).
+
+### Changed
+- `launch = false` agents are unchanged — they continue to register themselves via the legacy stdin-pipe flow. The new pre-register machinery is opt-in via `launch = true` + a configured `prompt_file`.
+- `examples/dispatch-comms.md` splits the "Register yourself" guidance into managed (`$DISPATCH_WORKER_ID` present → claim with `--for-agent`) and unmanaged (legacy self-register) sections.
+
 ## [0.4.1] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/examples/dispatch-comms.md
+++ b/examples/dispatch-comms.md
@@ -19,7 +19,23 @@ A vendor Stop hook may also remind you to keep listening by injecting a "do not 
 
 ## Register yourself
 
-Before you can send or receive messages, register with the broker:
+Before you can send or receive messages, register with the broker. There are two modes depending on how you were started.
+
+### Managed agents (dispatch spawned you)
+
+If `$DISPATCH_WORKER_ID` is set in your environment, dispatch pre-registered a worker for you and stored your role prompt under that id. Claim it:
+
+```bash
+dispatch register --worker-id "$DISPATCH_WORKER_ID" \
+  --name "$DISPATCH_AGENT_NAME" --role "$DISPATCH_AGENT_ROLE" \
+  --description "<what you do>" --for-agent
+```
+
+The `--for-agent` flag prints your role prompt body to stdout (so it lands in your tool result as your next set of instructions). The `worker_id` returned matches `$DISPATCH_WORKER_ID` — keep using it for all subsequent commands.
+
+### Unmanaged agents (you were launched manually)
+
+If `$DISPATCH_WORKER_ID` is unset, you're responsible for picking your own identity:
 
 ```bash
 dispatch register --name <YOUR_NAME> --role <YOUR_ROLE> \

--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -3,11 +3,23 @@
 //! Assembles `claude [extra_args...] -p` and feeds the prompt via stdin from
 //! `prompt_file`. Non-interactive (`-p`) mode only; interactive support is a
 //! follow-up.
+//!
+//! Issue #43: when `stream_json` is set, appends
+//! `--output-format stream-json --verbose` so per-tool-use entries appear
+//! in the agent log. Required because claude's default `-p` output only
+//! shows the final assistant message — making a hallucinated `dispatch
+//! register` call visually identical to a real one in the log.
 
 use super::{AdapterError, BuildContext, Launch};
 
 pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
     let mut args: Vec<String> = ctx.extra_args.to_vec();
+    if ctx.stream_json {
+        // Claude Code requires --verbose when combining -p with stream-json.
+        args.push("--output-format".to_string());
+        args.push("stream-json".to_string());
+        args.push("--verbose".to_string());
+    }
     args.push("-p".to_string());
 
     Ok(Launch {
@@ -29,7 +41,14 @@ mod tests {
             prompt_file,
             prompt_inline: None,
             command_string: None,
+            stream_json: false,
         }
+    }
+
+    fn ctx_stream<'a>(extras: &'a [String], prompt_file: Option<&'a Path>) -> BuildContext<'a> {
+        let mut c = ctx(extras, prompt_file);
+        c.stream_json = true;
+        c
     }
 
     #[test]
@@ -55,5 +74,48 @@ mod tests {
         let launch = Adapter::Claude.build(&ctx(&[], Some(prompt))).unwrap();
         assert_eq!(launch.args, vec!["-p"]);
         assert_eq!(launch.stdin_file.as_deref(), Some(prompt));
+    }
+
+    /// Issue #43: when stream_json is set, claude is launched with
+    /// `--output-format stream-json --verbose -p` so per-tool-use entries
+    /// appear in the agent log (the verification mechanism for whether
+    /// pre-register actually fixed the hallucination).
+    #[test]
+    fn stream_json_appends_output_format_and_verbose() {
+        let launch = Adapter::Claude.build(&ctx_stream(&[], None)).unwrap();
+        assert_eq!(
+            launch.args,
+            vec!["--output-format", "stream-json", "--verbose", "-p"],
+            "stream_json must add --output-format stream-json --verbose before -p",
+        );
+    }
+
+    /// Default off: stream_json=false preserves the legacy argv shape
+    /// bit-for-bit, so users not opted in see no log change.
+    #[test]
+    fn stream_json_off_preserves_legacy_argv() {
+        let extras = vec!["--model".to_string(), "sonnet".to_string()];
+        let launch = Adapter::Claude.build(&ctx(&extras, None)).unwrap();
+        assert_eq!(launch.args, vec!["--model", "sonnet", "-p"]);
+    }
+
+    /// User extra_args still come first; stream-json flags slot between
+    /// them and `-p`. Keeps user-supplied --model / etc. consistent with
+    /// the legacy argv.
+    #[test]
+    fn stream_json_preserves_extra_args_order() {
+        let extras = vec!["--model".to_string(), "sonnet".to_string()];
+        let launch = Adapter::Claude.build(&ctx_stream(&extras, None)).unwrap();
+        assert_eq!(
+            launch.args,
+            vec![
+                "--model",
+                "sonnet",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "-p",
+            ],
+        );
     }
 }

--- a/src/adapter/codex.rs
+++ b/src/adapter/codex.rs
@@ -29,6 +29,7 @@ mod tests {
             prompt_file,
             prompt_inline: None,
             command_string: None,
+            stream_json: false,
         }
     }
 

--- a/src/adapter/command.rs
+++ b/src/adapter/command.rs
@@ -59,6 +59,7 @@ mod tests {
             prompt_file: None,
             prompt_inline: None,
             command_string: command,
+            stream_json: false,
         }
     }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -47,6 +47,10 @@ pub struct BuildContext<'a> {
     pub prompt_inline: Option<&'a str>,
     /// Full shell command — only used by the `command` adapter.
     pub command_string: Option<&'a str>,
+    /// Issue #43: when true, the claude adapter appends
+    /// `--output-format stream-json --verbose` so per-tool-use entries
+    /// appear in the agent log. Other adapters ignore this flag.
+    pub stream_json: bool,
 }
 
 /// The result of an adapter building a launch specification.

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -757,8 +757,12 @@ pub async fn serve(
     if !manual.is_empty() {
         eprintln!("\ndispatch serve: ready. Unmanaged agents — run these in separate terminals:\n");
         for agent in &manual {
-            let cmd =
-                super::orchestrator::build_agent_command(agent, cell_id, monitor_url.as_deref());
+            let cmd = super::orchestrator::build_agent_command(
+                agent,
+                cell_id,
+                monitor_url.as_deref(),
+                None,
+            );
             eprintln!("  # {} ({})", agent.name, agent.role);
             eprintln!("  {cmd}\n");
         }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -248,6 +248,15 @@ impl BrokerState {
                     let ttl = ttl_secs.unwrap_or(self.default_ttl);
                     existing.ttl_secs = ttl;
                     existing.expires_at = now_secs() + ttl;
+                    // Refresh mutable metadata so a re-register with updated
+                    // config values isn't silently dropped. `capabilities` is
+                    // only overwritten when non-empty — agent-side claims pass
+                    // an empty vec and must not erase what the orchestrator
+                    // registered.
+                    existing.description = description;
+                    if !capabilities.is_empty() {
+                        existing.capabilities = capabilities;
+                    }
                     let id = supplied.clone();
                     // Only overwrite the stored prompt if the caller supplied
                     // one — agent claims pass `None` and must not erase what
@@ -272,10 +281,7 @@ impl BrokerState {
                 .map(|(id, _)| id.clone())
                 .collect();
             for old_id in &old_ids {
-                self.workers.remove(old_id);
-                self.mailboxes.remove(old_id);
-                self.notifiers.remove(old_id);
-                self.role_prompts.remove(old_id);
+                self.remove_worker(old_id);
             }
         }
 
@@ -301,6 +307,18 @@ impl BrokerState {
         Ok(id)
     }
 
+    /// Remove a worker and all per-worker state (mailbox, notifier, role
+    /// prompt). Callers should route every worker removal through this so
+    /// the broker never retains partial state for a worker that no longer
+    /// exists — an invariant the issue-#43 pre-register cleanup path relies
+    /// on.
+    pub fn remove_worker(&mut self, id: &str) {
+        self.workers.remove(id);
+        self.mailboxes.remove(id);
+        self.notifiers.remove(id);
+        self.role_prompts.remove(id);
+    }
+
     /// Remove workers whose TTL has expired, including their mailboxes and notifiers.
     /// Returns `(id, name)` pairs for the evicted workers so callers can populate
     /// expire events with the worker's name (which is otherwise lost on removal).
@@ -313,10 +331,7 @@ impl BrokerState {
             .map(|(id, w)| (id.clone(), w.name.clone()))
             .collect();
         for (id, _) in &expired {
-            self.workers.remove(id);
-            self.mailboxes.remove(id);
-            self.notifiers.remove(id);
-            self.role_prompts.remove(id);
+            self.remove_worker(id);
         }
         expired
     }
@@ -1714,6 +1729,68 @@ mod tests {
         assert!(
             state.workers.get(&id).unwrap().expires_at > 0,
             "claim should renew TTL",
+        );
+    }
+
+    /// Issue #43: an idempotent claim with updated `description` /
+    /// `capabilities` must refresh the stored worker record so `dispatch
+    /// team` reflects current config — stale metadata from the initial
+    /// pre-register otherwise lingers. Empty capabilities (agent-side
+    /// claim shape) must NOT clobber the stored list.
+    #[test]
+    fn test_register_worker_idempotent_claim_updates_metadata() {
+        let mut state = BrokerState::new();
+        let id = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "original description".into(),
+                vec!["cap-a".into(), "cap-b".into()],
+                None,
+                false,
+                Some("w-fixed".into()),
+                None,
+            )
+            .expect("first register");
+
+        // Re-register with a new description and fresh capabilities —
+        // both must flow through to the stored worker.
+        state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "updated description".into(),
+                vec!["cap-c".into()],
+                None,
+                false,
+                Some("w-fixed".into()),
+                None,
+            )
+            .expect("claim with updated metadata");
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.description, "updated description");
+        assert_eq!(w.capabilities, vec!["cap-c".to_string()]);
+
+        // Agent-style claim with empty capabilities must preserve the
+        // existing list rather than blanking it.
+        state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "third description".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+                None,
+            )
+            .expect("agent-style claim");
+        let w = state.workers.get(&id).unwrap();
+        assert_eq!(w.description, "third description");
+        assert_eq!(
+            w.capabilities,
+            vec!["cap-c".to_string()],
+            "empty capabilities must not wipe stored list",
         );
     }
 

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -197,6 +197,21 @@ impl BrokerState {
     /// If `evict` is true and a worker with the same name already exists, the
     /// old registration is removed (including its mailbox and notifier) before
     /// the new one is created.
+    ///
+    /// If `worker_id` is `Some(id)` (issue #43 pre-register flow):
+    /// - When the id already exists with the same name+role, this is treated
+    ///   as an idempotent claim — the existing id is returned and TTL is
+    ///   renewed. This lets dispatch pre-register a worker server-side and
+    ///   the spawned agent then call `dispatch register` to fetch its prompt
+    ///   without creating a duplicate worker record.
+    /// - When the id already exists with a different name or role, the call
+    ///   is rejected with an error (config drift / collision).
+    /// - Otherwise, the supplied id is used verbatim.
+    ///
+    /// If `worker_id` is `None`, a fresh UUID is generated (legacy behavior).
+    // Splitting these into a struct buys nothing — every caller passes them
+    // positionally and clippy's 7-arg threshold is an arbitrary heuristic.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_worker(
         &mut self,
         name: String,
@@ -205,7 +220,28 @@ impl BrokerState {
         capabilities: Vec<String>,
         ttl_secs: Option<u64>,
         evict: bool,
-    ) -> String {
+        worker_id: Option<String>,
+    ) -> Result<String, String> {
+        // Idempotent-claim short-circuit: if the supplied id already exists
+        // and matches name+role, return it (and renew TTL) without touching
+        // the rest of the state. This must run BEFORE the evict pass so that
+        // a pre-registered worker can be claimed by its agent without being
+        // wiped by a same-name evict.
+        if let Some(ref supplied) = worker_id {
+            if let Some(existing) = self.workers.get_mut(supplied) {
+                if existing.name == name && existing.role == role {
+                    let ttl = ttl_secs.unwrap_or(self.default_ttl);
+                    existing.ttl_secs = ttl;
+                    existing.expires_at = now_secs() + ttl;
+                    return Ok(supplied.clone());
+                }
+                return Err(format!(
+                    "worker_id {supplied} already registered as {}/{} -- supplied {name}/{role} does not match",
+                    existing.name, existing.role,
+                ));
+            }
+        }
+
         if evict {
             let old_ids: Vec<String> = self
                 .workers
@@ -220,7 +256,7 @@ impl BrokerState {
             }
         }
 
-        let id = uuid::Uuid::new_v4().to_string();
+        let id = worker_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let now = now_secs();
         let ttl = ttl_secs.unwrap_or(self.default_ttl);
         let worker = Worker {
@@ -236,7 +272,7 @@ impl BrokerState {
             status_history: VecDeque::new(),
         };
         self.workers.insert(id.clone(), worker);
-        id
+        Ok(id)
     }
 
     /// Remove workers whose TTL has expired, including their mailboxes and notifiers.
@@ -895,16 +931,24 @@ async fn handle_request(
             capabilities,
             ttl_secs,
             evict,
+            worker_id,
         } => {
             let mut state = state.lock().await;
-            let worker_id = state.register_worker(
+            let worker_id = match state.register_worker(
                 name.clone(),
                 role.clone(),
                 description,
                 capabilities,
                 ttl_secs,
                 evict,
-            );
+                worker_id,
+            ) {
+                Ok(id) => id,
+                Err(message) => {
+                    tracing::warn!(%message, "register rejected");
+                    return BrokerResponse::Error { message };
+                }
+            };
             tracing::info!(worker_id = %worker_id, "worker registered");
             state.emit_and_record(
                 event_tx,
@@ -1576,25 +1620,159 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
+    /// Issue #43: when an id is supplied, the broker uses it verbatim.
+    #[test]
+    fn test_register_worker_uses_supplied_id() {
+        let mut state = BrokerState::new();
+        let id = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect("register");
+        assert_eq!(id, "w-fixed");
+        assert!(state.workers.contains_key("w-fixed"));
+    }
+
+    /// Issue #43: re-registering an existing id with the same name+role is an
+    /// idempotent claim — same id returned, no duplicate worker, TTL renewed.
+    #[test]
+    fn test_register_worker_idempotent_claim_renews_ttl() {
+        let mut state = BrokerState::new();
+        let id = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                Some(60),
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect("first register");
+        // Force the expiry into the past so we can detect the renewal.
+        state.workers.get_mut(&id).unwrap().expires_at = 0;
+
+        let id2 = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                Some(60),
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect("idempotent claim");
+        assert_eq!(id, id2);
+        assert_eq!(state.workers.len(), 1, "no duplicate worker created");
+        assert!(
+            state.workers.get(&id).unwrap().expires_at > 0,
+            "claim should renew TTL",
+        );
+    }
+
+    /// Issue #43: re-registering an existing id with a *different* name or
+    /// role is rejected — silent overwriting would mask config drift.
+    #[test]
+    fn test_register_worker_collision_rejected() {
+        let mut state = BrokerState::new();
+        state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect("first register");
+        let err = state
+            .register_worker(
+                "bob".into(),
+                "reviewer".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect_err("collision must be rejected");
+        assert!(
+            err.contains("w-fixed"),
+            "error should name the colliding id: {err}"
+        );
+        assert!(
+            err.contains("alice"),
+            "error should name the existing worker: {err}"
+        );
+        // The original worker is still there, untouched.
+        assert_eq!(state.workers.len(), 1);
+        assert_eq!(state.workers.get("w-fixed").unwrap().name, "alice");
+    }
+
+    /// Idempotent claim runs BEFORE evict, so a same-name evict cannot wipe a
+    /// pre-registered worker that an agent is about to claim.
+    #[test]
+    fn test_register_worker_claim_beats_evict() {
+        let mut state = BrokerState::new();
+        let id = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+            )
+            .expect("pre-register");
+        let claimed = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                true, // evict
+                Some("w-fixed".into()),
+            )
+            .expect("claim should win over evict");
+        assert_eq!(id, claimed);
+        assert_eq!(state.workers.len(), 1);
+    }
+
     #[test]
     fn test_register_worker_returns_unique_ids() {
         let mut state = BrokerState::new();
-        let id1 = state.register_worker(
-            "worker-a".into(),
-            "planner".into(),
-            "Plans things".into(),
-            vec!["plan:create plans".into()],
-            None,
-            false,
-        );
-        let id2 = state.register_worker(
-            "worker-b".into(),
-            "coder".into(),
-            "Writes code".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id1 = state
+            .register_worker(
+                "worker-a".into(),
+                "planner".into(),
+                "Plans things".into(),
+                vec!["plan:create plans".into()],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
+        let id2 = state
+            .register_worker(
+                "worker-b".into(),
+                "coder".into(),
+                "Writes code".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         assert_ne!(id1, id2, "each registration must produce a unique ID");
         assert_eq!(state.workers.len(), 2);
     }
@@ -1602,14 +1780,17 @@ mod tests {
     #[test]
     fn test_register_worker_stores_fields() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "my-worker".into(),
-            "reviewer".into(),
-            "Reviews pull requests".into(),
-            vec!["review:code".into(), "review:docs".into()],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "my-worker".into(),
+                "reviewer".into(),
+                "Reviews pull requests".into(),
+                vec!["review:code".into(), "review:docs".into()],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let worker = state.workers.get(&id).unwrap();
         assert_eq!(worker.name, "my-worker");
         assert_eq!(worker.role, "reviewer");
@@ -1625,14 +1806,17 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let id = state.register_worker(
-            "ttl-worker".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "ttl-worker".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let worker = state.workers.get(&id).unwrap();
         // Should expire roughly DEFAULT_WORKER_TTL_SECS from now.
         assert!(worker.expires_at >= now + DEFAULT_WORKER_TTL_SECS - 1);
@@ -1642,14 +1826,17 @@ mod tests {
     #[test]
     fn test_evict_expired_workers() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "soon-expired".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "soon-expired".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         // Manually set expiry to the past.
         state.workers.get_mut(&id).unwrap().expires_at = 0;
         state.evict_expired();
@@ -1774,22 +1961,28 @@ mod tests {
     #[test]
     fn test_list_workers_excludes_expired() {
         let mut state = BrokerState::new();
-        let active_id = state.register_worker(
-            "active".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
-        let expired_id = state.register_worker(
-            "expired".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let active_id = state
+            .register_worker(
+                "active".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
+        let expired_id = state
+            .register_worker(
+                "expired".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         // Expire one worker.
         state.workers.get_mut(&expired_id).unwrap().expires_at = 0;
 
@@ -1801,14 +1994,17 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_renews_ttl() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "hb-worker".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "hb-worker".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let original_expiry = state.workers.get(&id).unwrap().expires_at;
 
         // Manually lower the expiry to simulate time passing.
@@ -1830,14 +2026,17 @@ mod tests {
     #[test]
     fn test_heartbeat_worker_expired() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "exp-worker".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "exp-worker".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         state.workers.get_mut(&id).unwrap().expires_at = 0;
 
         assert!(
@@ -1852,14 +2051,17 @@ mod tests {
     #[test]
     fn test_status_history_caps_at_max() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "hist".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "hist".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         for s in ["A", "B", "C", "D", "E"] {
             state.heartbeat_worker(&id, Some(s.into())).unwrap();
         }
@@ -1876,14 +2078,17 @@ mod tests {
     #[test]
     fn test_status_history_dedupes_consecutive_repeats() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "dedup".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "dedup".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         state.heartbeat_worker(&id, Some("running".into())).unwrap();
         let first_at = state.workers.get(&id).unwrap().last_status_at;
         // Same status again — should not push, should not bump last_status_at.
@@ -1905,14 +2110,17 @@ mod tests {
     #[test]
     fn test_clear_status_preserves_history() {
         let mut state = BrokerState::new();
-        let id = state.register_worker(
-            "clr".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let id = state
+            .register_worker(
+                "clr".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         state.heartbeat_worker(&id, Some("phase 1".into())).unwrap();
         state.heartbeat_worker(&id, Some("phase 2".into())).unwrap();
         state.clear_status(&id).unwrap();
@@ -2028,14 +2236,17 @@ mod tests {
     #[test]
     fn test_send_message_queues_in_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
 
         let msg_id = state.send_message(worker_id.clone(), "hello".into(), Some("sender-1".into()));
         assert!(msg_id.is_some(), "send_message should return a message ID");
@@ -2059,14 +2270,17 @@ mod tests {
     #[test]
     fn test_send_message_expired_recipient() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "expiring".into(),
-            "role".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "expiring".into(),
+                "role".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         state.workers.get_mut(&worker_id).unwrap().expires_at = 0;
 
         let result = state.send_message(worker_id, "hello".into(), None);
@@ -2076,14 +2290,17 @@ mod tests {
     #[test]
     fn test_send_message_unique_ids() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
 
         let id1 = state
             .send_message(worker_id.clone(), "msg1".into(), None)
@@ -2098,14 +2315,17 @@ mod tests {
     #[test]
     fn test_send_message_without_from() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
 
         let msg_id = state
             .send_message(worker_id.clone(), "anon msg".into(), None)
@@ -2195,14 +2415,17 @@ mod tests {
     #[test]
     fn test_pop_message_returns_fifo_order() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         state.send_message(worker_id.clone(), "first".into(), None);
         state.send_message(worker_id.clone(), "second".into(), None);
 
@@ -2216,14 +2439,17 @@ mod tests {
     #[test]
     fn test_pop_message_empty_mailbox() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         assert!(state.pop_message(&worker_id).is_none());
     }
 
@@ -2236,14 +2462,17 @@ mod tests {
     #[test]
     fn test_get_notifier_returns_same_instance() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let n1 = state.get_notifier(&worker_id);
         let n2 = state.get_notifier(&worker_id);
         assert!(Arc::ptr_eq(&n1, &n2), "same worker should get same Notify");
@@ -2261,14 +2490,17 @@ mod tests {
     #[test]
     fn test_ack_message_rejects_unknown_message() {
         let mut state = BrokerState::new();
-        let worker_id = state.register_worker(
-            "recv".into(),
-            "coder".into(),
-            "desc".into(),
-            vec![],
-            None,
-            false,
-        );
+        let worker_id = state
+            .register_worker(
+                "recv".into(),
+                "coder".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let err = state
             .ack_message(&worker_id, "nonexistent-message", None)
             .unwrap_err();
@@ -2278,9 +2510,28 @@ mod tests {
     #[test]
     fn test_ack_message_rejects_wrong_recipient() {
         let mut state = BrokerState::new();
-        let alice =
-            state.register_worker("alice".into(), "r".into(), "d".into(), vec![], None, false);
-        let bob = state.register_worker("bob".into(), "r".into(), "d".into(), vec![], None, false);
+        let alice = state
+            .register_worker(
+                "alice".into(),
+                "r".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
+        let bob = state
+            .register_worker(
+                "bob".into(),
+                "r".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let message_id = state
             .send_message(alice.clone(), "for alice".into(), None)
             .expect("send");
@@ -2294,8 +2545,17 @@ mod tests {
     #[test]
     fn test_ack_message_success_updates_history() {
         let mut state = BrokerState::new();
-        let alice =
-            state.register_worker("alice".into(), "r".into(), "d".into(), vec![], None, false);
+        let alice = state
+            .register_worker(
+                "alice".into(),
+                "r".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                None,
+            )
+            .expect("register");
         let message_id = state
             .send_message(alice.clone(), "hello".into(), None)
             .expect("send");

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::broadcast;
@@ -15,6 +16,27 @@ use crate::protocol::{
     BrokerRequest, BrokerResponse, Message, ResponsePayload, StatusEntry, Worker,
     STATUS_HISTORY_MAX,
 };
+
+/// Errors returned by `BrokerState` mutations. Distinct from `DispatchError`
+/// because the broker is process-internal — these are translated at the IPC
+/// boundary into `BrokerResponse::Error { message }` (whose `message` is
+/// this enum's `Display`) and at the orchestrator boundary into
+/// `DispatchError::AgentLaunchFailed`. Keeping them typed lets call sites
+/// match on the variant (e.g. distinguish a collision from a future "not
+/// found" or "quota exceeded") instead of string-matching on `format!` output.
+#[derive(Debug, Error)]
+pub enum BrokerError {
+    #[error(
+        "worker_id {supplied} already registered as {existing_name}/{existing_role} -- supplied {requested_name}/{requested_role} does not match"
+    )]
+    WorkerIdCollision {
+        supplied: String,
+        existing_name: String,
+        existing_role: String,
+        requested_name: String,
+        requested_role: String,
+    },
+}
 
 /// Default worker TTL in seconds (1 hour).
 const DEFAULT_WORKER_TTL_SECS: u64 = 3600;
@@ -236,7 +258,7 @@ impl BrokerState {
         evict: bool,
         worker_id: Option<String>,
         role_prompt: Option<String>,
-    ) -> Result<String, String> {
+    ) -> Result<String, BrokerError> {
         // Idempotent-claim short-circuit: if the supplied id already exists
         // and matches name+role, return it (and renew TTL) without touching
         // the rest of the state. This must run BEFORE the evict pass so that
@@ -266,10 +288,13 @@ impl BrokerState {
                     }
                     return Ok(id);
                 }
-                return Err(format!(
-                    "worker_id {supplied} already registered as {}/{} -- supplied {name}/{role} does not match",
-                    existing.name, existing.role,
-                ));
+                return Err(BrokerError::WorkerIdCollision {
+                    supplied: supplied.clone(),
+                    existing_name: existing.name.clone(),
+                    existing_role: existing.role.clone(),
+                    requested_name: name,
+                    requested_role: role,
+                });
             }
         }
 
@@ -989,7 +1014,8 @@ async fn handle_request(
                 role_prompt,
             ) {
                 Ok(id) => id,
-                Err(message) => {
+                Err(err) => {
+                    let message = err.to_string();
                     tracing::warn!(%message, "register rejected");
                     return BrokerResponse::Error { message };
                 }
@@ -1178,14 +1204,18 @@ async fn handle_request(
                     // Spurious wake — treat as timeout.
                     tracing::debug!(worker_id = %worker_id, "listen: spurious wake, returning timeout");
                     BrokerResponse::Ok {
-                        payload: ResponsePayload::Timeout { worker_id },
+                        payload: ResponsePayload::Timeout(crate::protocol::TimeoutPayload {
+                            worker_id,
+                        }),
                     }
                 }
             } else {
                 // Timed out.
                 tracing::debug!(worker_id = %worker_id, timeout, "listen: timed out");
                 BrokerResponse::Ok {
-                    payload: ResponsePayload::Timeout { worker_id },
+                    payload: ResponsePayload::Timeout(crate::protocol::TimeoutPayload {
+                        worker_id,
+                    }),
                 }
             }
         }
@@ -1320,14 +1350,33 @@ async fn handle_request(
         }
         BrokerRequest::AgentStart { name } => {
             let resolved = resolve_agent_target(&name, &state, &orchestrator).await;
-            let mut orch = orchestrator.lock().await;
-            match orch.start_by_name(&resolved).await {
-                Ok(()) => BrokerResponse::Ok {
-                    payload: ResponsePayload::Ack {},
-                },
-                Err(e) => BrokerResponse::Error {
-                    message: format!("agent start failed: {e}"),
-                },
+            // Three-phase pattern (PR #28 / #43): release the orchestrator
+            // mutex during the heavy spawn await so concurrent dashboard
+            // polls and other broker requests don't stall on file IO +
+            // pre-register + spawn_child_process.
+            let (config, ctx) = {
+                let mut orch = orchestrator.lock().await;
+                let config = match orch.check_can_start(&resolved) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return BrokerResponse::Error {
+                            message: format!("agent start failed: {e}"),
+                        };
+                    }
+                };
+                (config, orch.snapshot_spawn_context())
+            };
+            let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
+                Ok(p) => p,
+                Err(e) => {
+                    return BrokerResponse::Error {
+                        message: format!("agent start failed: {e}"),
+                    };
+                }
+            };
+            orchestrator.lock().await.register_pending(pending);
+            BrokerResponse::Ok {
+                payload: ResponsePayload::Ack {},
             }
         }
         BrokerRequest::AgentStop { name } => {
@@ -1370,14 +1419,30 @@ async fn handle_request(
             if let Some(h) = handle {
                 let _ = h.await;
             }
-            let mut orch = orchestrator.lock().await;
-            match orch.start_by_name(&resolved).await {
-                Ok(()) => BrokerResponse::Ok {
-                    payload: ResponsePayload::Ack {},
-                },
-                Err(e) => BrokerResponse::Error {
-                    message: format!("agent restart failed: {e}"),
-                },
+            // Same three-phase pattern as AgentStart for the respawn.
+            let (config, ctx) = {
+                let mut orch = orchestrator.lock().await;
+                let config = match orch.check_can_start(&resolved) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return BrokerResponse::Error {
+                            message: format!("agent restart failed: {e}"),
+                        };
+                    }
+                };
+                (config, orch.snapshot_spawn_context())
+            };
+            let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
+                Ok(p) => p,
+                Err(e) => {
+                    return BrokerResponse::Error {
+                        message: format!("agent restart failed: {e}"),
+                    };
+                }
+            };
+            orchestrator.lock().await.register_pending(pending);
+            BrokerResponse::Ok {
+                payload: ResponsePayload::Ack {},
             }
         }
     }
@@ -1824,12 +1889,21 @@ mod tests {
             )
             .expect_err("collision must be rejected");
         assert!(
-            err.contains("w-fixed"),
-            "error should name the colliding id: {err}"
+            matches!(
+                err,
+                BrokerError::WorkerIdCollision { ref supplied, ref existing_name, .. }
+                    if supplied == "w-fixed" && existing_name == "alice"
+            ),
+            "expected WorkerIdCollision for w-fixed/alice, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("w-fixed"),
+            "error display should name the colliding id: {msg}"
         );
         assert!(
-            err.contains("alice"),
-            "error should name the existing worker: {err}"
+            msg.contains("alice"),
+            "error display should name the existing worker: {msg}"
         );
         // The original worker is still there, untouched.
         assert_eq!(state.workers.len(), 1);

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -1369,6 +1369,9 @@ async fn handle_request(
             let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
                 Ok(p) => p,
                 Err(e) => {
+                    // Release the phase 1 reservation so future starts
+                    // of this name aren't blocked by a stale slot.
+                    orchestrator.lock().await.cancel_start(&resolved);
                     return BrokerResponse::Error {
                         message: format!("agent start failed: {e}"),
                     };
@@ -1435,6 +1438,8 @@ async fn handle_request(
             let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
                 Ok(p) => p,
                 Err(e) => {
+                    // Release the phase 3 reservation on build failure.
+                    orchestrator.lock().await.cancel_start(&resolved);
                     return BrokerResponse::Error {
                         message: format!("agent restart failed: {e}"),
                     };

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -259,6 +259,20 @@ impl BrokerState {
         worker_id: Option<String>,
         role_prompt: Option<String>,
     ) -> Result<String, BrokerError> {
+        // Prune expired workers up front — every other broker entry point
+        // (`list_workers`, `heartbeat_worker`, message / team / mailbox
+        // handlers) does this, and skipping it here opens a race where the
+        // issue-#43 pre-register path stores a role_prompt, the pre-registered
+        // worker's TTL elapses before the agent claims, another broker
+        // request (e.g. `listen`) drops it via its own `evict_expired` AND
+        // its `role_prompts` entry, the agent's subsequent claim misses the
+        // idempotent short-circuit and falls through to the insert branch,
+        // and the response carries `role_prompt: None`. With the preamble
+        // the failure is deterministic regardless of interleaving, and the
+        // supervisor's respawn-time re-register (evict=true, role_prompt
+        // populated) restores the prompt on the next attempt.
+        self.evict_expired();
+
         // Idempotent-claim short-circuit: if the supplied id already exists
         // and matches name+role, return it (and renew TTL) without touching
         // the rest of the state. This must run BEFORE the evict pass so that
@@ -861,12 +875,8 @@ pub async fn serve(
     if !manual.is_empty() {
         eprintln!("\ndispatch serve: ready. Unmanaged agents — run these in separate terminals:\n");
         for agent in &manual {
-            let cmd = super::orchestrator::build_agent_command(
-                agent,
-                cell_id,
-                monitor_url.as_deref(),
-                None,
-            );
+            let cmd =
+                super::orchestrator::build_agent_command(agent, cell_id, monitor_url.as_deref());
             eprintln!("  # {} ({})", agent.name, agent.role);
             eprintln!("  {cmd}\n");
         }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -162,6 +162,11 @@ pub struct BrokerState {
     pub messages_delivered: u64,
     /// Total number of requests handled.
     pub requests_handled: u64,
+    /// Per-worker role-prompt body keyed by worker ID (issue #43). Populated
+    /// at orchestrator pre-register time; returned in the `WorkerRegistered`
+    /// response when the spawned agent calls `dispatch register` to claim
+    /// its session. Absent for workers registered the legacy way.
+    pub role_prompts: HashMap<String, String>,
 }
 
 impl Default for BrokerState {
@@ -189,6 +194,7 @@ impl BrokerState {
             messages_sent: 0,
             messages_delivered: 0,
             requests_handled: 0,
+            role_prompts: HashMap::new(),
         }
     }
 
@@ -209,6 +215,14 @@ impl BrokerState {
     /// - Otherwise, the supplied id is used verbatim.
     ///
     /// If `worker_id` is `None`, a fresh UUID is generated (legacy behavior).
+    ///
+    /// `role_prompt` (issue #43) is the agent's role prompt body. Only the
+    /// orchestrator passes it — at pre-register time it loads the agent's
+    /// prompt file and ships the content here. The broker stores it under
+    /// the worker id so the spawned agent can fetch it back via the
+    /// `WorkerRegistered` response of its own `dispatch register` claim.
+    /// Agents themselves never pass `role_prompt`, so the claim path leaves
+    /// the stored value untouched when `role_prompt` is `None`.
     // Splitting these into a struct buys nothing — every caller passes them
     // positionally and clippy's 7-arg threshold is an arbitrary heuristic.
     #[allow(clippy::too_many_arguments)]
@@ -221,6 +235,7 @@ impl BrokerState {
         ttl_secs: Option<u64>,
         evict: bool,
         worker_id: Option<String>,
+        role_prompt: Option<String>,
     ) -> Result<String, String> {
         // Idempotent-claim short-circuit: if the supplied id already exists
         // and matches name+role, return it (and renew TTL) without touching
@@ -233,7 +248,14 @@ impl BrokerState {
                     let ttl = ttl_secs.unwrap_or(self.default_ttl);
                     existing.ttl_secs = ttl;
                     existing.expires_at = now_secs() + ttl;
-                    return Ok(supplied.clone());
+                    let id = supplied.clone();
+                    // Only overwrite the stored prompt if the caller supplied
+                    // one — agent claims pass `None` and must not erase what
+                    // the orchestrator stored at pre-register time.
+                    if let Some(prompt) = role_prompt {
+                        self.role_prompts.insert(id.clone(), prompt);
+                    }
+                    return Ok(id);
                 }
                 return Err(format!(
                     "worker_id {supplied} already registered as {}/{} -- supplied {name}/{role} does not match",
@@ -253,6 +275,7 @@ impl BrokerState {
                 self.workers.remove(old_id);
                 self.mailboxes.remove(old_id);
                 self.notifiers.remove(old_id);
+                self.role_prompts.remove(old_id);
             }
         }
 
@@ -272,6 +295,9 @@ impl BrokerState {
             status_history: VecDeque::new(),
         };
         self.workers.insert(id.clone(), worker);
+        if let Some(prompt) = role_prompt {
+            self.role_prompts.insert(id.clone(), prompt);
+        }
         Ok(id)
     }
 
@@ -290,6 +316,7 @@ impl BrokerState {
             self.workers.remove(id);
             self.mailboxes.remove(id);
             self.notifiers.remove(id);
+            self.role_prompts.remove(id);
         }
         expired
     }
@@ -932,6 +959,7 @@ async fn handle_request(
             ttl_secs,
             evict,
             worker_id,
+            role_prompt,
         } => {
             let mut state = state.lock().await;
             let worker_id = match state.register_worker(
@@ -942,6 +970,7 @@ async fn handle_request(
                 ttl_secs,
                 evict,
                 worker_id,
+                role_prompt,
             ) {
                 Ok(id) => id,
                 Err(message) => {
@@ -961,8 +990,15 @@ async fn handle_request(
                     "role": role,
                 })),
             );
+            // Issue #43: include the stored role prompt (if any) so the
+            // spawned agent receives its first instructions as the response
+            // body of its own `dispatch register` claim.
+            let role_prompt = state.role_prompts.get(&worker_id).cloned();
             BrokerResponse::Ok {
-                payload: ResponsePayload::WorkerRegistered { worker_id },
+                payload: ResponsePayload::WorkerRegistered {
+                    worker_id,
+                    role_prompt,
+                },
             }
         }
         BrokerRequest::Team { from } => {
@@ -1633,6 +1669,7 @@ mod tests {
                 None,
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect("register");
         assert_eq!(id, "w-fixed");
@@ -1653,6 +1690,7 @@ mod tests {
                 Some(60),
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect("first register");
         // Force the expiry into the past so we can detect the renewal.
@@ -1667,6 +1705,7 @@ mod tests {
                 Some(60),
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect("idempotent claim");
         assert_eq!(id, id2);
@@ -1691,6 +1730,7 @@ mod tests {
                 None,
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect("first register");
         let err = state
@@ -1702,6 +1742,7 @@ mod tests {
                 None,
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect_err("collision must be rejected");
         assert!(
@@ -1715,6 +1756,91 @@ mod tests {
         // The original worker is still there, untouched.
         assert_eq!(state.workers.len(), 1);
         assert_eq!(state.workers.get("w-fixed").unwrap().name, "alice");
+    }
+
+    /// Issue #43: a fresh registration with `role_prompt` stores the prompt
+    /// keyed by worker id; subsequent claims with `role_prompt: None` see
+    /// the stored prompt back via `role_prompts`.
+    #[test]
+    fn test_register_worker_stores_and_returns_role_prompt() {
+        let mut state = BrokerState::new();
+        let id = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+                Some("Run: dispatch listen --timeout 270".into()),
+            )
+            .expect("pre-register");
+        assert_eq!(
+            state.role_prompts.get(&id).map(String::as_str),
+            Some("Run: dispatch listen --timeout 270"),
+        );
+
+        // Agent claim with role_prompt=None must NOT erase the stored prompt.
+        let claimed = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+                None,
+            )
+            .expect("claim");
+        assert_eq!(claimed, id);
+        assert_eq!(
+            state.role_prompts.get(&id).map(String::as_str),
+            Some("Run: dispatch listen --timeout 270"),
+            "claim must not erase the stored prompt",
+        );
+    }
+
+    /// Issue #43: evicting a worker (via `evict=true` or TTL expiry) drops
+    /// its stored prompt too — no stale prompts left behind.
+    #[test]
+    fn test_register_worker_evict_clears_role_prompt() {
+        let mut state = BrokerState::new();
+        let first = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                false,
+                None,
+                Some("first prompt".into()),
+            )
+            .expect("first");
+        // Evict and re-register with a different id. Old prompt must be gone.
+        let second = state
+            .register_worker(
+                "alice".into(),
+                "test-runner".into(),
+                "desc".into(),
+                vec![],
+                None,
+                true,
+                None,
+                Some("second prompt".into()),
+            )
+            .expect("evict + re-register");
+        assert_ne!(first, second);
+        assert!(
+            !state.role_prompts.contains_key(&first),
+            "evicted worker's prompt must be cleared",
+        );
+        assert_eq!(
+            state.role_prompts.get(&second).map(String::as_str),
+            Some("second prompt"),
+        );
     }
 
     /// Idempotent claim runs BEFORE evict, so a same-name evict cannot wipe a
@@ -1731,6 +1857,7 @@ mod tests {
                 None,
                 false,
                 Some("w-fixed".into()),
+                None,
             )
             .expect("pre-register");
         let claimed = state
@@ -1742,6 +1869,7 @@ mod tests {
                 None,
                 true, // evict
                 Some("w-fixed".into()),
+                None,
             )
             .expect("claim should win over evict");
         assert_eq!(id, claimed);
@@ -1760,6 +1888,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         let id2 = state
@@ -1770,6 +1899,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -1788,6 +1918,7 @@ mod tests {
                 vec!["review:code".into(), "review:docs".into()],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -1815,6 +1946,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         let worker = state.workers.get(&id).unwrap();
@@ -1834,6 +1966,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -1970,6 +2103,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         let expired_id = state
@@ -1980,6 +2114,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2002,6 +2137,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2035,6 +2171,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         state.workers.get_mut(&id).unwrap().expires_at = 0;
@@ -2059,6 +2196,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2086,6 +2224,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2118,6 +2257,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2245,6 +2385,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
 
@@ -2279,6 +2420,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         state.workers.get_mut(&worker_id).unwrap().expires_at = 0;
@@ -2298,6 +2440,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2323,6 +2466,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2424,6 +2568,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         state.send_message(worker_id.clone(), "first".into(), None);
@@ -2448,6 +2593,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         assert!(state.pop_message(&worker_id).is_none());
@@ -2470,6 +2616,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2499,6 +2646,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         let err = state
@@ -2519,6 +2667,7 @@ mod tests {
                 None,
                 false,
                 None,
+                None,
             )
             .expect("register");
         let bob = state
@@ -2529,6 +2678,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");
@@ -2553,6 +2703,7 @@ mod tests {
                 vec![],
                 None,
                 false,
+                None,
                 None,
             )
             .expect("register");

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -765,6 +765,7 @@ pub async fn serve(
         &config.agent_cwd,
         log_dir.clone(),
         config.agents.clone(),
+        Arc::clone(&state),
     )));
 
     // Optionally start the HTTP monitor dashboard.

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -149,7 +149,6 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
                 a,
                 &state.cell_id,
                 state.monitor_url.as_deref(),
-                None,
             );
             serde_json::json!({
                 "name": a.name,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -467,6 +467,7 @@ mod tests {
             prompt: None,
             prompt_file_path: None,
             ttl: None,
+            stream_json: false,
             launch: false,
         }
     }

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -355,7 +355,8 @@ async fn api_agent_start(
         return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
     }
 
-    // Phase 1 (locked): validate name + snapshot spawn context.
+    // Phase 1 (locked): validate name + claim the `starting` reservation
+    // + snapshot spawn context.
     let (config, ctx) = {
         let mut orch = state.orchestrator.lock().await;
         let config = match orch.check_can_start(&name) {
@@ -369,10 +370,17 @@ async fn api_agent_start(
     // process launch — without pinning the orchestrator mutex.
     let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
         Ok(p) => p,
-        Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+        Err(e) => {
+            // Build failed — release the phase 1 reservation so future
+            // starts of this name aren't blocked by a stale "already
+            // starting" slot.
+            state.orchestrator.lock().await.cancel_start(&name);
+            return error_response(classify_agent_error(&e), &e.to_string());
+        }
     };
 
-    // Phase 3 (locked): commit the spawned agent into the tracked set.
+    // Phase 3 (locked): commit the spawned agent into the tracked set
+    // (also clears the `starting` reservation).
     state.orchestrator.lock().await.register_pending(pending);
     ok_response()
 }
@@ -432,9 +440,9 @@ async fn api_agent_restart(
         let _ = h.await;
     }
 
-    // Phase 3 (locked): validate + snapshot for the respawn.
-    // `check_can_start` reaps any finished supervisor entry in case one
-    // slipped through between phases.
+    // Phase 3 (locked): validate + claim `starting` + snapshot for the
+    // respawn. `check_can_start` reaps any finished supervisor entry in
+    // case one slipped through between phases.
     let (config, ctx) = {
         let mut orch = state.orchestrator.lock().await;
         let config = match orch.check_can_start(&name) {
@@ -447,10 +455,14 @@ async fn api_agent_restart(
     // Phase 4 (unlocked): heavy spawn — same rationale as api_agent_start.
     let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
         Ok(p) => p,
-        Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+        Err(e) => {
+            // Release the phase 3 reservation on build failure.
+            state.orchestrator.lock().await.cancel_start(&name);
+            return error_response(classify_agent_error(&e), &e.to_string());
+        }
     };
 
-    // Phase 5 (locked): commit.
+    // Phase 5 (locked): commit (also clears the `starting` reservation).
     state.orchestrator.lock().await.register_pending(pending);
     ok_response()
 }

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -340,6 +340,13 @@ async fn api_shutdown(State(state): State<MonitorState>) -> StatusCode {
 
 /// Start a configured agent by name. Same authz posture as `/api/shutdown`:
 /// unauthenticated, intended for local-loopback use only.
+///
+/// Three-phase pattern (PR #28 / #43): hold the orchestrator mutex only
+/// for cheap synchronous validation + snapshot in phase 1, run the heavy
+/// `build_pending_agent` await in phase 2 unlocked, and re-lock in phase
+/// 3 just to push the result. Without this, a slow start (boot prompt
+/// write + broker pre-register + `spawn_child_process`) would stall the
+/// dashboard's 2 s `/api/agents/state` poll on the same mutex.
 async fn api_agent_start(
     State(state): State<MonitorState>,
     Path(name): Path<String>,
@@ -347,11 +354,27 @@ async fn api_agent_start(
     if !super::orchestrator::is_safe_name(&name) {
         return error_response(StatusCode::BAD_REQUEST, "invalid agent name");
     }
-    let mut orch = state.orchestrator.lock().await;
-    match orch.start_by_name(&name).await {
-        Ok(()) => ok_response(),
-        Err(e) => error_response(classify_agent_error(&e), &e.to_string()),
-    }
+
+    // Phase 1 (locked): validate name + snapshot spawn context.
+    let (config, ctx) = {
+        let mut orch = state.orchestrator.lock().await;
+        let config = match orch.check_can_start(&name) {
+            Ok(c) => c,
+            Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+        };
+        (config, orch.snapshot_spawn_context())
+    };
+
+    // Phase 2 (unlocked): heavy spawn — file IO, broker pre-register,
+    // process launch — without pinning the orchestrator mutex.
+    let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
+        Ok(p) => p,
+        Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+    };
+
+    // Phase 3 (locked): commit the spawned agent into the tracked set.
+    state.orchestrator.lock().await.register_pending(pending);
+    ok_response()
 }
 
 /// Stop a running managed agent by name. Releases the orchestrator mutex
@@ -409,13 +432,27 @@ async fn api_agent_restart(
         let _ = h.await;
     }
 
-    // Phase 3 (locked): respawn. `start_by_name` reaps any finished
-    // supervisor entry in case one slipped through between phases.
-    let mut orch = state.orchestrator.lock().await;
-    match orch.start_by_name(&name).await {
-        Ok(()) => ok_response(),
-        Err(e) => error_response(classify_agent_error(&e), &e.to_string()),
-    }
+    // Phase 3 (locked): validate + snapshot for the respawn.
+    // `check_can_start` reaps any finished supervisor entry in case one
+    // slipped through between phases.
+    let (config, ctx) = {
+        let mut orch = state.orchestrator.lock().await;
+        let config = match orch.check_can_start(&name) {
+            Ok(c) => c,
+            Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+        };
+        (config, orch.snapshot_spawn_context())
+    };
+
+    // Phase 4 (unlocked): heavy spawn — same rationale as api_agent_start.
+    let pending = match super::orchestrator::build_pending_agent(ctx, &config).await {
+        Ok(p) => p,
+        Err(e) => return error_response(classify_agent_error(&e), &e.to_string()),
+    };
+
+    // Phase 5 (locked): commit.
+    state.orchestrator.lock().await.register_pending(pending);
+    ok_response()
 }
 
 /// Map orchestrator launch errors to HTTP statuses. "No such agent" is 404,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -149,6 +149,7 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
                 a,
                 &state.cell_id,
                 state.monitor_url.as_deref(),
+                None,
             );
             serde_json::json!({
                 "name": a.name,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -484,6 +484,7 @@ mod tests {
             tmp,
             tmp.join("logs"),
             configs,
+            Arc::clone(&broker),
         )));
         MonitorState {
             broker,

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -171,6 +171,7 @@ impl AgentOrchestrator {
             prompt_file: config.prompt_file_path.as_deref(),
             prompt_inline: config.prompt.as_deref(),
             command_string: config.command.as_deref(),
+            stream_json: config.stream_json,
         };
         config
             .adapter
@@ -973,6 +974,7 @@ mod tests {
             prompt: None,
             prompt_file_path: None,
             ttl: None,
+            stream_json: false,
             launch: true,
         }
     }
@@ -993,6 +995,7 @@ mod tests {
             prompt: None,
             prompt_file_path: Some(prompt_path),
             ttl: None,
+            stream_json: false,
             launch: true,
         }
     }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -106,9 +106,15 @@ pub struct AgentOrchestrator {
     /// All configured agents, used to look up an agent's config by name
     /// when responding to `dispatch agent start/restart <name>` requests.
     configs: Vec<ResolvedAgentConfig>,
+    /// Shared broker state — used by `spawn_agent` to pre-register managed
+    /// agents server-side at spawn time (issue #43) and by the supervisor
+    /// to re-register them on restart so the worker record + role prompt
+    /// stay alive across respawns.
+    broker: Arc<Mutex<super::local::BrokerState>>,
 }
 
 impl AgentOrchestrator {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cell_id: &str,
         socket_path: &Path,
@@ -116,6 +122,7 @@ impl AgentOrchestrator {
         agent_cwd: &Path,
         log_dir: PathBuf,
         configs: Vec<ResolvedAgentConfig>,
+        broker: Arc<Mutex<super::local::BrokerState>>,
     ) -> Self {
         Self {
             agents: Vec::new(),
@@ -126,6 +133,7 @@ impl AgentOrchestrator {
             agent_cwd: agent_cwd.to_path_buf(),
             log_dir,
             configs,
+            broker,
         }
     }
 
@@ -179,16 +187,95 @@ impl AgentOrchestrator {
     /// Stdout/stderr go to `<log_dir>/<sanitized-agent-name>.log`. Stdin
     /// comes from the adapter's `stdin_file` (typically the prompt file) or
     /// is `/dev/null` if the adapter doesn't need one.
+    ///
+    /// **Issue #43 — managed-agent pre-register flow.** When the agent has
+    /// `launch = true` AND a `prompt_file`, dispatch:
+    /// 1. Reads the prompt file content into memory.
+    /// 2. Generates a fresh worker id and registers the worker server-side
+    ///    (eviction on, so a stale same-name worker from a crashed prior
+    ///    session is replaced).
+    /// 3. Writes a one-line boot prompt that forces the model's first
+    ///    observable action to be `dispatch register --for-agent ...` —
+    ///    the broker returns the role prompt body in that response.
+    /// 4. Injects `DISPATCH_WORKER_ID` so the boot command can name the id.
+    /// 5. Hands the supervisor a re-register hook so the worker record +
+    ///    role prompt stay alive across respawns.
+    ///
+    /// Agents with `launch = false` are external (user copy-pastes the
+    /// command into a separate terminal) and stay on the legacy path:
+    /// no pre-register, full prompt piped to stdin as before.
     pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
-        // Step 4 of the issue-#43 rollout will pre-register the worker here
-        // and pass the assigned id. Until then, leave `DISPATCH_WORKER_ID`
-        // unset so the legacy in-agent register flow keeps working.
-        let env_vars = self.env_vars(&config.name, &config.role, None);
+        let pre_register = config.launch && config.prompt_file_path.is_some();
+
+        let (env_vars, worker_id, role_prompt, spawn_config) = if pre_register {
+            let prompt_path = config
+                .prompt_file_path
+                .as_ref()
+                .expect("checked by pre_register guard");
+            let prompt_content = tokio::fs::read_to_string(prompt_path).await.map_err(|_| {
+                DispatchError::PromptFileNotFound {
+                    name: config.name.clone(),
+                    path: prompt_path.clone(),
+                }
+            })?;
+
+            let id = uuid::Uuid::new_v4().to_string();
+            {
+                let mut broker = self.broker.lock().await;
+                broker
+                    .register_worker(
+                        config.name.clone(),
+                        config.role.clone(),
+                        config.description.clone(),
+                        Vec::new(),
+                        config.ttl,
+                        true, // evict any stale same-name worker from a prior session
+                        Some(id.clone()),
+                        Some(prompt_content.clone()),
+                    )
+                    .map_err(|e| DispatchError::AgentLaunchFailed {
+                        name: config.name.clone(),
+                        reason: format!("pre-register failed: {e}"),
+                    })?;
+            }
+
+            let boot_path = write_boot_prompt(&self.log_dir, config)
+                .await
+                .map_err(|e| DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: format!("write boot prompt: {e}"),
+                })?;
+
+            let mut sc = config.clone();
+            sc.prompt_file_path = Some(boot_path);
+
+            let env = self.env_vars(&config.name, &config.role, Some(&id));
+            (env, Some(id), Some(prompt_content), sc)
+        } else {
+            // Legacy unmanaged path (launch=false, or no prompt_file).
+            let env = self.env_vars(&config.name, &config.role, None);
+            (env, None, None, config.clone())
+        };
 
         // Initial spawn is synchronous so the caller sees config errors
         // (bad prompt file, missing binary) as a proper Err instead of
         // discovering them later via AgentState::Crashed.
-        let child = spawn_child_process(config, &env_vars, &self.agent_cwd, &self.log_dir).await?;
+        let child =
+            match spawn_child_process(&spawn_config, &env_vars, &self.agent_cwd, &self.log_dir)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    // Clean up the pre-registered worker so we don't leave an
+                    // orphan in the broker that will never check in.
+                    if let Some(ref id) = worker_id {
+                        let mut b = self.broker.lock().await;
+                        b.workers.remove(id);
+                        b.role_prompts.remove(id);
+                    }
+                    return Err(e);
+                }
+            };
         let pid = child.id().unwrap_or(0);
         eprintln!(
             "dispatch serve: launched agent '{}' (role={}, pid={})",
@@ -201,14 +288,22 @@ impl AgentOrchestrator {
         }));
         let shutdown = Arc::new(Notify::new());
 
+        // Re-register hook: passed to the supervisor so it can refresh the
+        // worker record (and re-store the role prompt) on every respawn.
+        // None for unmanaged agents — the supervisor stays on legacy behavior.
+        let re_register = worker_id
+            .zip(role_prompt)
+            .map(|(id, prompt)| (Arc::clone(&self.broker), id, prompt));
+
         let supervisor = tokio::spawn(supervise_agent(
-            config.clone(),
+            spawn_config,
             env_vars,
             self.agent_cwd.clone(),
             self.log_dir.clone(),
             child,
             Arc::clone(&state),
             Arc::clone(&shutdown),
+            re_register,
         ));
 
         self.agents.push(ManagedAgent {
@@ -424,6 +519,29 @@ impl AgentOrchestrator {
     }
 }
 
+/// Write the issue-#43 one-line boot prompt to a stable per-agent file
+/// under the log dir. The boot prompt forces the model's first observable
+/// action to be a real `dispatch register --for-agent` tool call, which
+/// returns the role prompt body in its tool result. Description is
+/// substituted at write time (shell-escaped) so the dispatch CLI's
+/// required `--description` flag is satisfied without an env var.
+async fn write_boot_prompt(
+    log_dir: &Path,
+    config: &ResolvedAgentConfig,
+) -> Result<PathBuf, std::io::Error> {
+    tokio::fs::create_dir_all(log_dir).await?;
+    let safe = sanitize_name(&config.name);
+    let path = log_dir.join(format!("{safe}.boot.prompt"));
+    let body = format!(
+        "Run: dispatch register --worker-id \"$DISPATCH_WORKER_ID\" \
+         --name \"$DISPATCH_AGENT_NAME\" --role \"$DISPATCH_AGENT_ROLE\" \
+         --description {} --for-agent\n",
+        shell_escape(&config.description),
+    );
+    tokio::fs::write(&path, body).await?;
+    Ok(path)
+}
+
 /// Spawn the agent process (single attempt, no supervision).
 ///
 /// Used both for the initial launch and for respawns inside the supervisor.
@@ -517,6 +635,7 @@ async fn spawn_child_process(
 /// - Applies `restart_backoff(attempt)` before respawning.
 /// - Gives up after `MAX_RESTART_ATTEMPTS` consecutive unstable failures and
 ///   leaves `AgentState::Crashed` in place.
+#[allow(clippy::too_many_arguments)]
 async fn supervise_agent(
     config: ResolvedAgentConfig,
     env_vars: HashMap<String, String>,
@@ -525,6 +644,10 @@ async fn supervise_agent(
     initial_child: Child,
     state: Arc<Mutex<AgentState>>,
     shutdown: Arc<Notify>,
+    // `Some((broker, worker_id, role_prompt))` for managed agents that need
+    // the broker worker record + role prompt re-stored on every respawn
+    // (issue #43). `None` for unmanaged agents on the legacy path.
+    re_register: Option<(Arc<Mutex<super::local::BrokerState>>, String, String)>,
 ) {
     let mut child = initial_child;
     let mut attempt: u32 = 0;
@@ -592,6 +715,27 @@ async fn supervise_agent(
                         return;
                     }
                     _ = tokio::time::sleep(backoff) => {}
+                }
+
+                // Issue #43: refresh the broker's worker record + role
+                // prompt before the respawn so the agent's claim call can
+                // get its prompt back even if TTL expired during downtime.
+                // Idempotent on alive workers (no-op claim renewing TTL),
+                // fresh-creates if the record was GC'd.
+                if let Some((broker, worker_id, role_prompt)) = &re_register {
+                    let mut b = broker.lock().await;
+                    if let Err(err) = b.register_worker(
+                        config.name.clone(),
+                        config.role.clone(),
+                        config.description.clone(),
+                        Vec::new(),
+                        config.ttl,
+                        false,
+                        Some(worker_id.clone()),
+                        Some(role_prompt.clone()),
+                    ) {
+                        tracing::warn!(agent = %config.name, %err, "restart re-register failed");
+                    }
                 }
 
                 match spawn_child_process(&config, &env_vars, &agent_cwd, &log_dir).await {
@@ -751,6 +895,7 @@ mod tests {
             tmp.path(),
             tmp.path().join("logs"),
             Vec::new(),
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
         );
 
         let with_id = orch.env_vars("alice", "test-runner", Some("w-123"));
@@ -832,6 +977,124 @@ mod tests {
         }
     }
 
+    /// Helper: build a managed test config (launch=true, with prompt_file)
+    /// that exercises the issue-#43 pre-register flow. Uses the `command`
+    /// adapter so we don't need `claude` on the test host — the prompt file
+    /// is created but ignored by the adapter; what we're testing is whether
+    /// the orchestrator correctly pre-registers the worker server-side.
+    fn managed_test_config(name: &str, command: &str, prompt_path: PathBuf) -> ResolvedAgentConfig {
+        ResolvedAgentConfig {
+            name: name.into(),
+            role: "test-runner".into(),
+            description: "managed test agent".into(),
+            adapter: Adapter::Command,
+            command: Some(command.into()),
+            extra_args: Vec::new(),
+            prompt: None,
+            prompt_file_path: Some(prompt_path),
+            ttl: None,
+            launch: true,
+        }
+    }
+
+    /// Issue #43: spawning a managed agent (launch=true with prompt_file)
+    /// pre-registers the worker server-side BEFORE the child starts, with
+    /// the prompt body stored under the assigned worker id.
+    #[tokio::test]
+    async fn spawn_managed_agent_pre_registers_with_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prompt_path = tmp.path().join("alice.md");
+        let prompt_body = "Run: dispatch listen --timeout 270\nRole context here.";
+        tokio::fs::write(&prompt_path, prompt_body).await.unwrap();
+
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+        let cfg = managed_test_config("alice", "sleep 30", prompt_path);
+        orch.spawn_agent(&cfg).await.expect("spawn");
+
+        // Worker is in the broker right away — the agent's later claim
+        // call will idempotently match it without inventing an id.
+        let b = broker.lock().await;
+        assert_eq!(b.workers.len(), 1, "pre-register must create the worker");
+        let (id, worker) = b.workers.iter().next().unwrap();
+        assert_eq!(worker.name, "alice");
+        assert_eq!(worker.role, "test-runner");
+        assert_eq!(
+            b.role_prompts.get(id).map(String::as_str),
+            Some(prompt_body),
+            "role prompt must be stored under the worker id",
+        );
+
+        drop(b);
+        orch.shutdown_all().await;
+    }
+
+    /// Issue #43: launch=false agents stay on the legacy register-yourself
+    /// path. No worker shows up in the broker after `spawn_agent`.
+    #[tokio::test]
+    async fn spawn_unmanaged_agent_does_not_pre_register() {
+        let tmp = tempfile::tempdir().unwrap();
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+        let mut cfg = test_config("bob", "sleep 30");
+        cfg.launch = false; // explicitly unmanaged
+        orch.spawn_agent(&cfg).await.expect("spawn");
+
+        let b = broker.lock().await;
+        assert!(
+            b.workers.is_empty(),
+            "unmanaged agents must not be pre-registered: {:?}",
+            b.workers,
+        );
+        drop(b);
+        orch.shutdown_all().await;
+    }
+
+    /// Issue #43: a missing prompt file fails the spawn and leaves NO
+    /// orphan worker in the broker — the cleanup guard runs before the
+    /// supervisor is attached.
+    #[tokio::test]
+    async fn spawn_managed_agent_missing_prompt_file_leaves_no_orphan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+        let cfg = managed_test_config("alice", "sleep 30", tmp.path().join("does-not-exist.md"));
+        let err = orch.spawn_agent(&cfg).await.expect_err("must fail");
+        assert!(
+            matches!(err, DispatchError::PromptFileNotFound { .. }),
+            "expected PromptFileNotFound, got: {err:?}",
+        );
+        let b = broker.lock().await;
+        assert!(
+            b.workers.is_empty(),
+            "failed pre-register must not leave an orphan worker",
+        );
+    }
+
     /// Supervisor reports Running while a long-lived child is alive, and
     /// transitions to Stopped after `stop_by_name`.
     #[tokio::test]
@@ -844,6 +1107,7 @@ mod tests {
             tmp.path(),
             tmp.path().join("logs"),
             Vec::new(),
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
         );
         let cfg = test_config("alice", "sleep 30");
         orch.spawn_agent(&cfg).await.expect("spawn");
@@ -871,6 +1135,7 @@ mod tests {
             tmp.path(),
             tmp.path().join("logs"),
             Vec::new(),
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
         );
         let cfg = test_config("flaky", "exit 1");
         orch.spawn_agent(&cfg).await.expect("spawn");

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -91,6 +91,48 @@ struct RunningHeartbeat {
     handle: tokio::task::JoinHandle<()>,
 }
 
+/// Snapshot of the orchestrator's immutable spawn-side state. Created by
+/// `AgentOrchestrator::snapshot_spawn_context` so the heavy spawn work can
+/// run with the orchestrator mutex released. See `monitor::api_agent_start`
+/// for the canonical three-phase usage (check → build → register).
+pub struct SpawnContext {
+    broker: Arc<Mutex<super::local::BrokerState>>,
+    cell_id: String,
+    socket_path: PathBuf,
+    monitor_url: Option<String>,
+    agent_cwd: PathBuf,
+    log_dir: PathBuf,
+}
+
+impl SpawnContext {
+    fn env_vars(&self, name: &str, role: &str, worker_id: Option<&str>) -> HashMap<String, String> {
+        let mut vars = HashMap::new();
+        vars.insert("DISPATCH_CELL_ID".into(), self.cell_id.clone());
+        vars.insert(
+            "DISPATCH_SOCKET_PATH".into(),
+            self.socket_path.display().to_string(),
+        );
+        if let Some(ref url) = self.monitor_url {
+            vars.insert("DISPATCH_MONITOR_URL".into(), url.clone());
+        }
+        vars.insert("DISPATCH_AGENT_NAME".into(), name.into());
+        vars.insert("DISPATCH_AGENT_ROLE".into(), role.into());
+        if let Some(id) = worker_id {
+            vars.insert("DISPATCH_WORKER_ID".into(), id.into());
+        }
+        vars
+    }
+}
+
+/// Opaque handle to an agent that has been spawned but not yet registered
+/// with the orchestrator. Returned by `build_pending_agent`; consumed by
+/// `AgentOrchestrator::register_pending`. Wraps the private `ManagedAgent`
+/// so callers outside this module can move spawn results across the lock
+/// boundary without touching internals.
+pub struct PendingAgent {
+    inner: ManagedAgent,
+}
+
 /// Manages the lifecycle of agent subprocesses and heartbeat timers.
 pub struct AgentOrchestrator {
     agents: Vec<ManagedAgent>,
@@ -137,29 +179,6 @@ impl AgentOrchestrator {
         }
     }
 
-    /// Build the environment variables injected into every agent subprocess.
-    ///
-    /// `worker_id` is `Some` once dispatch pre-registers the worker server-side
-    /// at spawn time (see issue #43). When `None`, the var is omitted and the
-    /// agent must fall back to the legacy "register myself" flow.
-    fn env_vars(&self, name: &str, role: &str, worker_id: Option<&str>) -> HashMap<String, String> {
-        let mut vars = HashMap::new();
-        vars.insert("DISPATCH_CELL_ID".into(), self.cell_id.clone());
-        vars.insert(
-            "DISPATCH_SOCKET_PATH".into(),
-            self.socket_path.display().to_string(),
-        );
-        if let Some(ref url) = self.monitor_url {
-            vars.insert("DISPATCH_MONITOR_URL".into(), url.clone());
-        }
-        vars.insert("DISPATCH_AGENT_NAME".into(), name.into());
-        vars.insert("DISPATCH_AGENT_ROLE".into(), role.into());
-        if let Some(id) = worker_id {
-            vars.insert("DISPATCH_WORKER_ID".into(), id.into());
-        }
-        vars
-    }
-
     /// Build the adapter's Launch spec for this agent.
     ///
     /// The Launch describes the program, argv, shell-wrap hint, and optional
@@ -192,12 +211,14 @@ impl AgentOrchestrator {
     /// **Issue #43 — managed-agent pre-register flow.** When the agent has
     /// `launch = true` AND a `prompt_file`, dispatch:
     /// 1. Reads the prompt file content into memory.
-    /// 2. Generates a fresh worker id and registers the worker server-side
-    ///    (eviction on, so a stale same-name worker from a crashed prior
-    ///    session is replaced).
-    /// 3. Writes a one-line boot prompt that forces the model's first
+    /// 2. Writes a one-line boot prompt that forces the model's first
     ///    observable action to be `dispatch register --for-agent ...` —
     ///    the broker returns the role prompt body in that response.
+    ///    Done BEFORE step 3 so a write failure can't leave a zombie
+    ///    worker in the broker.
+    /// 3. Generates a fresh worker id and registers the worker server-side
+    ///    (eviction on, so a stale same-name worker from a crashed prior
+    ///    session is replaced).
     /// 4. Injects `DISPATCH_WORKER_ID` so the boot command can name the id.
     /// 5. Hands the supervisor a re-register hook so the worker record +
     ///    role prompt stay alive across respawns.
@@ -205,124 +226,67 @@ impl AgentOrchestrator {
     /// Agents with `launch = false` are external (user copy-pastes the
     /// command into a separate terminal) and stay on the legacy path:
     /// no pre-register, full prompt piped to stdin as before.
+    ///
+    /// **Mutex contention warning.** This holds `&mut self` for the entire
+    /// duration, including the prompt file read, boot prompt write, broker
+    /// `register_worker` call, and `spawn_child_process` await. HTTP / IPC
+    /// handlers wrapping the orchestrator in `Arc<Mutex<…>>` should
+    /// instead use the three-phase pattern: `check_can_start` (locked) →
+    /// `build_pending_agent` (unlocked) → `register_pending` (locked).
+    /// See `monitor::api_agent_start` for the canonical example.
     pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
-        let pre_register = config.launch && config.prompt_file_path.is_some();
-
-        let (env_vars, worker_id, role_prompt, spawn_config) = if pre_register {
-            let prompt_path = config.prompt_file_path.as_ref().ok_or_else(|| {
-                DispatchError::AgentLaunchFailed {
-                    name: config.name.clone(),
-                    reason: "pre_register set but prompt_file_path is None".into(),
-                }
-            })?;
-            let prompt_content = tokio::fs::read_to_string(prompt_path).await.map_err(|_| {
-                DispatchError::PromptFileNotFound {
-                    name: config.name.clone(),
-                    path: prompt_path.clone(),
-                }
-            })?;
-
-            // Write the boot prompt BEFORE pre-registering so a write failure
-            // (disk full, log_dir not writable, etc.) can't leave an orphan
-            // worker in the broker. After register_worker runs, any subsequent
-            // failure has to route through the cleanup guard below to maintain
-            // the "no zombie state" invariant.
-            let boot_path = write_boot_prompt(&self.log_dir, config)
-                .await
-                .map_err(|e| DispatchError::AgentLaunchFailed {
-                    name: config.name.clone(),
-                    reason: format!("write boot prompt: {e}"),
-                })?;
-
-            let id = uuid::Uuid::new_v4().to_string();
-            {
-                let mut broker = self.broker.lock().await;
-                broker
-                    .register_worker(
-                        config.name.clone(),
-                        config.role.clone(),
-                        config.description.clone(),
-                        Vec::new(),
-                        config.ttl,
-                        true, // evict any stale same-name worker from a prior session
-                        Some(id.clone()),
-                        Some(prompt_content.clone()),
-                    )
-                    .map_err(|e| DispatchError::AgentLaunchFailed {
-                        name: config.name.clone(),
-                        reason: format!("pre-register failed: {e}"),
-                    })?;
-            }
-
-            let mut sc = config.clone();
-            sc.prompt_file_path = Some(boot_path);
-
-            let env = self.env_vars(&config.name, &config.role, Some(&id));
-            (env, Some(id), Some(prompt_content), sc)
-        } else {
-            // Legacy unmanaged path (launch=false, or no prompt_file).
-            let env = self.env_vars(&config.name, &config.role, None);
-            (env, None, None, config.clone())
-        };
-
-        // Initial spawn is synchronous so the caller sees config errors
-        // (bad prompt file, missing binary) as a proper Err instead of
-        // discovering them later via AgentState::Crashed.
-        let child =
-            match spawn_child_process(&spawn_config, &env_vars, &self.agent_cwd, &self.log_dir)
-                .await
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    // Clean up the pre-registered worker so we don't leave an
-                    // orphan in the broker that will never check in. Routes
-                    // through remove_worker so mailboxes/notifiers go with it.
-                    if let Some(ref id) = worker_id {
-                        let mut b = self.broker.lock().await;
-                        b.remove_worker(id);
-                    }
-                    return Err(e);
-                }
-            };
-        let pid = child.id().unwrap_or(0);
-        eprintln!(
-            "dispatch serve: launched agent '{}' (role={}, pid={})",
-            config.name, config.role, pid
-        );
-
-        let state = Arc::new(Mutex::new(AgentState::Running {
-            pid,
-            started_at: super::local::now_secs(),
-        }));
-        let shutdown = Arc::new(Notify::new());
-
-        // Re-register hook: passed to the supervisor so it can refresh the
-        // worker record (and re-store the role prompt) on every respawn.
-        // None for unmanaged agents — the supervisor stays on legacy behavior.
-        let re_register = worker_id
-            .zip(role_prompt)
-            .map(|(id, prompt)| (Arc::clone(&self.broker), id, prompt));
-
-        let supervisor = tokio::spawn(supervise_agent(
-            spawn_config,
-            env_vars,
-            self.agent_cwd.clone(),
-            self.log_dir.clone(),
-            child,
-            Arc::clone(&state),
-            Arc::clone(&shutdown),
-            re_register,
-        ));
-
-        self.agents.push(ManagedAgent {
-            name: config.name.clone(),
-            role: config.role.clone(),
-            state,
-            shutdown,
-            supervisor,
-        });
-
+        let snapshot = self.snapshot_spawn_context();
+        let pending = build_pending_agent(snapshot, config).await?;
+        self.register_pending(pending);
         Ok(())
+    }
+
+    /// Validate that an agent named `name` can be started right now: reap
+    /// any finished supervisors, reject if an instance is already running,
+    /// and look up the config. Pure synchronous validation — no IO, no
+    /// broker calls — so callers can release the orchestrator mutex
+    /// immediately after and run the heavy spawn work unlocked.
+    ///
+    /// Companion to `build_pending_agent` + `register_pending` for the
+    /// three-phase start pattern used by HTTP / IPC handlers.
+    pub fn check_can_start(&mut self, name: &str) -> Result<ResolvedAgentConfig, DispatchError> {
+        self.agents.retain(|a| !a.supervisor.is_finished());
+
+        if self.agents.iter().any(|a| a.name == name) {
+            return Err(DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "already running".into(),
+            });
+        }
+        self.configs
+            .iter()
+            .find(|a| a.name == name)
+            .cloned()
+            .ok_or_else(|| DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "no such agent in config".into(),
+            })
+    }
+
+    /// Snapshot the immutable orchestrator state needed to spawn an agent.
+    /// Cheap clones (PathBuf / String / Arc) so the caller can release the
+    /// orchestrator mutex before running the heavyweight async spawn.
+    pub fn snapshot_spawn_context(&self) -> SpawnContext {
+        SpawnContext {
+            broker: Arc::clone(&self.broker),
+            cell_id: self.cell_id.clone(),
+            socket_path: self.socket_path.clone(),
+            monitor_url: self.monitor_url.clone(),
+            agent_cwd: self.agent_cwd.clone(),
+            log_dir: self.log_dir.clone(),
+        }
+    }
+
+    /// Commit a freshly-spawned agent to the orchestrator's tracked set.
+    /// Phase 3 of the unlocked-spawn pattern — caller has already done
+    /// `check_can_start` (phase 1) and `build_pending_agent` (phase 2).
+    pub fn register_pending(&mut self, pending: PendingAgent) {
+        self.agents.push(pending.inner);
     }
 
     /// Snapshot of all managed agents' current runtime state.
@@ -353,23 +317,7 @@ impl AgentOrchestrator {
     /// whose supervisor task has already finished (Crashed or Stopped), so a
     /// previously-failed agent can be started again without needing `restart`.
     pub async fn start_by_name(&mut self, name: &str) -> Result<(), DispatchError> {
-        self.agents.retain(|a| !a.supervisor.is_finished());
-
-        if self.agents.iter().any(|a| a.name == name) {
-            return Err(DispatchError::AgentLaunchFailed {
-                name: name.to_string(),
-                reason: "already running".into(),
-            });
-        }
-        let config = self
-            .configs
-            .iter()
-            .find(|a| a.name == name)
-            .cloned()
-            .ok_or_else(|| DispatchError::AgentLaunchFailed {
-                name: name.to_string(),
-                reason: "no such agent in config".into(),
-            })?;
+        let config = self.check_can_start(name)?;
         self.spawn_agent(&config).await
     }
 
@@ -525,6 +473,138 @@ impl AgentOrchestrator {
             None => false,
         }
     }
+}
+
+/// Spawn an agent process and assemble the supervisor task **without**
+/// touching the orchestrator. Phase 2 of the unlocked-spawn pattern:
+/// `AgentOrchestrator::check_can_start` (locked) → this (unlocked) →
+/// `AgentOrchestrator::register_pending` (locked).
+///
+/// All the heavy waits live here: prompt file read, boot prompt write,
+/// broker pre-register, and `spawn_child_process`. Running this with the
+/// orchestrator mutex released keeps the dashboard's 2 s
+/// `/api/agents/state` poll from stalling on a slow start. The caller is
+/// responsible for calling `check_can_start` first to validate the name.
+pub async fn build_pending_agent(
+    ctx: SpawnContext,
+    config: &ResolvedAgentConfig,
+) -> Result<PendingAgent, DispatchError> {
+    let pre_register = config.launch && config.prompt_file_path.is_some();
+
+    let (env_vars, worker_id, role_prompt, spawn_config) =
+        if pre_register {
+            let prompt_path = config.prompt_file_path.as_ref().ok_or_else(|| {
+                DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: "pre_register set but prompt_file_path is None".into(),
+                }
+            })?;
+            let prompt_content = tokio::fs::read_to_string(prompt_path).await.map_err(|_| {
+                DispatchError::PromptFileNotFound {
+                    name: config.name.clone(),
+                    path: prompt_path.clone(),
+                }
+            })?;
+
+            // Write the boot prompt BEFORE pre-registering so a write failure
+            // (disk full, log_dir not writable, etc.) can't leave an orphan
+            // worker in the broker. After register_worker runs, any subsequent
+            // failure has to route through the cleanup guard below to maintain
+            // the "no zombie state" invariant.
+            let boot_path = write_boot_prompt(&ctx.log_dir, config).await.map_err(|e| {
+                DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: format!("write boot prompt: {e}"),
+                }
+            })?;
+
+            let id = uuid::Uuid::new_v4().to_string();
+            {
+                let mut broker = ctx.broker.lock().await;
+                broker
+                    .register_worker(
+                        config.name.clone(),
+                        config.role.clone(),
+                        config.description.clone(),
+                        Vec::new(),
+                        config.ttl,
+                        true, // evict any stale same-name worker from a prior session
+                        Some(id.clone()),
+                        Some(prompt_content.clone()),
+                    )
+                    .map_err(|e| DispatchError::AgentLaunchFailed {
+                        name: config.name.clone(),
+                        reason: format!("pre-register failed: {e}"),
+                    })?;
+            }
+
+            let mut sc = config.clone();
+            sc.prompt_file_path = Some(boot_path);
+
+            let env = ctx.env_vars(&config.name, &config.role, Some(&id));
+            (env, Some(id), Some(prompt_content), sc)
+        } else {
+            // Legacy unmanaged path (launch=false, or no prompt_file).
+            let env = ctx.env_vars(&config.name, &config.role, None);
+            (env, None, None, config.clone())
+        };
+
+    // Initial spawn is synchronous so the caller sees config errors
+    // (bad prompt file, missing binary) as a proper Err instead of
+    // discovering them later via AgentState::Crashed.
+    let child =
+        match spawn_child_process(&spawn_config, &env_vars, &ctx.agent_cwd, &ctx.log_dir).await {
+            Ok(c) => c,
+            Err(e) => {
+                // Clean up the pre-registered worker so we don't leave an
+                // orphan in the broker that will never check in. Routes
+                // through remove_worker so mailboxes/notifiers go with it.
+                if let Some(ref id) = worker_id {
+                    let mut b = ctx.broker.lock().await;
+                    b.remove_worker(id);
+                }
+                return Err(e);
+            }
+        };
+    let pid = child.id().unwrap_or(0);
+    eprintln!(
+        "dispatch serve: launched agent '{}' (role={}, pid={})",
+        config.name, config.role, pid
+    );
+
+    let state = Arc::new(Mutex::new(AgentState::Running {
+        pid,
+        started_at: super::local::now_secs(),
+    }));
+    let shutdown = Arc::new(Notify::new());
+
+    // Re-register hook: passed to the supervisor so it can refresh the
+    // worker record (and re-store the role prompt) on every respawn.
+    // None for unmanaged agents — the supervisor stays on legacy behavior.
+    let re_register = worker_id
+        .zip(role_prompt)
+        .map(|(id, prompt)| (Arc::clone(&ctx.broker), id, prompt));
+
+    let supervisor = tokio::spawn(supervise_agent(
+        spawn_config,
+        env_vars,
+        ctx.agent_cwd.clone(),
+        ctx.log_dir.clone(),
+        child,
+        Arc::clone(&state),
+        Arc::clone(&shutdown),
+        re_register,
+    ));
+
+    Ok(PendingAgent {
+        inner: ManagedAgent {
+            name: config.name.clone(),
+            role: config.role.clone(),
+            state,
+            shutdown,
+            supervisor,
+        },
+    })
 }
 
 /// Write the issue-#43 one-line boot prompt to a stable per-agent file
@@ -729,7 +809,11 @@ async fn supervise_agent(
                 // prompt before the respawn so the agent's claim call can
                 // get its prompt back even if TTL expired during downtime.
                 // Idempotent on alive workers (no-op claim renewing TTL),
-                // fresh-creates if the record was GC'd.
+                // fresh-creates if the record was GC'd. evict=true so any
+                // stale same-name worker with a different id (e.g. from a
+                // manual `dispatch register` that raced during downtime)
+                // is cleaned up — the supervisor's id should be the only
+                // record bearing this name.
                 //
                 // Treat failure as terminal: if we can't restore the broker
                 // state, the respawned child will fail its `--for-agent`
@@ -737,17 +821,22 @@ async fn supervise_agent(
                 // a generic "exited with ..." reason. Surface the real cause
                 // immediately instead.
                 if let Some((broker, worker_id, role_prompt)) = &re_register {
-                    let mut b = broker.lock().await;
-                    if let Err(err) = b.register_worker(
-                        config.name.clone(),
-                        config.role.clone(),
-                        config.description.clone(),
-                        Vec::new(),
-                        config.ttl,
-                        false,
-                        Some(worker_id.clone()),
-                        Some(role_prompt.clone()),
-                    ) {
+                    let register_result = {
+                        let mut b = broker.lock().await;
+                        b.register_worker(
+                            config.name.clone(),
+                            config.role.clone(),
+                            config.description.clone(),
+                            Vec::new(),
+                            config.ttl,
+                            true,
+                            Some(worker_id.clone()),
+                            Some(role_prompt.clone()),
+                        )
+                        // `b` drops here so `state.lock().await` below
+                        // doesn't pin the broker mutex across the await.
+                    };
+                    if let Err(err) = register_result {
                         tracing::error!(
                             agent = %config.name,
                             %err,
@@ -773,6 +862,16 @@ async fn supervise_agent(
                     }
                     Err(e) => {
                         tracing::warn!(agent = %config.name, error = %e, "respawn failed");
+                        // Symmetric with the initial-spawn cleanup guard:
+                        // the re-register above restored the worker record,
+                        // but spawn_child_process failed (log dir gone,
+                        // prompt file deleted, binary missing, ...). Drop
+                        // the broker entry so it doesn't linger as a zombie
+                        // for a process that will never run.
+                        if let Some((broker, worker_id, _)) = &re_register {
+                            let mut b = broker.lock().await;
+                            b.remove_worker(worker_id);
+                        }
                         *state.lock().await = AgentState::Crashed {
                             reason: format!("respawn failed: {e}"),
                             attempts: attempt,
@@ -905,9 +1004,9 @@ mod tests {
     use super::*;
     use crate::adapter::Adapter;
 
-    /// Constructing `env_vars(_, _, Some(id))` injects `DISPATCH_WORKER_ID`;
-    /// `None` omits the key entirely so legacy register-yourself agents see
-    /// exactly the previous environment.
+    /// Constructing `SpawnContext::env_vars(_, _, Some(id))` injects
+    /// `DISPATCH_WORKER_ID`; `None` omits the key entirely so legacy
+    /// register-yourself agents see exactly the previous environment.
     #[test]
     fn env_vars_includes_worker_id_when_some() {
         let tmp = tempfile::tempdir().unwrap();
@@ -920,8 +1019,9 @@ mod tests {
             Vec::new(),
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
         );
+        let ctx = orch.snapshot_spawn_context();
 
-        let with_id = orch.env_vars("alice", "test-runner", Some("w-123"));
+        let with_id = ctx.env_vars("alice", "test-runner", Some("w-123"));
         assert_eq!(
             with_id.get("DISPATCH_WORKER_ID").map(String::as_str),
             Some("w-123")
@@ -935,7 +1035,7 @@ mod tests {
             Some("test-runner")
         );
 
-        let without_id = orch.env_vars("alice", "test-runner", None);
+        let without_id = ctx.env_vars("alice", "test-runner", None);
         assert!(!without_id.contains_key("DISPATCH_WORKER_ID"));
         // The other vars must match exactly so the legacy code path is bit-for-bit unchanged.
         assert_eq!(
@@ -1147,11 +1247,10 @@ mod tests {
             Arc::clone(&broker),
         );
 
-        // Seed a dummy mailbox + notifier under a placeholder id so we can
-        // confirm the cleanup guard also wipes those alongside `workers` /
-        // `role_prompts`. Any worker id the orchestrator later assigns
-        // won't collide with this placeholder — we're just asserting that
-        // `remove_worker` is what the cleanup path calls.
+        // Force `spawn_agent` to fail and verify the broker is left with no
+        // residual state. This covers cleanup of any entries created during
+        // the failed spawn attempt across `workers`, `role_prompts`,
+        // `mailboxes`, and `notifiers`.
         let cfg = managed_test_config("alice", "true", prompt_path);
         let err = orch.spawn_agent(&cfg).await.expect_err("must fail");
         assert!(

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -136,6 +136,14 @@ pub struct PendingAgent {
 /// Manages the lifecycle of agent subprocesses and heartbeat timers.
 pub struct AgentOrchestrator {
     agents: Vec<ManagedAgent>,
+    /// Names that have passed `check_can_start` but haven't yet reached
+    /// `register_pending`. The 3-phase pattern releases the orchestrator
+    /// mutex during `build_pending_agent`; without this reservation, two
+    /// concurrent `AgentStart` calls for the same name would both pass
+    /// phase 1's "not in agents" check and both push duplicate entries
+    /// in phase 3. Phase 1 atomically inserts here; phase 3 (success) or
+    /// `cancel_start` (build failure) removes.
+    starting: HashSet<String>,
     heartbeats: Vec<RunningHeartbeat>,
     cell_id: String,
     socket_path: PathBuf,
@@ -168,6 +176,7 @@ impl AgentOrchestrator {
     ) -> Self {
         Self {
             agents: Vec::new(),
+            starting: HashSet::new(),
             heartbeats: Vec::new(),
             cell_id: cell_id.to_string(),
             socket_path: socket_path.to_path_buf(),
@@ -241,11 +250,18 @@ impl AgentOrchestrator {
         Ok(())
     }
 
-    /// Validate that an agent named `name` can be started right now: reap
-    /// any finished supervisors, reject if an instance is already running,
-    /// and look up the config. Pure synchronous validation — no IO, no
-    /// broker calls — so callers can release the orchestrator mutex
-    /// immediately after and run the heavy spawn work unlocked.
+    /// Validate that an agent named `name` can be started right now and
+    /// reserve the slot. Reaps any finished supervisors, rejects if an
+    /// instance is already running OR another concurrent caller is
+    /// already in the middle of starting one, looks up the config, and
+    /// inserts `name` into `starting`. Pure synchronous validation —
+    /// no IO, no broker calls — so callers can release the orchestrator
+    /// mutex immediately after and run the heavy spawn work unlocked.
+    ///
+    /// On success the caller MUST eventually call either `register_pending`
+    /// (build succeeded) or `cancel_start` (build failed). Otherwise the
+    /// `starting` reservation lingers and future starts of the same name
+    /// will be rejected with "already starting" forever.
     ///
     /// Companion to `build_pending_agent` + `register_pending` for the
     /// three-phase start pattern used by HTTP / IPC handlers.
@@ -258,14 +274,31 @@ impl AgentOrchestrator {
                 reason: "already running".into(),
             });
         }
-        self.configs
+        if self.starting.contains(name) {
+            return Err(DispatchError::AgentLaunchFailed {
+                name: name.to_string(),
+                reason: "already starting from a concurrent request".into(),
+            });
+        }
+        let config = self
+            .configs
             .iter()
             .find(|a| a.name == name)
             .cloned()
             .ok_or_else(|| DispatchError::AgentLaunchFailed {
                 name: name.to_string(),
                 reason: "no such agent in config".into(),
-            })
+            })?;
+        self.starting.insert(name.to_string());
+        Ok(config)
+    }
+
+    /// Release a `starting` reservation that was claimed by
+    /// `check_can_start` but won't be completed. Call from the build
+    /// error path of the three-phase pattern; without it the slot is
+    /// permanently reserved and future starts of the same name fail.
+    pub fn cancel_start(&mut self, name: &str) {
+        self.starting.remove(name);
     }
 
     /// Snapshot the immutable orchestrator state needed to spawn an agent.
@@ -284,8 +317,17 @@ impl AgentOrchestrator {
 
     /// Commit a freshly-spawned agent to the orchestrator's tracked set.
     /// Phase 3 of the unlocked-spawn pattern — caller has already done
-    /// `check_can_start` (phase 1) and `build_pending_agent` (phase 2).
+    /// `check_can_start` (phase 1, claimed the `starting` reservation)
+    /// and `build_pending_agent` (phase 2, did the heavy IO work).
+    /// Removes the reservation and pushes onto `agents`. No race-recheck
+    /// needed: the phase 1 reservation guaranteed mutual exclusion against
+    /// other concurrent starts of this name.
+    ///
+    /// Tolerant of being called without a prior reservation (e.g. via
+    /// `spawn_agent`'s always-locked path) — the remove is a no-op when
+    /// the name isn't present.
     pub fn register_pending(&mut self, pending: PendingAgent) {
+        self.starting.remove(&pending.inner.name);
         self.agents.push(pending.inner);
     }
 
@@ -808,18 +850,27 @@ async fn supervise_agent(
                 // Issue #43: refresh the broker's worker record + role
                 // prompt before the respawn so the agent's claim call can
                 // get its prompt back even if TTL expired during downtime.
-                // Idempotent on alive workers (no-op claim renewing TTL),
-                // fresh-creates if the record was GC'd. evict=true so any
-                // stale same-name worker with a different id (e.g. from a
-                // manual `dispatch register` that raced during downtime)
-                // is cleaned up — the supervisor's id should be the only
-                // record bearing this name.
+                // Three branches in `BrokerState::register_worker`:
+                // - Supervisor's worker still alive (TTL not expired):
+                //   idempotent-claim short-circuit matches name+role,
+                //   renews TTL, refreshes description (and capabilities
+                //   if non-empty). evict pass is BYPASSED — a same-name
+                //   worker with a different id from a racing manual
+                //   `dispatch register` would persist alongside us.
+                // - Supervisor's worker GC'd: idempotent-claim misses,
+                //   evict=true wipes any same-name worker with a
+                //   different id, then a fresh entry is created using
+                //   the supervisor's id.
+                // - worker_id collision (different name+role under our
+                //   id — essentially impossible with UUIDs but defended
+                //   against): register_worker returns Err, handled below
+                //   as terminal Crashed.
                 //
-                // Treat failure as terminal: if we can't restore the broker
-                // state, the respawned child will fail its `--for-agent`
-                // lookup and crash-loop until MAX_RESTART_ATTEMPTS with only
-                // a generic "exited with ..." reason. Surface the real cause
-                // immediately instead.
+                // Treat the Err case as terminal: if we can't restore
+                // the broker state, the respawned child will fail its
+                // `--for-agent` lookup and crash-loop until
+                // MAX_RESTART_ATTEMPTS with only a generic "exited with
+                // ..." reason. Surface the real cause immediately instead.
                 if let Some((broker, worker_id, role_prompt)) = &re_register {
                     let register_result = {
                         let mut b = broker.lock().await;
@@ -1277,6 +1328,71 @@ mod tests {
             b.notifiers.is_empty(),
             "spawn failure must not leave an orphan notifier",
         );
+    }
+
+    /// `check_can_start` reserves the agent name in `starting` so a
+    /// concurrent caller in the unlocked-spawn pattern can't pass phase
+    /// 1 for the same name. `register_pending` and `cancel_start` both
+    /// release the reservation. Without this, two parallel
+    /// `BrokerRequest::AgentStart` calls would race past `check_can_start`
+    /// and push duplicate `ManagedAgent` entries.
+    #[tokio::test]
+    async fn check_can_start_reserves_name_until_register_or_cancel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = test_config("alice", "sleep 30");
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            vec![cfg.clone()],
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+        );
+
+        // First reservation succeeds.
+        orch.check_can_start("alice").expect("first reservation");
+
+        // Second reservation while the first is still pending must fail
+        // with "already starting" — this is the race-defense that makes
+        // the 3-phase pattern safe.
+        let err = orch
+            .check_can_start("alice")
+            .expect_err("second reservation must be rejected");
+        match err {
+            DispatchError::AgentLaunchFailed { name, reason } => {
+                assert_eq!(name, "alice");
+                assert!(
+                    reason.contains("already starting"),
+                    "expected 'already starting' rejection, got: {reason}"
+                );
+            }
+            other => panic!("expected AgentLaunchFailed, got: {other:?}"),
+        }
+
+        // cancel_start releases the slot — a fresh check_can_start succeeds.
+        orch.cancel_start("alice");
+        orch.check_can_start("alice")
+            .expect("post-cancel reservation");
+
+        // Now exercise the success path via a real spawn. spawn_agent is
+        // tolerant of the lingering reservation (register_pending removes
+        // it) so the agent ends up in `agents` with no leftover slot.
+        orch.spawn_agent(&cfg).await.expect("spawn");
+        // After register_pending, "alice" is in agents and NOT in starting.
+        // Starting a fresh "alice" now hits the "already running" guard,
+        // not "already starting".
+        let err = orch.check_can_start("alice").expect_err("alice is running");
+        match err {
+            DispatchError::AgentLaunchFailed { reason, .. } => {
+                assert!(
+                    reason.contains("already running"),
+                    "expected 'already running', got: {reason}"
+                );
+            }
+            other => panic!("expected AgentLaunchFailed, got: {other:?}"),
+        }
+        orch.shutdown_all().await;
     }
 
     /// Supervisor reports Running while a long-lived child is alive, and

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -130,7 +130,11 @@ impl AgentOrchestrator {
     }
 
     /// Build the environment variables injected into every agent subprocess.
-    fn env_vars(&self, name: &str, role: &str) -> HashMap<String, String> {
+    ///
+    /// `worker_id` is `Some` once dispatch pre-registers the worker server-side
+    /// at spawn time (see issue #43). When `None`, the var is omitted and the
+    /// agent must fall back to the legacy "register myself" flow.
+    fn env_vars(&self, name: &str, role: &str, worker_id: Option<&str>) -> HashMap<String, String> {
         let mut vars = HashMap::new();
         vars.insert("DISPATCH_CELL_ID".into(), self.cell_id.clone());
         vars.insert(
@@ -142,6 +146,9 @@ impl AgentOrchestrator {
         }
         vars.insert("DISPATCH_AGENT_NAME".into(), name.into());
         vars.insert("DISPATCH_AGENT_ROLE".into(), role.into());
+        if let Some(id) = worker_id {
+            vars.insert("DISPATCH_WORKER_ID".into(), id.into());
+        }
         vars
     }
 
@@ -173,7 +180,10 @@ impl AgentOrchestrator {
     /// comes from the adapter's `stdin_file` (typically the prompt file) or
     /// is `/dev/null` if the adapter doesn't need one.
     pub async fn spawn_agent(&mut self, config: &ResolvedAgentConfig) -> Result<(), DispatchError> {
-        let env_vars = self.env_vars(&config.name, &config.role);
+        // Step 4 of the issue-#43 rollout will pre-register the worker here
+        // and pass the assigned id. Until then, leave `DISPATCH_WORKER_ID`
+        // unset so the legacy in-agent register flow keeps working.
+        let env_vars = self.env_vars(&config.name, &config.role, None);
 
         // Initial spawn is synchronous so the caller sees config errors
         // (bad prompt file, missing binary) as a proper Err instead of
@@ -611,11 +621,14 @@ async fn supervise_agent(
 /// Build an agent command string for the user to paste.
 ///
 /// Includes the dispatch env vars (shell-escaped) and the adapter-assembled
-/// launch string.
+/// launch string. `worker_id` is `Some` only for the managed-spawn print path
+/// (issue #43); the unmanaged copy-paste path leaves it `None` so the agent
+/// receives a broker-assigned id from its own `dispatch register` call.
 pub fn build_agent_command(
     config: &ResolvedAgentConfig,
     cell_id: &str,
     monitor_url: Option<&str>,
+    worker_id: Option<&str>,
 ) -> String {
     let mut parts = vec![
         format!("DISPATCH_CELL_ID={}", shell_escape(cell_id)),
@@ -625,6 +638,10 @@ pub fn build_agent_command(
 
     if let Some(url) = monitor_url {
         parts.push(format!("DISPATCH_MONITOR_URL={}", shell_escape(url)));
+    }
+
+    if let Some(id) = worker_id {
+        parts.push(format!("DISPATCH_WORKER_ID={}", shell_escape(id)));
     }
 
     let cmd_str = AgentOrchestrator::build_launch(config)
@@ -720,6 +737,68 @@ pub(super) fn sanitize_name(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::adapter::Adapter;
+
+    /// Constructing `env_vars(_, _, Some(id))` injects `DISPATCH_WORKER_ID`;
+    /// `None` omits the key entirely so legacy register-yourself agents see
+    /// exactly the previous environment.
+    #[test]
+    fn env_vars_includes_worker_id_when_some() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = AgentOrchestrator::new(
+            "cell-x",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+        );
+
+        let with_id = orch.env_vars("alice", "test-runner", Some("w-123"));
+        assert_eq!(
+            with_id.get("DISPATCH_WORKER_ID").map(String::as_str),
+            Some("w-123")
+        );
+        assert_eq!(
+            with_id.get("DISPATCH_AGENT_NAME").map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            with_id.get("DISPATCH_AGENT_ROLE").map(String::as_str),
+            Some("test-runner")
+        );
+
+        let without_id = orch.env_vars("alice", "test-runner", None);
+        assert!(!without_id.contains_key("DISPATCH_WORKER_ID"));
+        // The other vars must match exactly so the legacy code path is bit-for-bit unchanged.
+        assert_eq!(
+            without_id.get("DISPATCH_AGENT_NAME").map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            without_id.get("DISPATCH_AGENT_ROLE").map(String::as_str),
+            Some("test-runner")
+        );
+    }
+
+    /// `build_agent_command` emits `DISPATCH_WORKER_ID=<id>` only when the id
+    /// is supplied — the unmanaged copy-paste path keeps its previous output.
+    #[test]
+    fn build_agent_command_includes_worker_id_when_some() {
+        let cfg = test_config("alice", "echo hi");
+        let with_id = build_agent_command(&cfg, "cell-x", None, Some("w-123"));
+        // shell_escape wraps the value in single quotes; assert on the
+        // assignment as it would appear after escaping.
+        assert!(
+            with_id.contains("DISPATCH_WORKER_ID='w-123'"),
+            "expected worker id in: {with_id}",
+        );
+
+        let without_id = build_agent_command(&cfg, "cell-x", None, None);
+        assert!(
+            !without_id.contains("DISPATCH_WORKER_ID"),
+            "did not expect worker id in: {without_id}",
+        );
+    }
 
     /// Exponential doubling capped at 30s — table-driven so the intent is
     /// obvious if anyone tunes the backoff schedule later.

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -358,9 +358,24 @@ impl AgentOrchestrator {
     /// Before rejecting on `already running`, this reaps any ManagedAgent
     /// whose supervisor task has already finished (Crashed or Stopped), so a
     /// previously-failed agent can be started again without needing `restart`.
+    ///
+    /// Uses the explicit three-phase pattern (`check_can_start` →
+    /// `build_pending_agent` → `register_pending` / `cancel_start`) so a
+    /// build failure after `check_can_start` reserved the slot releases
+    /// the reservation instead of leaving it stuck as "already starting".
     pub async fn start_by_name(&mut self, name: &str) -> Result<(), DispatchError> {
         let config = self.check_can_start(name)?;
-        self.spawn_agent(&config).await
+        let snapshot = self.snapshot_spawn_context();
+        match build_pending_agent(snapshot, &config).await {
+            Ok(pending) => {
+                self.register_pending(pending);
+                Ok(())
+            }
+            Err(e) => {
+                self.cancel_start(name);
+                Err(e)
+            }
+        }
     }
 
     /// Restart a running agent: stop it (if running) then spawn it again.
@@ -938,14 +953,17 @@ async fn supervise_agent(
 /// Build an agent command string for the user to paste.
 ///
 /// Includes the dispatch env vars (shell-escaped) and the adapter-assembled
-/// launch string. `worker_id` is `Some` only for the managed-spawn print path
-/// (issue #43); the unmanaged copy-paste path leaves it `None` so the agent
-/// receives a broker-assigned id from its own `dispatch register` call.
+/// launch string. Used by the monitor dashboard's sidebar and by the
+/// serve-time "Unmanaged agents" banner — both are copy-paste paths where
+/// the agent runs its own `dispatch register` and receives a broker-assigned
+/// id. The managed-spawn flow (issue #43, `launch = true` + `prompt_file`)
+/// goes through `build_pending_agent` / `spawn_child_process`, which assembles
+/// the command via `build_launch` directly and injects `DISPATCH_WORKER_ID`
+/// via the env snapshot rather than the command string.
 pub fn build_agent_command(
     config: &ResolvedAgentConfig,
     cell_id: &str,
     monitor_url: Option<&str>,
-    worker_id: Option<&str>,
 ) -> String {
     let mut parts = vec![
         format!("DISPATCH_CELL_ID={}", shell_escape(cell_id)),
@@ -955,10 +973,6 @@ pub fn build_agent_command(
 
     if let Some(url) = monitor_url {
         parts.push(format!("DISPATCH_MONITOR_URL={}", shell_escape(url)));
-    }
-
-    if let Some(id) = worker_id {
-        parts.push(format!("DISPATCH_WORKER_ID={}", shell_escape(id)));
     }
 
     let cmd_str = AgentOrchestrator::build_launch(config)
@@ -1025,7 +1039,7 @@ pub fn build_main_agent_command(
 /// Whether `s` is safe to use as a single filename component on disk and as
 /// a path segment in a URL (no separators, no `..`, ASCII alphanumerics plus
 /// `-` and `_`).
-pub(super) fn is_safe_name(s: &str) -> bool {
+pub fn is_safe_name(s: &str) -> bool {
     !s.is_empty()
         && s.chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -1096,26 +1110,6 @@ mod tests {
         assert_eq!(
             without_id.get("DISPATCH_AGENT_ROLE").map(String::as_str),
             Some("test-runner")
-        );
-    }
-
-    /// `build_agent_command` emits `DISPATCH_WORKER_ID=<id>` only when the id
-    /// is supplied — the unmanaged copy-paste path keeps its previous output.
-    #[test]
-    fn build_agent_command_includes_worker_id_when_some() {
-        let cfg = test_config("alice", "echo hi");
-        let with_id = build_agent_command(&cfg, "cell-x", None, Some("w-123"));
-        // shell_escape wraps the value in single quotes; assert on the
-        // assignment as it would appear after escaping.
-        assert!(
-            with_id.contains("DISPATCH_WORKER_ID='w-123'"),
-            "expected worker id in: {with_id}",
-        );
-
-        let without_id = build_agent_command(&cfg, "cell-x", None, None);
-        assert!(
-            !without_id.contains("DISPATCH_WORKER_ID"),
-            "did not expect worker id in: {without_id}",
         );
     }
 
@@ -1328,6 +1322,39 @@ mod tests {
             b.notifiers.is_empty(),
             "spawn failure must not leave an orphan notifier",
         );
+    }
+
+    /// `start_by_name` must release the `starting` reservation when
+    /// `build_pending_agent` fails — otherwise a bad prompt_file (or any
+    /// other build error) permanently blocks the name from ever being
+    /// started. Uses a managed config pointing at a nonexistent prompt
+    /// file to force `build_pending_agent` to error after the reservation
+    /// is claimed.
+    #[tokio::test]
+    async fn start_by_name_releases_reservation_on_build_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bad_cfg = managed_test_config("alice", "true", tmp.path().join("nope.md"));
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            vec![bad_cfg],
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+        );
+
+        // Build fails because the prompt file doesn't exist.
+        let err = orch.start_by_name("alice").await.expect_err("must fail");
+        assert!(
+            matches!(err, DispatchError::PromptFileNotFound { .. }),
+            "expected PromptFileNotFound, got: {err:?}",
+        );
+
+        // Reservation must have been released — a fresh `check_can_start`
+        // for the same name succeeds rather than hitting "already starting".
+        orch.check_can_start("alice")
+            .expect("reservation must be released after build failure");
     }
 
     /// `check_can_start` reserves the agent name in `starting` so a

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -209,16 +209,30 @@ impl AgentOrchestrator {
         let pre_register = config.launch && config.prompt_file_path.is_some();
 
         let (env_vars, worker_id, role_prompt, spawn_config) = if pre_register {
-            let prompt_path = config
-                .prompt_file_path
-                .as_ref()
-                .expect("checked by pre_register guard");
+            let prompt_path = config.prompt_file_path.as_ref().ok_or_else(|| {
+                DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: "pre_register set but prompt_file_path is None".into(),
+                }
+            })?;
             let prompt_content = tokio::fs::read_to_string(prompt_path).await.map_err(|_| {
                 DispatchError::PromptFileNotFound {
                     name: config.name.clone(),
                     path: prompt_path.clone(),
                 }
             })?;
+
+            // Write the boot prompt BEFORE pre-registering so a write failure
+            // (disk full, log_dir not writable, etc.) can't leave an orphan
+            // worker in the broker. After register_worker runs, any subsequent
+            // failure has to route through the cleanup guard below to maintain
+            // the "no zombie state" invariant.
+            let boot_path = write_boot_prompt(&self.log_dir, config)
+                .await
+                .map_err(|e| DispatchError::AgentLaunchFailed {
+                    name: config.name.clone(),
+                    reason: format!("write boot prompt: {e}"),
+                })?;
 
             let id = uuid::Uuid::new_v4().to_string();
             {
@@ -239,13 +253,6 @@ impl AgentOrchestrator {
                         reason: format!("pre-register failed: {e}"),
                     })?;
             }
-
-            let boot_path = write_boot_prompt(&self.log_dir, config)
-                .await
-                .map_err(|e| DispatchError::AgentLaunchFailed {
-                    name: config.name.clone(),
-                    reason: format!("write boot prompt: {e}"),
-                })?;
 
             let mut sc = config.clone();
             sc.prompt_file_path = Some(boot_path);
@@ -268,11 +275,11 @@ impl AgentOrchestrator {
                 Ok(c) => c,
                 Err(e) => {
                     // Clean up the pre-registered worker so we don't leave an
-                    // orphan in the broker that will never check in.
+                    // orphan in the broker that will never check in. Routes
+                    // through remove_worker so mailboxes/notifiers go with it.
                     if let Some(ref id) = worker_id {
                         let mut b = self.broker.lock().await;
-                        b.workers.remove(id);
-                        b.role_prompts.remove(id);
+                        b.remove_worker(id);
                     }
                     return Err(e);
                 }
@@ -723,6 +730,12 @@ async fn supervise_agent(
                 // get its prompt back even if TTL expired during downtime.
                 // Idempotent on alive workers (no-op claim renewing TTL),
                 // fresh-creates if the record was GC'd.
+                //
+                // Treat failure as terminal: if we can't restore the broker
+                // state, the respawned child will fail its `--for-agent`
+                // lookup and crash-loop until MAX_RESTART_ATTEMPTS with only
+                // a generic "exited with ..." reason. Surface the real cause
+                // immediately instead.
                 if let Some((broker, worker_id, role_prompt)) = &re_register {
                     let mut b = broker.lock().await;
                     if let Err(err) = b.register_worker(
@@ -735,7 +748,16 @@ async fn supervise_agent(
                         Some(worker_id.clone()),
                         Some(role_prompt.clone()),
                     ) {
-                        tracing::warn!(agent = %config.name, %err, "restart re-register failed");
+                        tracing::error!(
+                            agent = %config.name,
+                            %err,
+                            "restart re-register failed; marking agent crashed",
+                        );
+                        *state.lock().await = AgentState::Crashed {
+                            reason: format!("re-register failed: {err}"),
+                            attempts: attempt,
+                        };
+                        return;
                     }
                 }
 
@@ -1070,8 +1092,9 @@ mod tests {
     }
 
     /// Issue #43: a missing prompt file fails the spawn and leaves NO
-    /// orphan worker in the broker — the cleanup guard runs before the
-    /// supervisor is attached.
+    /// orphan worker in the broker. The read_to_string `?` returns before
+    /// `register_worker` is reached, so nothing is ever created — the
+    /// early return (not the cleanup guard) is what prevents the orphan.
     #[tokio::test]
     async fn spawn_managed_agent_missing_prompt_file_leaves_no_orphan() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1095,6 +1118,65 @@ mod tests {
         assert!(
             b.workers.is_empty(),
             "failed pre-register must not leave an orphan worker",
+        );
+    }
+
+    /// Issue #43: when `spawn_child_process` fails AFTER the pre-register
+    /// succeeds, the cleanup guard must remove the worker record, role
+    /// prompt, mailbox, and notifier so no zombie state survives in the
+    /// broker. We trigger a spawn failure by pointing `agent_cwd` at a
+    /// path that doesn't exist — `Command::current_dir` errors with ENOENT
+    /// when the spawn syscall tries to chdir.
+    #[tokio::test]
+    async fn spawn_managed_agent_spawn_failure_triggers_cleanup_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prompt_path = tmp.path().join("alice.md");
+        tokio::fs::write(&prompt_path, "role prompt body")
+            .await
+            .unwrap();
+
+        let bad_cwd = tmp.path().join("does-not-exist-cwd");
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let mut orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            &bad_cwd,
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+
+        // Seed a dummy mailbox + notifier under a placeholder id so we can
+        // confirm the cleanup guard also wipes those alongside `workers` /
+        // `role_prompts`. Any worker id the orchestrator later assigns
+        // won't collide with this placeholder — we're just asserting that
+        // `remove_worker` is what the cleanup path calls.
+        let cfg = managed_test_config("alice", "true", prompt_path);
+        let err = orch.spawn_agent(&cfg).await.expect_err("must fail");
+        assert!(
+            matches!(err, DispatchError::AgentLaunchFailed { .. }),
+            "expected AgentLaunchFailed, got: {err:?}",
+        );
+
+        let b = broker.lock().await;
+        assert!(
+            b.workers.is_empty(),
+            "spawn failure must not leave an orphan worker: {:?}",
+            b.workers,
+        );
+        assert!(
+            b.role_prompts.is_empty(),
+            "spawn failure must not leave an orphan role prompt: {:?}",
+            b.role_prompts,
+        );
+        assert!(
+            b.mailboxes.is_empty(),
+            "spawn failure must not leave an orphan mailbox",
+        );
+        assert!(
+            b.notifiers.is_empty(),
+            "spawn failure must not leave an orphan notifier",
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,22 @@ pub enum Commands {
         /// worker that dispatch pre-registered for them at spawn time.
         #[arg(long = "worker-id")]
         worker_id: Option<String>,
+
+        /// Role prompt body to associate with this worker (issue #43).
+        /// Only the orchestrator passes this — at pre-register time it
+        /// loads the agent's `prompt_file` and ships the content here so
+        /// the spawned agent can fetch it back via `--for-agent`.
+        #[arg(long = "role-prompt")]
+        role_prompt: Option<String>,
+
+        /// Output the role prompt body to stdout instead of the JSON
+        /// envelope (issue #43). Intentional CLI wart whose only purpose
+        /// is to be friendly to a downstream LLM tool result: the spawned
+        /// agent's first tool call is `dispatch register --for-agent`,
+        /// and the prompt body landing on stdout becomes its next
+        /// instruction. Without the flag, behavior is unchanged.
+        #[arg(long = "for-agent")]
+        for_agent: bool,
     },
 
     /// List active workers in the current cell

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,12 +88,14 @@ pub enum Commands {
         #[arg(long = "role-prompt")]
         role_prompt: Option<String>,
 
-        /// Output the role prompt body to stdout instead of the JSON
-        /// envelope (issue #43). Intentional CLI wart whose only purpose
-        /// is to be friendly to a downstream LLM tool result: the spawned
-        /// agent's first tool call is `dispatch register --for-agent`,
-        /// and the prompt body landing on stdout becomes its next
-        /// instruction. Without the flag, behavior is unchanged.
+        /// Route the role prompt body to stdout (for downstream LLM tool
+        /// result consumption); the JSON envelope is redirected to stderr
+        /// with `role_prompt` stripped (issue #43). Intentional CLI wart
+        /// whose only purpose is to be friendly to a downstream LLM tool
+        /// result: the spawned agent's first tool call is `dispatch
+        /// register --for-agent`, and the prompt body landing on stdout
+        /// becomes its next instruction. Without the flag, behavior is
+        /// unchanged.
         #[arg(long = "for-agent")]
         for_agent: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,14 @@ pub enum Commands {
         /// Evict any existing worker with the same name before registering
         #[arg(long)]
         evict: bool,
+
+        /// Pre-assigned worker id (issue #43). When set, the broker uses
+        /// this id rather than generating one. If a worker with this id
+        /// already exists with the same name+role, the call is treated as
+        /// an idempotent claim — used by spawned agents to attach to a
+        /// worker that dispatch pre-registered for them at spawn time.
+        #[arg(long = "worker-id")]
+        worker_id: Option<String>,
     },
 
     /// List active workers in the current cell

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,10 @@ pub struct ResolvedAgentConfig {
     /// substitution in command-adapter shell strings.
     pub prompt_file_path: Option<PathBuf>,
     pub ttl: Option<u64>,
+    /// Issue #43: when true, the claude adapter is launched with
+    /// `--output-format stream-json --verbose` so per-tool-use entries
+    /// appear in the agent log.
+    pub stream_json: bool,
     /// Whether `dispatch serve` should auto-launch and supervise this agent.
     pub launch: bool,
 }
@@ -128,6 +132,13 @@ pub struct AgentConfig {
     /// Whether `dispatch serve --launch` should auto-start this agent.
     #[serde(default)]
     pub launch: bool,
+    /// Issue #43: when true, the claude adapter is launched with
+    /// `--output-format stream-json --verbose` so per-tool-use entries
+    /// appear in the agent log. Verification mechanism — without it, a
+    /// hallucinated register call and a real one are visually identical
+    /// in the log. Default off so logs stay quiet for normal use.
+    #[serde(default)]
+    pub stream_json: bool,
 }
 
 /// On-disk main agent definition.
@@ -203,6 +214,7 @@ fn resolve_agent_config(
         prompt,
         prompt_file_path,
         ttl: agent.ttl,
+        stream_json: agent.stream_json,
         launch: agent.launch,
     })
 }
@@ -284,6 +296,10 @@ const CONFIG_TEMPLATE: &str = "\
 # prompt_file = \"prompts/reviewer.md\"            # role prompt body (see above)
 # launch = true
 # ttl = 3600
+# stream_json = false                            # when true, claude is launched with
+#                                                # `--output-format stream-json --verbose`
+#                                                # so per-tool-use entries appear in the
+#                                                # agent log (issue #43 verification).
 #
 # # `command` adapter — for bash-script / non-LLM workers:
 # [[agents]]
@@ -657,6 +673,39 @@ launch = true
         assert!(a.launch);
         assert!(a.command.is_none());
         assert!(a.prompt_file_path.is_some());
+        // Issue #43: stream_json defaults to false so existing configs see
+        // no behavior change.
+        assert!(!a.stream_json, "stream_json must default to false");
+    }
+
+    /// Issue #43: `stream_json = true` round-trips through TOML and lands
+    /// on the resolved config. Verified separately by the claude adapter
+    /// test that translates this flag into argv.
+    #[test]
+    fn agent_config_parses_stream_json_flag() {
+        let tmp = TempDir::new().unwrap();
+        let prompt_path = tmp.path().join("reviewer.md");
+        fs::write(&prompt_path, "you are a reviewer").unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "reviewer"
+role = "reviewer"
+description = "reviews"
+adapter = "claude"
+prompt_file = "reviewer.md"
+stream_json = true
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        assert!(
+            resolved.agents[0].stream_json,
+            "stream_json = true in TOML must land on the resolved config",
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,14 +261,27 @@ const CONFIG_TEMPLATE: &str = "\
 # port = 8384
 # open = true  # open the dashboard in your default browser
 
-# Agent definitions — auto-started by `dispatch serve --launch` when launch = true
+# Agent definitions — auto-started by `dispatch serve --launch` when launch = true.
+#
+# When `launch = true` AND `prompt_file` is set (the managed-agent flow),
+# dispatch pre-registers the worker server-side at spawn time, injects
+# DISPATCH_WORKER_ID into the agent's environment, and feeds the agent a
+# one-line boot prompt. The first thing the model does is run
+# `dispatch register --worker-id \"$DISPATCH_WORKER_ID\" ... --for-agent`,
+# whose response body is the contents of `prompt_file` — so the role prompt
+# lands in the model's tool result instead of being narrated up front (this
+# kills a class of hallucination where the model fakes the register step).
+#
+# When `launch = false`, dispatch prints the command for you to copy into a
+# separate terminal and the agent registers itself the legacy way.
+#
 # [[agents]]
 # name = \"reviewer\"
 # role = \"code-reviewer\"
 # description = \"Reviews code changes\"
 # adapter = \"claude\"                            # one of: command | claude | codex
 # extra_args = [\"--model\", \"sonnet\"]          # appended to the adapter's argv
-# prompt_file = \"prompts/reviewer.md\"
+# prompt_file = \"prompts/reviewer.md\"            # role prompt body (see above)
 # launch = true
 # ttl = 3600
 #

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,23 @@ fn resolve_agent_config(
 ) -> Result<ResolvedAgentConfig, DispatchError> {
     use crate::adapter::Adapter;
 
+    // Reject names that can't be used as a single on-disk filename
+    // component. The HTTP boundaries (`api_agent_start/stop/restart`) already
+    // gate on `is_safe_name`, but the `launch_all` / `spawn_agent` path
+    // derives the issue-#43 boot-prompt filename from `sanitize_name`, which
+    // lossily collapses non-`[A-Za-z0-9_-]` characters to `_`. Two configs
+    // like `alice/foo` and `alice_foo` would both map to
+    // `alice_foo.boot.prompt`, silently overwriting each other. Enforce the
+    // same rule at config time so both paths use the identical gate.
+    if !crate::backend::orchestrator::is_safe_name(&agent.name) {
+        return Err(DispatchError::AgentConfigError {
+            name: agent.name.clone(),
+            reason:
+                "agent name must be non-empty and contain only ASCII alphanumerics, '-', or '_'"
+                    .into(),
+        });
+    }
+
     if agent.adapter == Adapter::Command && agent.command.is_none() {
         return Err(DispatchError::AgentConfigError {
             name: agent.name.clone(),
@@ -842,5 +859,33 @@ adapter = "gpt"
         .unwrap();
 
         assert!(resolve_config_inner(None, None, None, tmp.path()).is_err());
+    }
+
+    /// Agent names must pass `is_safe_name` at resolve time so the
+    /// boot-prompt filename (derived via lossy `sanitize_name`) cannot
+    /// collide across distinct raw names under `dispatch serve --launch`.
+    #[test]
+    fn agent_config_rejects_name_with_unsafe_characters() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "alice/foo"
+role = "worker"
+description = "d"
+adapter = "command"
+command = "./run.sh"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("alice/foo") && msg.contains("ASCII"),
+            "expected safe-name rejection for 'alice/foo', got: {msg}"
+        );
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,12 @@ pub enum DispatchError {
     #[error("prompt file not found for agent \"{name}\": {path}")]
     PromptFileNotFound { name: String, path: PathBuf },
 
+    #[error("register --for-agent failed: {message}")]
+    RegisterForAgentFailed { message: String },
+
+    #[error("--for-agent set but response carries no role prompt")]
+    NoRolePromptReturned,
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     capabilities,
                     ttl,
                     evict,
+                    worker_id,
                 } => BrokerRequest::Register {
                     name,
                     role,
@@ -112,6 +113,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     capabilities,
                     ttl_secs: ttl,
                     evict,
+                    worker_id,
                 },
                 Commands::Team => BrokerRequest::Team {
                     from: cli.from.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,37 +219,49 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                 // broker has no prompt stored for this worker, exit nonzero
                 // — the agent has nothing to do and the supervisor should
                 // restart rather than have the model see empty stdout.
-                if let BrokerResponse::Ok {
-                    payload:
-                        ResponsePayload::WorkerRegistered {
-                            worker_id,
-                            role_prompt: Some(prompt),
-                        },
-                } = &response
-                {
-                    // Write the prompt body verbatim (no trailing newline
-                    // added) so the agent receives byte-for-byte what the
-                    // orchestrator stored.
-                    use std::io::Write as _;
-                    let mut stdout = std::io::stdout().lock();
-                    stdout.write_all(prompt.as_bytes())?;
-                    stdout.flush()?;
+                match &response {
+                    BrokerResponse::Ok {
+                        payload:
+                            ResponsePayload::WorkerRegistered {
+                                worker_id,
+                                role_prompt: Some(prompt),
+                            },
+                    } => {
+                        // Write the prompt body verbatim (no trailing newline
+                        // added) so the agent receives byte-for-byte what the
+                        // orchestrator stored.
+                        use std::io::Write as _;
+                        let mut stdout = std::io::stdout().lock();
+                        stdout.write_all(prompt.as_bytes())?;
+                        stdout.flush()?;
 
-                    // Strip `role_prompt` from the stderr envelope so the
-                    // prompt body isn't duplicated into agent logs.
-                    let stripped = BrokerResponse::Ok {
-                        payload: ResponsePayload::WorkerRegistered {
-                            worker_id: worker_id.clone(),
-                            role_prompt: None,
-                        },
-                    };
-                    let json = serde_json::to_string(&stripped)?;
-                    eprintln!("{json}");
-                } else {
-                    let json = serde_json::to_string(&response)?;
-                    eprintln!("{json}");
-                    eprintln!("dispatch: --for-agent set but response carries no role prompt");
-                    process::exit(1);
+                        // Strip `role_prompt` from the stderr envelope so the
+                        // prompt body isn't duplicated into agent logs.
+                        let stripped = BrokerResponse::Ok {
+                            payload: ResponsePayload::WorkerRegistered {
+                                worker_id: worker_id.clone(),
+                                role_prompt: None,
+                            },
+                        };
+                        let json = serde_json::to_string(&stripped)?;
+                        eprintln!("{json}");
+                    }
+                    // `send_request` returns `Ok(BrokerResponse::Error { .. })`
+                    // for broker-side errors (e.g. worker_id collision when
+                    // DISPATCH_AGENT_NAME drifted from what was pre-registered).
+                    // Forward `message` verbatim so the supervisor's logs
+                    // surface the real cause instead of the generic
+                    // "no role prompt" line below.
+                    BrokerResponse::Error { message } => {
+                        eprintln!("dispatch: register --for-agent failed: {message}");
+                        process::exit(1);
+                    }
+                    _ => {
+                        let json = serde_json::to_string(&response)?;
+                        eprintln!("{json}");
+                        eprintln!("dispatch: --for-agent set but response carries no role prompt");
+                        process::exit(1);
+                    }
                 }
             } else {
                 let json = serde_json::to_string(&response)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,18 +249,20 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     // `send_request` returns `Ok(BrokerResponse::Error { .. })`
                     // for broker-side errors (e.g. worker_id collision when
                     // DISPATCH_AGENT_NAME drifted from what was pre-registered).
-                    // Forward `message` verbatim so the supervisor's logs
-                    // surface the real cause instead of the generic
-                    // "no role prompt" line below.
+                    // Forward `message` verbatim via a typed error so the
+                    // exit-code classifier in `main` stays authoritative.
                     BrokerResponse::Error { message } => {
-                        eprintln!("dispatch: register --for-agent failed: {message}");
-                        process::exit(1);
+                        return Err(dispatch::errors::DispatchError::RegisterForAgentFailed {
+                            message: message.clone(),
+                        });
                     }
                     _ => {
+                        // Log the unexpected JSON envelope to stderr before
+                        // bubbling the typed error — useful for debugging a
+                        // response shape that shouldn't happen in practice.
                         let json = serde_json::to_string(&response)?;
                         eprintln!("{json}");
-                        eprintln!("dispatch: --for-agent set but response carries no role prompt");
-                        process::exit(1);
+                        return Err(dispatch::errors::DispatchError::NoRolePromptReturned);
                     }
                 }
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,7 +214,6 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                 Commands::CodexHook { .. } | Commands::ClaudeHook { .. } => unreachable!(),
             };
             let response = backend.send_request(&request).await?;
-            let json = serde_json::to_string(&response)?;
             if for_agent {
                 // Prompt body to stdout, JSON envelope to stderr. If the
                 // broker has no prompt stored for this worker, exit nonzero
@@ -223,19 +222,37 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                 if let BrokerResponse::Ok {
                     payload:
                         ResponsePayload::WorkerRegistered {
+                            worker_id,
                             role_prompt: Some(prompt),
-                            ..
                         },
                 } = &response
                 {
-                    println!("{prompt}");
+                    // Write the prompt body verbatim (no trailing newline
+                    // added) so the agent receives byte-for-byte what the
+                    // orchestrator stored.
+                    use std::io::Write as _;
+                    let mut stdout = std::io::stdout().lock();
+                    stdout.write_all(prompt.as_bytes())?;
+                    stdout.flush()?;
+
+                    // Strip `role_prompt` from the stderr envelope so the
+                    // prompt body isn't duplicated into agent logs.
+                    let stripped = BrokerResponse::Ok {
+                        payload: ResponsePayload::WorkerRegistered {
+                            worker_id: worker_id.clone(),
+                            role_prompt: None,
+                        },
+                    };
+                    let json = serde_json::to_string(&stripped)?;
                     eprintln!("{json}");
                 } else {
+                    let json = serde_json::to_string(&response)?;
                     eprintln!("{json}");
                     eprintln!("dispatch: --for-agent set but response carries no role prompt");
                     process::exit(1);
                 }
             } else {
+                let json = serde_json::to_string(&response)?;
                 println!("{json}");
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use dispatch::cli::{AgentAction, Cli, Commands, HookAction};
 use dispatch::config::resolve_config;
 use dispatch::hooks;
 use dispatch::logging::init_tracing;
-use dispatch::protocol::BrokerRequest;
+use dispatch::protocol::{BrokerRequest, BrokerResponse, ResponsePayload};
 
 /// Parse a timestamp string as either a relative duration (e.g. "5m", "1h", "30s")
 /// or an absolute Unix timestamp. Returns a Unix timestamp in seconds.
@@ -95,6 +95,16 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
             backend.serve().await?;
         }
         cmd => {
+            // Issue #43: when `dispatch register --for-agent` is invoked,
+            // route the prompt body to stdout (so it lands in the model's
+            // tool result) and the structured envelope to stderr.
+            let for_agent = matches!(
+                &cmd,
+                Commands::Register {
+                    for_agent: true,
+                    ..
+                }
+            );
             let request = match cmd {
                 Commands::Init => unreachable!(),
                 Commands::Serve { .. } => unreachable!(),
@@ -106,6 +116,8 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     ttl,
                     evict,
                     worker_id,
+                    role_prompt,
+                    for_agent: _,
                 } => BrokerRequest::Register {
                     name,
                     role,
@@ -114,6 +126,7 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
                     ttl_secs: ttl,
                     evict,
                     worker_id,
+                    role_prompt,
                 },
                 Commands::Team => BrokerRequest::Team {
                     from: cli.from.clone(),
@@ -202,7 +215,29 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
             };
             let response = backend.send_request(&request).await?;
             let json = serde_json::to_string(&response)?;
-            println!("{json}");
+            if for_agent {
+                // Prompt body to stdout, JSON envelope to stderr. If the
+                // broker has no prompt stored for this worker, exit nonzero
+                // — the agent has nothing to do and the supervisor should
+                // restart rather than have the model see empty stdout.
+                if let BrokerResponse::Ok {
+                    payload:
+                        ResponsePayload::WorkerRegistered {
+                            role_prompt: Some(prompt),
+                            ..
+                        },
+                } = &response
+                {
+                    println!("{prompt}");
+                    eprintln!("{json}");
+                } else {
+                    eprintln!("{json}");
+                    eprintln!("dispatch: --for-agent set but response carries no role prompt");
+                    process::exit(1);
+                }
+            } else {
+                println!("{json}");
+            }
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -46,6 +46,14 @@ pub enum BrokerRequest {
         /// If true, evict any existing worker with the same name.
         #[serde(default)]
         evict: bool,
+        /// Pre-assigned worker id from the orchestrator (issue #43). When set,
+        /// the broker uses this id instead of generating a UUID. If a worker
+        /// with this id already exists and matches the supplied name+role,
+        /// the call is treated as an idempotent claim — useful when dispatch
+        /// pre-registers a worker server-side and the spawned agent then
+        /// re-issues `dispatch register` to fetch its prompt.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worker_id: Option<String>,
     },
     /// List active workers.
     Team {
@@ -233,6 +241,17 @@ mod tests {
                 capabilities: vec!["rust".into()],
                 ttl_secs: None,
                 evict: false,
+                worker_id: None,
+            },
+            // Pre-assigned worker_id (issue #43) must round-trip cleanly.
+            BrokerRequest::Register {
+                name: "w1".into(),
+                role: "builder".into(),
+                description: "test".into(),
+                capabilities: vec!["rust".into()],
+                ttl_secs: None,
+                evict: false,
+                worker_id: Some("w-fixed-id".into()),
             },
             BrokerRequest::Team { from: None },
             BrokerRequest::Send {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -54,6 +54,13 @@ pub enum BrokerRequest {
         /// re-issues `dispatch register` to fetch its prompt.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         worker_id: Option<String>,
+        /// Role prompt body to associate with this worker (issue #43). Only
+        /// the orchestrator sets this — at pre-register time it loads the
+        /// agent's `prompt_file` and ships the content here so the spawned
+        /// agent can fetch it back as the response body of its own
+        /// `dispatch register` call. Agents never set this themselves.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role_prompt: Option<String>,
     },
     /// List active workers.
     Team {
@@ -198,8 +205,15 @@ pub enum ResponsePayload {
     HeartbeatAck { worker_id: String, expires_at: u64 },
     /// List of active workers.
     WorkerList { workers: Vec<Worker> },
-    /// A worker was registered; returns the assigned worker ID.
-    WorkerRegistered { worker_id: String },
+    /// A worker was registered; returns the assigned worker ID. When the
+    /// broker has a role prompt stored for this worker (issue #43), it is
+    /// returned here so the spawned agent receives its first instructions
+    /// as the response body of its own `dispatch register` call.
+    WorkerRegistered {
+        worker_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role_prompt: Option<String>,
+    },
     /// Message acknowledgement confirmed. MUST appear before `MessageAck`:
     /// serde's untagged deserializer tries variants in declaration order and
     /// ignores unknown fields, so an `AckConfirm` payload would otherwise
@@ -242,8 +256,9 @@ mod tests {
                 ttl_secs: None,
                 evict: false,
                 worker_id: None,
+                role_prompt: None,
             },
-            // Pre-assigned worker_id (issue #43) must round-trip cleanly.
+            // Pre-assigned worker_id + role_prompt (issue #43) must round-trip cleanly.
             BrokerRequest::Register {
                 name: "w1".into(),
                 role: "builder".into(),
@@ -252,6 +267,7 @@ mod tests {
                 ttl_secs: None,
                 evict: false,
                 worker_id: Some("w-fixed-id".into()),
+                role_prompt: Some("Run: dispatch listen --timeout 270".into()),
             },
             BrokerRequest::Team { from: None },
             BrokerRequest::Send {
@@ -319,6 +335,12 @@ mod tests {
         let payloads = vec![
             ResponsePayload::WorkerRegistered {
                 worker_id: "abc".into(),
+                role_prompt: None,
+            },
+            // Issue #43: WorkerRegistered must round-trip with a prompt body too.
+            ResponsePayload::WorkerRegistered {
+                worker_id: "abc".into(),
+                role_prompt: Some("Run: dispatch listen --timeout 270".into()),
             },
             ResponsePayload::MessageAck {
                 message_id: "msg-1".into(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -133,6 +133,17 @@ pub enum BrokerRequest {
     AgentRestart { name: String },
 }
 
+/// Payload for a `ResponsePayload::Timeout`. Wrapped in its own struct so
+/// `deny_unknown_fields` can apply (variant-level attribute isn't supported
+/// in this serde version) — see the doc comment on the variant for why
+/// rejecting unknown fields is what makes `Timeout` and `WorkerRegistered`
+/// distinguishable in the untagged enum.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimeoutPayload {
+    pub worker_id: String,
+}
+
 /// Summary of a worker's status for the status query response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerStatus {
@@ -205,13 +216,25 @@ pub enum ResponsePayload {
     HeartbeatAck { worker_id: String, expires_at: u64 },
     /// List of active workers.
     WorkerList { workers: Vec<Worker> },
+    /// Listen timed out with no messages. MUST appear before
+    /// `WorkerRegistered`: serde's untagged dispatcher treats `Option`
+    /// fields as defaultable, so a payload `{"worker_id":"x"}` would
+    /// otherwise silently deserialize as
+    /// `WorkerRegistered { role_prompt: None }` (declared further down)
+    /// and the timeout signal would be lost. The `deny_unknown_fields`
+    /// on `TimeoutPayload` stops Timeout from swallowing payloads that
+    /// DO carry `role_prompt` — those fall through to `WorkerRegistered`
+    /// as intended. (Variant-level `deny_unknown_fields` is not supported
+    /// in this serde version, hence the wrapper struct.)
+    Timeout(TimeoutPayload),
     /// A worker was registered; returns the assigned worker ID. When the
     /// broker has a role prompt stored for this worker (issue #43), it is
     /// returned here so the spawned agent receives its first instructions
-    /// as the response body of its own `dispatch register` call.
+    /// as the response body of its own `dispatch register` call. The
+    /// `role_prompt` field is always serialized (even when `None`) so the
+    /// wire shape is unambiguously distinct from `Timeout` above.
     WorkerRegistered {
         worker_id: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         role_prompt: Option<String>,
     },
     /// Message acknowledgement confirmed. MUST appear before `MessageAck`:
@@ -230,8 +253,6 @@ pub enum ResponsePayload {
     EventList { events: Vec<serde_json::Value> },
     /// Message history query result.
     MessageList { messages: Vec<Message> },
-    /// Listen timed out with no messages.
-    Timeout { worker_id: String },
     /// Map of arbitrary key-value data (used as a flexible response shape).
     Data {
         data: HashMap<String, serde_json::Value>,
@@ -369,9 +390,9 @@ mod tests {
                 to: "w1".into(),
                 body: "payload".into(),
             },
-            ResponsePayload::Timeout {
+            ResponsePayload::Timeout(TimeoutPayload {
                 worker_id: "w1".into(),
-            },
+            }),
             ResponsePayload::AckConfirm {
                 message_id: "msg-2".into(),
                 ack_confirmed: true,
@@ -455,6 +476,62 @@ mod tests {
             } => assert!(ack_confirmed),
             other => panic!("expected AckConfirm, got {other:?}"),
         }
+    }
+
+    /// Regression: `WorkerRegistered { role_prompt: None }` and `Timeout`
+    /// would both serialize to `{"worker_id":"..."}` if `role_prompt` were
+    /// skipped on `None`, and the untagged deserializer would always pick
+    /// the first matching variant — silently swapping `Timeout` into
+    /// `WorkerRegistered` or vice versa. Match-arm on the variant (not on
+    /// JSON equality, which is unable to detect this) so any future change
+    /// that reintroduces field-skipping or drops `deny_unknown_fields` on
+    /// `TimeoutPayload` fails this test.
+    #[test]
+    fn timeout_does_not_degrade_to_worker_registered() {
+        let payload = ResponsePayload::Timeout(TimeoutPayload {
+            worker_id: "w1".into(),
+        });
+        let resp = BrokerResponse::Ok { payload };
+        let json = serde_json::to_string(&resp).unwrap();
+        let back: BrokerResponse = serde_json::from_str(&json).unwrap();
+        assert!(
+            matches!(
+                back,
+                BrokerResponse::Ok {
+                    payload: ResponsePayload::Timeout(_)
+                }
+            ),
+            "Timeout round-tripped as the wrong variant: {json}"
+        );
+
+        // Symmetric: the no-prompt WorkerRegistered case must NOT degrade to
+        // Timeout either. With `role_prompt` always serialized, both forms
+        // (Some and None) carry the field. `TimeoutPayload`'s
+        // `deny_unknown_fields` rejects the `role_prompt` key, so untagged
+        // dispatch falls through to `WorkerRegistered`.
+        let payload = ResponsePayload::WorkerRegistered {
+            worker_id: "w1".into(),
+            role_prompt: None,
+        };
+        let resp = BrokerResponse::Ok { payload };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            json.contains("\"role_prompt\":null"),
+            "role_prompt must be serialized even when None to keep Timeout/WorkerRegistered distinguishable: {json}"
+        );
+        let back: BrokerResponse = serde_json::from_str(&json).unwrap();
+        assert!(
+            matches!(
+                back,
+                BrokerResponse::Ok {
+                    payload: ResponsePayload::WorkerRegistered {
+                        role_prompt: None,
+                        ..
+                    }
+                }
+            ),
+            "WorkerRegistered with None prompt round-tripped as the wrong variant: {json}"
+        );
     }
 
     /// BrokerResponse::Error round-trips correctly.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -233,10 +233,12 @@ fn register_for_agent_routes_prompt_to_stdout() {
     let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
     let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
 
+    // Byte-for-byte fidelity: the prompt body must land on stdout without
+    // an appended newline, so agents that feed stdout into a tool-result
+    // get exactly what the orchestrator stored.
     assert_eq!(
-        stdout.trim(),
-        prompt,
-        "prompt body must be on stdout for the model to see it",
+        stdout, prompt,
+        "prompt body must be written verbatim (no trailing newline)",
     );
     assert!(
         stderr.contains("\"status\":\"ok\""),
@@ -245,6 +247,13 @@ fn register_for_agent_routes_prompt_to_stdout() {
     assert!(
         stderr.contains("w-prompt-test"),
         "JSON envelope must contain worker_id: {stderr}",
+    );
+    // The stderr envelope must NOT duplicate the prompt body — stdout
+    // already carries it, and the log would otherwise bloat with (and
+    // potentially leak) the full role prompt on every --for-agent call.
+    assert!(
+        !stderr.contains(prompt),
+        "stderr envelope must not duplicate the role prompt body: {stderr}",
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -331,9 +331,8 @@ fn register_claim_returns_originally_stored_prompt() {
 
     let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
     assert_eq!(
-        stdout.trim(),
-        prompt,
-        "claim must return the prompt the orchestrator originally stored",
+        stdout, prompt,
+        "claim must return exactly the prompt the orchestrator originally stored",
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -199,6 +199,135 @@ fn register_with_worker_id_is_idempotent() {
     assert_eq!(workers[0]["id"], supplied_id);
 }
 
+/// Issue #43: `dispatch register --role-prompt <body> --for-agent` routes
+/// the prompt body to stdout and the JSON envelope to stderr — so when
+/// the spawned agent runs this command as its first tool call, the prompt
+/// body lands directly in the model's tool result.
+#[test]
+fn register_for_agent_routes_prompt_to_stdout() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-register-for-agent";
+    let _broker = start_broker(&dir, cell_id);
+
+    let prompt = "Run: dispatch listen --timeout 270";
+    let output = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "test worker",
+            "--worker-id",
+            "w-prompt-test",
+            "--role-prompt",
+            prompt,
+            "--for-agent",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
+
+    assert_eq!(
+        stdout.trim(),
+        prompt,
+        "prompt body must be on stdout for the model to see it",
+    );
+    assert!(
+        stderr.contains("\"status\":\"ok\""),
+        "JSON envelope must be on stderr: {stderr}",
+    );
+    assert!(
+        stderr.contains("w-prompt-test"),
+        "JSON envelope must contain worker_id: {stderr}",
+    );
+}
+
+/// Issue #43: `--for-agent` without a stored prompt exits nonzero so the
+/// supervisor can restart rather than have the model see empty stdout.
+#[test]
+fn register_for_agent_without_prompt_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-register-for-agent-nopr";
+    let _broker = start_broker(&dir, cell_id);
+
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "no prompt here",
+            "--for-agent",
+        ])
+        .assert()
+        .failure();
+}
+
+/// Issue #43: an agent claim (re-register with same id) returns the prompt
+/// originally stored at orchestrator pre-register time. The claim itself
+/// passes no `--role-prompt`, so the broker must produce it from storage.
+#[test]
+fn register_claim_returns_originally_stored_prompt() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-claim-prompt";
+    let _broker = start_broker(&dir, cell_id);
+
+    let supplied_id = "w-claim-test";
+    let prompt = "Run: dispatch listen --timeout 270";
+
+    // Pre-register: orchestrator-style call carrying the prompt.
+    dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "pre-register",
+            "--worker-id",
+            supplied_id,
+            "--role-prompt",
+            prompt,
+        ])
+        .assert()
+        .success();
+
+    // Agent claim: no --role-prompt, but --for-agent should return the stored one.
+    let output = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "agent claim",
+            "--worker-id",
+            supplied_id,
+            "--for-agent",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert_eq!(
+        stdout.trim(),
+        prompt,
+        "claim must return the prompt the orchestrator originally stored",
+    );
+}
+
 #[test]
 fn team_lists_registered_workers() {
     let dir = TempDir::new().unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -124,6 +124,81 @@ fn register_returns_worker_id() {
     );
 }
 
+/// Issue #43: registering with `--worker-id` uses the supplied id verbatim,
+/// and re-registering with the same id+name+role is an idempotent claim
+/// (returns the same id without creating a duplicate worker).
+#[test]
+fn register_with_worker_id_is_idempotent() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-register-claim";
+    let _broker = start_broker(&dir, cell_id);
+
+    let supplied_id = "w-fixed-id-for-test";
+
+    let first = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "test worker",
+            "--worker-id",
+            supplied_id,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let first_json: serde_json::Value =
+        serde_json::from_slice(&first).expect("stdout should be valid JSON");
+    assert_eq!(first_json["worker_id"], supplied_id);
+
+    // Re-register with the same id+name+role: should claim, not duplicate.
+    let second = dispatch_cmd(&dir, cell_id)
+        .args([
+            "register",
+            "--name",
+            "alice",
+            "--role",
+            "test-runner",
+            "--description",
+            "test worker",
+            "--worker-id",
+            supplied_id,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second).expect("stdout should be valid JSON");
+    assert_eq!(second_json["worker_id"], supplied_id);
+
+    // Team should report exactly one worker.
+    let team = dispatch_cmd(&dir, cell_id)
+        .arg("team")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let team_json: serde_json::Value =
+        serde_json::from_slice(&team).expect("team stdout should be valid JSON");
+    let workers = team_json["workers"]
+        .as_array()
+        .expect("workers should be an array");
+    assert_eq!(
+        workers.len(),
+        1,
+        "claim must not create duplicates: {team_json}"
+    );
+    assert_eq!(workers[0]["id"], supplied_id);
+}
+
 #[test]
 fn team_lists_registered_workers() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #43.

## Summary

- Dispatch now pre-registers `launch=true` agents server-side at spawn time, injects `DISPATCH_WORKER_ID`, and feeds the agent a one-line boot prompt: `Run: dispatch register --worker-id "$DISPATCH_WORKER_ID" ... --for-agent`. The model's first observable action is a real tool call by construction — no role narrative for it to drift into "explain-what-I'll-do" mode.
- The role prompt body now lands in the agent's tool result via the `dispatch register --for-agent` response (broker stores it under the worker id at pre-register time, returns it on the agent's claim). The agent never invents its own worker_id, never narrates a fabricated register step, never silently exits without entering the listen loop.
- `launch=false` agents are completely unchanged — they keep the legacy stdin-pipe + self-register flow. Verification mechanism: a new `stream_json = true` config flag launches claude with `--output-format stream-json --verbose` so per-tool-use entries appear in agent logs (without it, hallucinated and real `dispatch register` calls produce identical logs).

## Design decisions locked

- **D1**: Extended `BrokerRequest::Register` with `worker_id: Option<String>` (vs. a separate `Claim` variant). Idempotent claim semantics: same id+name+role → success, conflict → reject with descriptive error.
- **D2**: Orchestrator reads `prompt_file` at pre-register and ships content into the broker. Broker stores per-worker, returns on claim. No separate prompt registry needed.
- **D4**: `--for-agent` CLI flag routes prompt body to stdout, JSON envelope to stderr. Default off — existing callers see no change.
- **D5**: Broker outage at boot → agent exits nonzero → supervisor backs off → `Crashed` after ~31s. Surfaces broker problems loudly.

## Test plan

- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo build && cargo test` — green (150 lib + 24 integration tests pass locally)
- [ ] End-to-end smoke: spin up a `launch=true` claude agent with a real prompt file, confirm `dispatch team` shows the worker before the child has run, confirm the agent log shows the boot prompt followed by a real `dispatch register --for-agent` invocation
- [ ] Enable `stream_json = true` on the same agent and confirm the agent log contains `tool_use` / `tool_result` entries (verification that pre-register is actually firing)
- [ ] Idempotency: run `dispatch register --worker-id <existing-id> --name <same> --role <same>` against an active broker, confirm the same id is returned and `dispatch team` still shows exactly one worker
- [ ] Collision: run the same with a mismatched name, confirm a clear error message and the original worker is untouched
- [ ] Backward compat: an existing `launch=false` example agent (e.g., `examples/agent-counsel/setup.sh`) registers itself the legacy way without changes
- [ ] Broker-outage failure: kill the broker, spawn a managed agent, confirm it exits nonzero and the supervisor reaches `Crashed` after ~31s of backoff