### PR TITLE
feat: unify main_agent into [[agents]], extend bootstrap to unmanaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-22
+
+### Added
+- `launch = false` agents with a `prompt_file` now use the same register-prompt-bootstrap as supervised agents. At serve startup dispatch pre-registers a worker server-side and prints a pasteable command that includes `DISPATCH_WORKER_ID=<uuid>` and redirects stdin from a one-line boot prompt (`Run: dispatch register --worker-id "$DISPATCH_WORKER_ID" ... --for-agent`). The agent's first tool call idempotently claims the pre-registered worker and retrieves the role prompt — same mechanism as supervised agents, just with the user launching the process.
+- `AgentOrchestrator::pre_register_unmanaged(ctx, config)` — factored from the managed-spawn pre-register flow; returns `(worker_id, boot_prompt_path)` for the serve-time banner to render.
+- `build_agent_command` accepts a `worker_id: Option<&str>` parameter; when `Some`, emits `DISPATCH_WORKER_ID=<id>` so the bootstrap works on paste.
+
+### Changed
+- **Breaking:** dropped the `--launch` flag on `dispatch serve`. `launch = true` in the agent config is now the single source of truth: those agents auto-spawn under the supervisor; `launch = false` agents are printed for copy-paste. Removes a redundant CLI-vs-config toggle.
+- **Breaking:** removed `[main_agent]` / `MainAgentConfig`. The main-agent concept collapses into a regular `[[agents]]` entry with `launch = false` (plus a `prompt_file` if you want the bootstrap). Configs with `[main_agent]` now fail parse with `unknown field 'main_agent'` — migrate by renaming the table to `[[agents]]` and adding `launch = false`. The previous schema didn't support `adapter`, `extra_args`, `role`, `description`, or `ttl`, so the unified shape is strictly more expressive.
+- Monitor dashboard: the pinned "main agent" slot is gone. All agents render uniformly; the hardcoded `role = "coordinator"` label for the main slot no longer exists (agents now show their configured role).
+- `dispatch init` template updated to show a commented `[[agents]] launch = false + prompt_file` example for the coordinator-style use case.
+
 ## [0.5.0] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Spawned agents now receive `DISPATCH_CONFIG_PATH` in env — lets hooks and `dispatch` subcommands run from any cwd inside the agent tree while still resolving the orchestrator's config. Previously, when an agent was launched with `cwd = ".."` (or any cwd that lacks `dispatch.config.toml`), child `dispatch` calls fell back to a derived `cell-<hash>` and resolved the wrong socket/config.
+- `dispatch` CLI honors `DISPATCH_CONFIG_PATH` as a fallback to `--config`. Precedence is `--config` flag > `DISPATCH_CONFIG_PATH` env > cwd discovery.
+- `ResolvedConfig.config_file_path` — the absolute, canonicalized config path, threaded through `AgentOrchestrator` and `SpawnContext` to the env-vars emit site.
+- `build_agent_command` accepts a `config_file_path: Option<&Path>` parameter; emits `DISPATCH_CONFIG_PATH=<abs>` in the printed copy-paste command when set.
+
+### Changed
+- **Breaking:** `DISPATCH_CONFIG_PATH` pointing at a missing or unreadable file is now a hard error (same failure mode as `--config nonexistent.toml`). Users with stale env values will see a clear error instead of a silent fallback.
+
 ## [0.5.1] - 2026-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Multi-agent, multi-vendor orchestration system"
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Dispatch runs as a **cell** — a single broker process that coordinates workers
 | Command | Description |
 |---------|-------------|
 | `dispatch init` | Create a `dispatch.config.toml` in the current directory |
-| `dispatch serve` | Start the broker (prints agent commands; use `--launch` to auto-start) |
+| `dispatch serve` | Start the broker: auto-launches `launch = true` agents; prints copy-paste commands for `launch = false` agents |
 | `dispatch register` | Register a worker (`--evict` replaces existing by name) |
 | `dispatch team` | List active workers |
 | `dispatch send` | Send a direct message to a worker |
@@ -152,7 +152,7 @@ command = "./examples/watch-files.sh --worker-id $DISPATCH_WORKER_ID src/"
 launch = true
 ```
 
-Run `dispatch serve --launch` to auto-spawn every agent with `launch = true`. Agents with `launch = false` (the default) are printed as ready-to-paste commands so you can run them in separate terminals.
+Run `dispatch serve` to auto-spawn every agent with `launch = true` under the supervisor. Agents with `launch = false` (the default) are pre-registered server-side and printed as ready-to-paste bootstrap commands so you can run them in separate terminals — the first tool call each one makes is `dispatch register --for-agent`, which returns its role prompt from the broker.
 
 ### Supervisor + auto-restart
 

--- a/src/adapter/claude.rs
+++ b/src/adapter/claude.rs
@@ -1,10 +1,13 @@
 //! Claude Code CLI adapter.
 //!
-//! Assembles `claude [extra_args...] -p` and feeds the prompt via stdin from
-//! `prompt_file`. Non-interactive (`-p`) mode only; interactive support is a
-//! follow-up.
+//! Headless mode (default): assembles `claude [extra_args...] -p` and feeds
+//! the prompt via stdin from `prompt_file`.
 //!
-//! Issue #43: when `stream_json` is set, appends
+//! Interactive mode (`interactive = true`): omits `-p` so claude opens in
+//! its REPL. `stream_json` is a no-op in this mode (the output-format /
+//! verbose flags require `-p`).
+//!
+//! Issue #43: when `stream_json` is set (headless only), appends
 //! `--output-format stream-json --verbose` so per-tool-use entries appear
 //! in the agent log. Required because claude's default `-p` output only
 //! shows the final assistant message — making a hallucinated `dispatch
@@ -14,13 +17,15 @@ use super::{AdapterError, BuildContext, Launch};
 
 pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
     let mut args: Vec<String> = ctx.extra_args.to_vec();
-    if ctx.stream_json {
-        // Claude Code requires --verbose when combining -p with stream-json.
-        args.push("--output-format".to_string());
-        args.push("stream-json".to_string());
-        args.push("--verbose".to_string());
+    if !ctx.interactive {
+        if ctx.stream_json {
+            // Claude Code requires --verbose when combining -p with stream-json.
+            args.push("--output-format".to_string());
+            args.push("stream-json".to_string());
+            args.push("--verbose".to_string());
+        }
+        args.push("-p".to_string());
     }
-    args.push("-p".to_string());
 
     Ok(Launch {
         program: "claude".to_string(),
@@ -42,12 +47,22 @@ mod tests {
             prompt_inline: None,
             command_string: None,
             stream_json: false,
+            interactive: false,
         }
     }
 
     fn ctx_stream<'a>(extras: &'a [String], prompt_file: Option<&'a Path>) -> BuildContext<'a> {
         let mut c = ctx(extras, prompt_file);
         c.stream_json = true;
+        c
+    }
+
+    fn ctx_interactive<'a>(
+        extras: &'a [String],
+        prompt_file: Option<&'a Path>,
+    ) -> BuildContext<'a> {
+        let mut c = ctx(extras, prompt_file);
+        c.interactive = true;
         c
     }
 
@@ -117,5 +132,31 @@ mod tests {
                 "-p",
             ],
         );
+    }
+
+    /// `interactive = true` drops `-p` so claude opens its REPL; user
+    /// extras still come through unchanged.
+    #[test]
+    fn interactive_omits_dash_p() {
+        let extras = vec!["--model".to_string(), "sonnet".to_string()];
+        let launch = Adapter::Claude
+            .build(&ctx_interactive(&extras, None))
+            .unwrap();
+        assert_eq!(launch.args, vec!["--model", "sonnet"]);
+        assert!(
+            !launch.args.iter().any(|a| a == "-p"),
+            "-p must be omitted in interactive mode",
+        );
+    }
+
+    /// In interactive mode, stream_json is a no-op: the `--output-format`
+    /// / `--verbose` flags are rejected by claude without `-p`, so we
+    /// skip them to keep the REPL launchable.
+    #[test]
+    fn interactive_suppresses_stream_json_flags() {
+        let mut c = ctx_interactive(&[], None);
+        c.stream_json = true;
+        let launch = Adapter::Claude.build(&c).unwrap();
+        assert!(launch.args.is_empty(), "got {:?}", launch.args);
     }
 }

--- a/src/adapter/codex.rs
+++ b/src/adapter/codex.rs
@@ -1,13 +1,18 @@
 //! Codex CLI adapter.
 //!
-//! Assembles `codex exec [extra_args...]` and feeds the prompt via stdin from
-//! `prompt_file`. Non-interactive (`exec`) mode only; interactive support is
-//! a follow-up.
+//! Headless mode (default): assembles `codex exec [extra_args...]` and feeds
+//! the prompt via stdin from `prompt_file`.
+//!
+//! Interactive mode (`interactive = true`): omits the `exec` subcommand so
+//! codex opens in its REPL. Extra args still follow.
 
 use super::{AdapterError, BuildContext, Launch};
 
 pub fn build(ctx: &BuildContext<'_>) -> Result<Launch, AdapterError> {
-    let mut args: Vec<String> = vec!["exec".to_string()];
+    let mut args: Vec<String> = Vec::new();
+    if !ctx.interactive {
+        args.push("exec".to_string());
+    }
     args.extend(ctx.extra_args.iter().cloned());
 
     Ok(Launch {
@@ -30,7 +35,17 @@ mod tests {
             prompt_inline: None,
             command_string: None,
             stream_json: false,
+            interactive: false,
         }
+    }
+
+    fn ctx_interactive<'a>(
+        extras: &'a [String],
+        prompt_file: Option<&'a Path>,
+    ) -> BuildContext<'a> {
+        let mut c = ctx(extras, prompt_file);
+        c.interactive = true;
+        c
     }
 
     #[test]
@@ -77,6 +92,21 @@ mod tests {
                 "-c",
                 "service_tier=\"fast\"",
             ]
+        );
+    }
+
+    /// `interactive = true` drops the `exec` subcommand so codex opens
+    /// in its REPL. User extras still pass through in the same order.
+    #[test]
+    fn interactive_omits_exec() {
+        let extras = vec!["-m".to_string(), "gpt-5.4".to_string()];
+        let launch = Adapter::Codex
+            .build(&ctx_interactive(&extras, None))
+            .unwrap();
+        assert_eq!(launch.args, vec!["-m", "gpt-5.4"]);
+        assert!(
+            !launch.args.iter().any(|a| a == "exec"),
+            "`exec` must be omitted in interactive mode",
         );
     }
 }

--- a/src/adapter/command.rs
+++ b/src/adapter/command.rs
@@ -60,6 +60,7 @@ mod tests {
             prompt_inline: None,
             command_string: command,
             stream_json: false,
+            interactive: false,
         }
     }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -51,6 +51,10 @@ pub struct BuildContext<'a> {
     /// `--output-format stream-json --verbose` so per-tool-use entries
     /// appear in the agent log. Other adapters ignore this flag.
     pub stream_json: bool,
+    /// When true, the adapter omits its headless flag (`-p` for claude,
+    /// `exec` for codex) so the program opens in REPL / interactive mode.
+    /// The `command` adapter ignores this (user owns the shell string).
+    pub interactive: bool,
 }
 
 /// The result of an adapter building a launch specification.

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -287,6 +287,13 @@ impl BrokerState {
                     if !capabilities.is_empty() {
                         existing.capabilities = capabilities;
                     }
+                    // Flip `claimed` on the idempotent-claim path so the
+                    // monitor can distinguish "pre-registered, waiting" from
+                    // "agent attached." The orchestrator passes `role_prompt =
+                    // Some(_)` when re-registering on respawn; agent claims
+                    // pass `None`. Either way, reaching this branch means an
+                    // actual process called register with our id, so mark it.
+                    existing.claimed = true;
                     let id = supplied.clone();
                     // Only overwrite the stored prompt if the caller supplied
                     // one — agent claims pass `None` and must not erase what
@@ -318,6 +325,14 @@ impl BrokerState {
             }
         }
 
+        // `claimed = false` only when a caller pre-registers with a supplied
+        // id (issue #43 bootstrap flow — orchestrator creates the record
+        // server-side before the agent process starts). A fresh register
+        // without a supplied id is always an agent registering itself, so
+        // mark it claimed immediately. Distinguishing these keeps the
+        // "reserved, waiting" state precise rather than bleeding into the
+        // legacy self-register path.
+        let claimed = worker_id.is_none();
         let id = worker_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let now = now_secs();
         let ttl = ttl_secs.unwrap_or(self.default_ttl);
@@ -332,6 +347,7 @@ impl BrokerState {
             last_status: None,
             last_status_at: None,
             status_history: VecDeque::new(),
+            claimed,
         };
         self.workers.insert(id.clone(), worker);
         if let Some(prompt) = role_prompt {
@@ -392,6 +408,12 @@ impl BrokerState {
         if let Some(worker) = self.workers.get_mut(worker_id) {
             let now = now_secs();
             worker.expires_at = now + worker.ttl_secs;
+            // Any heartbeat from the agent is proof of life — flip claimed
+            // so the monitor shows it as attached rather than "reserved,
+            // waiting" (relevant when the orchestrator pre-registers and
+            // the agent starts up by heartbeat-without-register, though
+            // the issue-#43 bootstrap always registers first).
+            worker.claimed = true;
             if let Some(s) = status {
                 let unchanged = worker.last_status.as_deref() == Some(s.as_str());
                 if !unchanged {
@@ -1979,6 +2001,96 @@ mod tests {
             state.role_prompts.get(&id).map(String::as_str),
             Some("Run: dispatch listen --timeout 270"),
             "claim must not erase the stored prompt",
+        );
+    }
+
+    /// A pre-registered worker (caller supplied `worker_id`) is born with
+    /// `claimed = false` so the monitor can show it as "reserved, waiting
+    /// for the agent" rather than solid green. When the agent then
+    /// registers with the same id (idempotent-claim path) OR sends a
+    /// heartbeat, `claimed` flips to true. Self-registered workers
+    /// (no supplied id) skip the reserved state entirely — they're
+    /// always a real process registering itself.
+    #[test]
+    fn test_register_worker_claimed_flips_on_attach() {
+        let mut state = BrokerState::new();
+
+        // Pre-register via supplied id — should start unclaimed.
+        let pre = state
+            .register_worker(
+                "alice".into(),
+                "runner".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+                Some("prompt".into()),
+            )
+            .expect("pre-register");
+        assert!(
+            !state.workers.get(&pre).unwrap().claimed,
+            "pre-register must leave worker unclaimed",
+        );
+
+        // Agent-side claim (supplied id matches existing record).
+        let claimed = state
+            .register_worker(
+                "alice".into(),
+                "runner".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                Some("w-fixed".into()),
+                None,
+            )
+            .expect("claim");
+        assert_eq!(claimed, pre);
+        assert!(
+            state.workers.get(&pre).unwrap().claimed,
+            "idempotent claim must flip claimed = true",
+        );
+
+        // Self-register (no supplied id) should be claimed immediately.
+        let self_reg = state
+            .register_worker(
+                "bob".into(),
+                "worker".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                None,
+                None,
+            )
+            .expect("self-register");
+        assert!(
+            state.workers.get(&self_reg).unwrap().claimed,
+            "self-register (no supplied id) must be claimed immediately",
+        );
+
+        // Heartbeat alone is also proof of life — flips claimed on a
+        // pre-registered worker even without a register-claim step.
+        let hb_pre = state
+            .register_worker(
+                "carol".into(),
+                "worker".into(),
+                "d".into(),
+                vec![],
+                None,
+                false,
+                Some("w-carol".into()),
+                None,
+            )
+            .expect("pre-register carol");
+        assert!(!state.workers.get(&hb_pre).unwrap().claimed);
+        state
+            .heartbeat_worker(&hb_pre, None)
+            .expect("heartbeat on pre-registered worker");
+        assert!(
+            state.workers.get(&hb_pre).unwrap().claimed,
+            "heartbeat must flip claimed = true",
         );
     }
 

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -835,6 +835,7 @@ pub async fn serve(
         log_dir.clone(),
         config.agents.clone(),
         Arc::clone(&state),
+        config.config_file_path.clone(),
     )));
 
     // Optionally start the HTTP monitor dashboard.
@@ -923,6 +924,7 @@ pub async fn serve(
                 cell_id,
                 monitor_url.as_deref(),
                 worker_id.as_deref(),
+                config.config_file_path.as_deref(),
             );
             eprintln!("  # {} ({})", agent.name, agent.role);
             eprintln!("  {cmd}\n");
@@ -1555,6 +1557,7 @@ mod tests {
             cell_id: cell_id.to_string(),
             backend: None,
             project_root: project_root.to_path_buf(),
+            config_file_path: None,
             agent_cwd: project_root.to_path_buf(),
             monitor_port: None,
             monitor_open: false,

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -833,7 +833,6 @@ pub async fn serve(
             cell_id: cell_id.clone(),
             started_at: now_secs(),
             agents: config.agents.clone(),
-            main_agent: config.main_agent.clone(),
             heartbeats: config.heartbeats.clone(),
             log_dir: log_dir.clone(),
             monitor_url: Some(url.clone()),
@@ -867,6 +866,15 @@ pub async fn serve(
     // Print copy-paste launch commands for agents that were not auto-launched.
     // That means: every agent when `--launch` is not set, plus `launch = false`
     // agents when `--launch` is set.
+    //
+    // For every unmanaged agent with a `prompt_file`, pre-register a worker
+    // server-side and wire the printed command to the issue-#43 boot-prompt
+    // bootstrap: `DISPATCH_WORKER_ID=<uuid>` in the env + `< <name>.boot.prompt`
+    // on stdin. When the user pastes + runs, the agent's first tool call
+    // (`dispatch register --for-agent`) idempotently claims the pre-registered
+    // worker and retrieves the role prompt — same mechanism as supervised
+    // agents, just with the user launching the process instead of the
+    // orchestrator.
     let manual: Vec<&crate::config::ResolvedAgentConfig> = config
         .agents
         .iter()
@@ -874,23 +882,40 @@ pub async fn serve(
         .collect();
     if !manual.is_empty() {
         eprintln!("\ndispatch serve: ready. Unmanaged agents — run these in separate terminals:\n");
+        let ctx = orchestrator.lock().await.snapshot_spawn_context();
         for agent in &manual {
-            let cmd =
-                super::orchestrator::build_agent_command(agent, cell_id, monitor_url.as_deref());
+            // Agents with a prompt_file get the boot-prompt bootstrap; the
+            // legacy bare-register path is reserved for configs with no prompt.
+            // Pre-register failures log + fall back to the legacy path so one
+            // misconfigured agent doesn't block the serve banner.
+            let (worker_id, render_config): (Option<String>, crate::config::ResolvedAgentConfig) =
+                if agent.prompt_file_path.is_some() {
+                    match super::orchestrator::pre_register_unmanaged(&ctx, agent).await {
+                        Ok((id, boot_path)) => {
+                            let mut cloned = (*agent).clone();
+                            cloned.prompt_file_path = Some(boot_path);
+                            (Some(id), cloned)
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "  # warning: pre-register failed for '{}': {e} — falling back to legacy copy-paste",
+                                agent.name
+                            );
+                            (None, (*agent).clone())
+                        }
+                    }
+                } else {
+                    (None, (*agent).clone())
+                };
+            let cmd = super::orchestrator::build_agent_command(
+                &render_config,
+                cell_id,
+                monitor_url.as_deref(),
+                worker_id.as_deref(),
+            );
             eprintln!("  # {} ({})", agent.name, agent.role);
             eprintln!("  {cmd}\n");
         }
-    }
-
-    // Print the main agent launch command.
-    if let Some(ref main_agent) = config.main_agent {
-        let cmd = super::orchestrator::build_main_agent_command(
-            main_agent,
-            cell_id,
-            monitor_url.as_deref(),
-        );
-        eprintln!("dispatch serve: main session:\n");
-        eprintln!("  {cmd}\n");
     }
 
     // Run until shutdown signal (OS signal or monitor UI).
@@ -1524,7 +1549,6 @@ mod tests {
             monitor_open: false,
             default_ttl: None,
             agents: vec![],
-            main_agent: None,
             heartbeats: vec![],
         }
     }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -70,19 +70,13 @@ pub struct BrokerEvent {
 pub struct LocalBackend {
     config: crate::config::ResolvedConfig,
     monitor_port: Option<u16>,
-    launch_agents: bool,
 }
 
 impl LocalBackend {
-    pub fn new(
-        config: &crate::config::ResolvedConfig,
-        monitor_port: Option<u16>,
-        launch_agents: bool,
-    ) -> Self {
+    pub fn new(config: &crate::config::ResolvedConfig, monitor_port: Option<u16>) -> Self {
         Self {
             config: config.clone(),
             monitor_port,
-            launch_agents,
         }
     }
 }
@@ -92,7 +86,7 @@ impl super::Backend for LocalBackend {
     /// Start the broker server on a Unix domain socket, blocking until
     /// a shutdown signal (SIGINT/SIGTERM) is received.
     async fn serve(&self) -> Result<(), DispatchError> {
-        serve(&self.config, self.monitor_port, self.launch_agents).await
+        serve(&self.config, self.monitor_port).await
     }
 
     /// Send a request to the broker over a Unix domain socket and
@@ -768,7 +762,6 @@ async fn check_no_existing_broker(socket: &Path, cell_id: &str) -> Result<(), Di
 pub async fn serve(
     config: &crate::config::ResolvedConfig,
     monitor_port: Option<u16>,
-    launch_agents: bool,
 ) -> Result<(), DispatchError> {
     let cell_id = &config.cell_id;
     let project_root = &config.project_root;
@@ -851,10 +844,11 @@ pub async fn serve(
         }
     }
 
-    if launch_agents {
-        // Auto-launch only agents explicitly marked `launch = true`. Agents
-        // with `launch = false` (the default) stay unmanaged and their
-        // copy-paste launch commands are printed below instead.
+    // Auto-launch agents marked `launch = true`. Agents with `launch = false`
+    // (the default) stay unmanaged and their copy-paste launch commands are
+    // printed below instead. `launch_all` already filters by `launch = true`,
+    // so it's safe to always call.
+    {
         let mut orch = orchestrator.lock().await;
         orch.launch_all().await?;
         // Start configured heartbeat timers.
@@ -863,9 +857,7 @@ pub async fn serve(
         }
     }
 
-    // Print copy-paste launch commands for agents that were not auto-launched.
-    // That means: every agent when `--launch` is not set, plus `launch = false`
-    // agents when `--launch` is set.
+    // Print copy-paste launch commands for every `launch = false` agent.
     //
     // For every unmanaged agent with a `prompt_file`, pre-register a worker
     // server-side and wire the printed command to the issue-#43 boot-prompt
@@ -875,11 +867,8 @@ pub async fn serve(
     // worker and retrieves the role prompt — same mechanism as supervised
     // agents, just with the user launching the process instead of the
     // orchestrator.
-    let manual: Vec<&crate::config::ResolvedAgentConfig> = config
-        .agents
-        .iter()
-        .filter(|a| !launch_agents || !a.launch)
-        .collect();
+    let manual: Vec<&crate::config::ResolvedAgentConfig> =
+        config.agents.iter().filter(|a| !a.launch).collect();
     if !manual.is_empty() {
         eprintln!("\ndispatch serve: ready. Unmanaged agents — run these in separate terminals:\n");
         let ctx = orchestrator.lock().await.snapshot_spawn_context();
@@ -1559,7 +1548,7 @@ mod tests {
     async fn test_client_broker_not_running() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path(), "nonexistent-cell");
-        let backend = LocalBackend::new(&config, None, false);
+        let backend = LocalBackend::new(&config, None);
 
         let result = backend
             .send_request(&BrokerRequest::Team { from: None })
@@ -1583,13 +1572,13 @@ mod tests {
         // Start broker in background.
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait for broker to start.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let cfg = test_config(&project_root, cell_id);
-        let backend = LocalBackend::new(&cfg, None, false);
+        let backend = LocalBackend::new(&cfg, None);
         let response = backend
             .send_request(&BrokerRequest::Team { from: None })
             .await;
@@ -1679,7 +1668,7 @@ mod tests {
         // Start broker in background.
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1725,7 +1714,7 @@ mod tests {
         });
 
         // Try to start second broker — should fail.
-        let result = serve(&test_config(&project_root, cell_id), None, false).await;
+        let result = serve(&test_config(&project_root, cell_id), None).await;
         assert!(result.is_err());
 
         match result.unwrap_err() {
@@ -1760,7 +1749,7 @@ mod tests {
         // Starting serve should clean up the stale socket and bind fresh.
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
 
         // Wait briefly for the server to bind.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -2176,7 +2165,7 @@ mod tests {
         // Start broker.
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Send register request via raw socket.
@@ -2224,7 +2213,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, "cap-test");
@@ -2470,7 +2459,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2510,7 +2499,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2543,7 +2532,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2678,7 +2667,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2720,7 +2709,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2921,7 +2910,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -2968,7 +2957,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -3008,7 +2997,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -3061,7 +3050,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -3110,7 +3099,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -3139,7 +3128,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);
@@ -3185,7 +3174,7 @@ mod tests {
 
         let root = project_root.clone();
         let serve_handle =
-            tokio::spawn(async move { serve(&test_config(&root, cell_id), None, false).await });
+            tokio::spawn(async move { serve(&test_config(&root, cell_id), None).await });
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let sock = socket_path(&project_root, cell_id);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -31,14 +31,9 @@ pub trait Backend: Send + Sync {
 pub fn create_backend(
     config: &ResolvedConfig,
     monitor_port: Option<u16>,
-    launch_agents: bool,
 ) -> Result<Box<dyn Backend>, DispatchError> {
     match config.backend.as_deref().unwrap_or("local") {
-        "local" => Ok(Box::new(local::LocalBackend::new(
-            config,
-            monitor_port,
-            launch_agents,
-        ))),
+        "local" => Ok(Box::new(local::LocalBackend::new(config, monitor_port))),
         other => Err(DispatchError::UnknownBackend {
             name: other.to_string(),
         }),

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -321,9 +321,6 @@ async function fetchAgentConfigs() {
     const resp = await fetch('/api/agents');
     const data = await resp.json();
     agentConfigs = data.agents || [];
-    if (data.main_agent) {
-      agentConfigs.unshift({ ...data.main_agent, name: 'main', role: 'main-agent', description: 'Main interactive agent', _isMain: true });
-    }
   } catch(e) {}
 }
 
@@ -403,7 +400,6 @@ function renderSidebar() {
   // and are read back from `dataset` by the delegated click handler — never
   // interpolated into a JS string.
   for (const cfg of agentConfigs) {
-    if (cfg._isMain) continue; // main agent shown separately
     seen.add(cfg.name);
     const worker = teamWorkers.find(w => w.name === cfg.name);
     const isLive = !!worker;
@@ -428,19 +424,6 @@ function renderSidebar() {
     html += `</div></div>`;
   }
 
-  // Main agent
-  const mainCfg = agentConfigs.find(a => a._isMain);
-  if (mainCfg) {
-    const mainWorker = teamWorkers.find(w => w.role === 'main-agent' || w.name === 'main');
-    const isLive = !!mainWorker;
-    const isActive = selectedAgent === 'main' && currentView === 'agent';
-    html += `<div class="nav-item${isActive ? ' active' : ''}" data-agent-name="main">`;
-    html += `<span class="dot${isLive ? ' live' : ' pending'}"></span>`;
-    html += `<span class="name">main</span>`;
-    html += `<span class="role-tag">coordinator</span>`;
-    html += `</div>`;
-  }
-
   list.innerHTML = html || '<div class="nav-item empty" style="cursor:default">No agents configured</div>';
 }
 
@@ -451,7 +434,7 @@ function renderSidebar() {
 function renderAgentCards() {
   const grid = document.getElementById('agents-grid');
   if (!grid) return;
-  const managed = (agentConfigs || []).filter(a => !a._isMain);
+  const managed = agentConfigs || [];
   if (managed.length === 0) {
     grid.innerHTML = '<div class="empty">No agents configured</div>';
     return;

--- a/src/backend/monitor.html
+++ b/src/backend/monitor.html
@@ -29,6 +29,11 @@
   .sidebar .nav-item.active { background: #161b22; color: #c9d1d9; border-left-color: #58a6ff; }
   .sidebar .nav-item .dot { width: 6px; height: 6px; border-radius: 50%; background: #484f58; flex-shrink: 0; }
   .sidebar .nav-item .dot.live { background: #3fb950; }
+  /* `reserved` = orchestrator has pre-registered the worker server-side
+     (issue #43 bootstrap) but no agent process has claimed it yet. Amber
+     pulse disambiguates it from the dim-gray `pending` ("nothing there
+     at all") and the solid green `live` ("attached and heartbeating"). */
+  .sidebar .nav-item .dot.reserved { background: #d29922; animation: pulse 2s ease-in-out infinite; }
   .sidebar .nav-item .dot.pending { background: #484f58; animation: pulse 2s ease-in-out infinite; }
   @keyframes pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
   .sidebar .nav-item .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -140,6 +145,7 @@
   .copy-cmd .copy-btn:hover { color: #c9d1d9; border-color: #484f58; }
   .status-badge { display: inline-block; font-size: 10px; padding: 1px 6px; border-radius: 3px; font-weight: 600; }
   .status-badge.registered { background: #3fb95020; color: #3fb950; }
+  .status-badge.reserved { background: #d2992220; color: #d29922; }
   .status-badge.pending { background: #484f5820; color: #484f58; }
 
   /* Log output */
@@ -402,23 +408,35 @@ function renderSidebar() {
   for (const cfg of agentConfigs) {
     seen.add(cfg.name);
     const worker = teamWorkers.find(w => w.name === cfg.name);
-    const isLive = !!worker;
+    // Three-state dot:
+    //   no worker record at all        → pending (dim gray, pulsing)
+    //   worker present, not claimed    → reserved (amber, pulsing)
+    //   worker present + claimed       → live (solid green)
+    // `claimed` defaults to false on responses from older brokers, which
+    // would leave the old behavior downgraded to reserved. That's fine:
+    // if a user runs a newer client against an older broker, every
+    // worker looks "reserved" but the data still flows.
+    const dotClass = !worker ? 'pending' : (worker.claimed ? 'live' : 'reserved');
     const statusText = worker?.last_status || '';
     const isActive = selectedAgent === cfg.name && currentView === 'agent';
     html += `<div class="nav-item${isActive ? ' active' : ''}" data-agent-name="${esc(cfg.name)}">`;
-    html += `<span class="dot${isLive ? ' live' : ' pending'}"></span>`;
+    html += `<span class="dot ${dotClass}"></span>`;
     html += `<div style="flex:1;overflow:hidden"><span class="name">${esc(cfg.name)}</span><span class="role-tag">${esc(cfg.role)}</span>`;
     if (statusText) html += `<span class="status-tag">${esc(statusText)}</span>`;
     html += `</div></div>`;
   }
 
-  // Show any registered workers not in config (e.g. manually registered)
+  // Show any registered workers not in config (e.g. manually registered).
+  // These reached the broker via an agent's own `dispatch register` call,
+  // so they're `claimed = true` by construction — but honor the field
+  // anyway in case a future path creates non-config records server-side.
   for (const w of teamWorkers) {
     if (seen.has(w.name)) continue;
+    const dotClass = w.claimed ? 'live' : 'reserved';
     const statusText = w.last_status || '';
     const isActive = selectedAgent === w.name && currentView === 'agent';
     html += `<div class="nav-item${isActive ? ' active' : ''}" data-agent-name="${esc(w.name)}">`;
-    html += `<span class="dot live"></span>`;
+    html += `<span class="dot ${dotClass}"></span>`;
     html += `<div style="flex:1;overflow:hidden"><span class="name">${esc(w.name)}</span><span class="role-tag">${esc(w.role)}</span>`;
     if (statusText) html += `<span class="status-tag">${esc(statusText)}</span>`;
     html += `</div></div>`;
@@ -752,9 +770,22 @@ function renderAgentDetail() {
   const configPanel = document.getElementById('agent-config-panel');
   let cfgHtml = '';
 
-  // Status badge
-  const isRegistered = !!worker;
-  cfgHtml += `<div class="config-section"><div class="config-label">Status</div><div class="config-value"><span class="status-badge ${isRegistered ? 'registered' : 'pending'}">${isRegistered ? 'Registered' : 'Waiting to register'}</span></div></div>`;
+  // Status badge — "Registered" means an agent process has actually
+  // claimed the slot (register-with-worker-id or heartbeat). A worker
+  // record exists pre-claim too (issue #43 pre-register flow), shown as
+  // "Reserved" so it's obvious the agent hasn't attached yet.
+  let statusClass, statusLabel;
+  if (!worker) {
+    statusClass = 'pending';
+    statusLabel = 'Waiting to register';
+  } else if (worker.claimed) {
+    statusClass = 'registered';
+    statusLabel = 'Registered';
+  } else {
+    statusClass = 'reserved';
+    statusLabel = 'Reserved (waiting for agent)';
+  }
+  cfgHtml += `<div class="config-section"><div class="config-label">Status</div><div class="config-value"><span class="status-badge ${statusClass}">${statusLabel}</span></div></div>`;
 
   cfgHtml += configBlock('Name', agentCfg?.name || worker?.name || agentName);
   cfgHtml += configBlock('Role', agentCfg?.role || worker?.role || '--');

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -24,7 +24,6 @@ pub struct MonitorState {
     /// Unix timestamp (seconds) when the server started.
     pub started_at: u64,
     pub agents: Vec<crate::config::ResolvedAgentConfig>,
-    pub main_agent: Option<crate::config::MainAgentConfig>,
     pub heartbeats: Vec<crate::config::HeartbeatConfig>,
     pub log_dir: PathBuf,
     pub monitor_url: Option<String>,
@@ -140,6 +139,11 @@ async fn api_health(State(state): State<MonitorState>) -> axum::Json<serde_json:
 }
 
 /// Return configured agent definitions (for the sidebar agent detail view).
+///
+/// The dashboard surface for an unmanaged agent (`launch = false`) doesn't
+/// need the boot-prompt worker_id here — that bootstrap is only printed
+/// at serve startup where the pre-register lives. This view is purely
+/// informational, so we pass `worker_id = None` regardless of `launch`.
 async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json::Value> {
     let agents: Vec<serde_json::Value> = state
         .agents
@@ -149,6 +153,7 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
                 a,
                 &state.cell_id,
                 state.monitor_url.as_deref(),
+                None,
             );
             serde_json::json!({
                 "name": a.name,
@@ -164,19 +169,6 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
             })
         })
         .collect();
-    let main_agent = state.main_agent.as_ref().map(|m| {
-        let launch_cmd = super::orchestrator::build_main_agent_command(
-            m,
-            &state.cell_id,
-            state.monitor_url.as_deref(),
-        );
-        serde_json::json!({
-            "command": m.command,
-            "model": m.model,
-            "prompt": m.prompt,
-            "launch_command": launch_cmd,
-        })
-    });
     let heartbeats: Vec<serde_json::Value> = state
         .heartbeats
         .iter()
@@ -190,7 +182,6 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
         .collect();
     axum::Json(serde_json::json!({
         "agents": agents,
-        "main_agent": main_agent,
         "heartbeats": heartbeats,
     }))
 }
@@ -543,7 +534,6 @@ mod tests {
             cell_id: "test-cell".into(),
             started_at: 0,
             agents: vec![],
-            main_agent: None,
             heartbeats: vec![],
             log_dir: tmp.join("logs"),
             monitor_url: None,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -154,6 +154,7 @@ async fn api_agents(State(state): State<MonitorState>) -> axum::Json<serde_json:
                 &state.cell_id,
                 state.monitor_url.as_deref(),
                 None,
+                None,
             );
             serde_json::json!({
                 "name": a.name,
@@ -526,6 +527,7 @@ mod tests {
             tmp.join("logs"),
             configs,
             Arc::clone(&broker),
+            None,
         )));
         MonitorState {
             broker,

--- a/src/backend/monitor.rs
+++ b/src/backend/monitor.rs
@@ -507,6 +507,7 @@ mod tests {
             prompt_file_path: None,
             ttl: None,
             stream_json: false,
+            interactive: false,
             launch: false,
         }
     }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -200,6 +200,7 @@ impl AgentOrchestrator {
             prompt_inline: config.prompt.as_deref(),
             command_string: config.command.as_deref(),
             stream_json: config.stream_json,
+            interactive: config.interactive,
         };
         config
             .adapter
@@ -1192,6 +1193,7 @@ mod tests {
             prompt_file_path: None,
             ttl: None,
             stream_json: false,
+            interactive: false,
             launch: true,
         }
     }
@@ -1213,6 +1215,7 @@ mod tests {
             prompt_file_path: Some(prompt_path),
             ttl: None,
             stream_json: false,
+            interactive: false,
             launch: true,
         }
     }

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -102,6 +102,11 @@ pub struct SpawnContext {
     monitor_url: Option<String>,
     agent_cwd: PathBuf,
     log_dir: PathBuf,
+    /// Absolute path of the `dispatch.config.toml` that produced this
+    /// resolution, if one exists. Propagated to spawned agents via
+    /// `DISPATCH_CONFIG_PATH` so child `dispatch` calls resolve the same
+    /// config even when their cwd doesn't contain it.
+    config_file_path: Option<PathBuf>,
 }
 
 impl SpawnContext {
@@ -112,6 +117,9 @@ impl SpawnContext {
             "DISPATCH_SOCKET_PATH".into(),
             self.socket_path.display().to_string(),
         );
+        if let Some(ref path) = self.config_file_path {
+            vars.insert("DISPATCH_CONFIG_PATH".into(), path.display().to_string());
+        }
         if let Some(ref url) = self.monitor_url {
             vars.insert("DISPATCH_MONITOR_URL".into(), url.clone());
         }
@@ -161,6 +169,10 @@ pub struct AgentOrchestrator {
     /// to re-register them on restart so the worker record + role prompt
     /// stay alive across respawns.
     broker: Arc<Mutex<super::local::BrokerState>>,
+    /// Propagated to spawned agents via `DISPATCH_CONFIG_PATH` so child
+    /// `dispatch` calls from any cwd in the agent tree resolve the same
+    /// config the orchestrator loaded.
+    config_file_path: Option<PathBuf>,
 }
 
 impl AgentOrchestrator {
@@ -173,6 +185,7 @@ impl AgentOrchestrator {
         log_dir: PathBuf,
         configs: Vec<ResolvedAgentConfig>,
         broker: Arc<Mutex<super::local::BrokerState>>,
+        config_file_path: Option<PathBuf>,
     ) -> Self {
         Self {
             agents: Vec::new(),
@@ -185,6 +198,7 @@ impl AgentOrchestrator {
             log_dir,
             configs,
             broker,
+            config_file_path,
         }
     }
 
@@ -313,6 +327,7 @@ impl AgentOrchestrator {
             monitor_url: self.monitor_url.clone(),
             agent_cwd: self.agent_cwd.clone(),
             log_dir: self.log_dir.clone(),
+            config_file_path: self.config_file_path.clone(),
         }
     }
 
@@ -1041,12 +1056,25 @@ pub fn build_agent_command(
     cell_id: &str,
     monitor_url: Option<&str>,
     worker_id: Option<&str>,
+    config_file_path: Option<&Path>,
 ) -> String {
-    let mut parts = vec![
-        format!("DISPATCH_CELL_ID={}", shell_escape(cell_id)),
-        format!("DISPATCH_AGENT_NAME={}", shell_escape(&config.name)),
-        format!("DISPATCH_AGENT_ROLE={}", shell_escape(&config.role)),
-    ];
+    let mut parts = vec![format!("DISPATCH_CELL_ID={}", shell_escape(cell_id))];
+
+    if let Some(path) = config_file_path {
+        parts.push(format!(
+            "DISPATCH_CONFIG_PATH={}",
+            shell_escape(&path.display().to_string())
+        ));
+    }
+
+    parts.push(format!(
+        "DISPATCH_AGENT_NAME={}",
+        shell_escape(&config.name)
+    ));
+    parts.push(format!(
+        "DISPATCH_AGENT_ROLE={}",
+        shell_escape(&config.role)
+    ));
 
     if let Some(url) = monitor_url {
         parts.push(format!("DISPATCH_MONITOR_URL={}", shell_escape(url)));
@@ -1134,6 +1162,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
         );
         let ctx = orch.snapshot_spawn_context();
 
@@ -1162,6 +1191,54 @@ mod tests {
             without_id.get("DISPATCH_AGENT_ROLE").map(String::as_str),
             Some("test-runner")
         );
+    }
+
+    /// `DISPATCH_CONFIG_PATH` is injected when the orchestrator carries a
+    /// config file path, so child `dispatch` calls from any cwd in the
+    /// agent tree resolve the same config.
+    #[test]
+    fn env_vars_includes_config_path_when_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        let orch = AgentOrchestrator::new(
+            "cell-x",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            Some(config_path.clone()),
+        );
+        let ctx = orch.snapshot_spawn_context();
+
+        let vars = ctx.env_vars("alice", "test-runner", None);
+        assert_eq!(
+            vars.get("DISPATCH_CONFIG_PATH").map(String::as_str),
+            Some(config_path.display().to_string().as_str())
+        );
+    }
+
+    /// When the orchestrator has no config file path (e.g. serve launched
+    /// outside a project), no `DISPATCH_CONFIG_PATH` env var is emitted
+    /// — regression guard for configs that don't opt into the feature.
+    #[test]
+    fn env_vars_absent_when_config_path_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let orch = AgentOrchestrator::new(
+            "cell-x",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
+        );
+        let ctx = orch.snapshot_spawn_context();
+
+        let vars = ctx.env_vars("alice", "test-runner", None);
+        assert!(!vars.contains_key("DISPATCH_CONFIG_PATH"));
     }
 
     /// Exponential doubling capped at 30s — table-driven so the intent is
@@ -1239,6 +1316,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
         let cfg = managed_test_config("alice", "sleep 30", prompt_path);
         orch.spawn_agent(&cfg).await.expect("spawn");
@@ -1274,6 +1352,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
         let mut cfg = test_config("bob", "sleep 30");
         cfg.launch = false; // explicitly unmanaged
@@ -1305,6 +1384,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
         let cfg = managed_test_config("alice", "sleep 30", tmp.path().join("does-not-exist.md"));
         let err = orch.spawn_agent(&cfg).await.expect_err("must fail");
@@ -1343,6 +1423,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
 
         // Force `spawn_agent` to fail and verify the broker is left with no
@@ -1398,6 +1479,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
         let mut cfg = managed_test_config("coordinator", "true", prompt_path);
         cfg.launch = false;
@@ -1441,6 +1523,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::clone(&broker),
+            None,
         );
         let mut cfg = test_config("bare", "true");
         cfg.launch = false;
@@ -1465,7 +1548,7 @@ mod tests {
     #[test]
     fn build_agent_command_includes_worker_id_when_some() {
         let cfg = test_config("alice", "echo hi");
-        let with_id = build_agent_command(&cfg, "cell-x", None, Some("w-123"));
+        let with_id = build_agent_command(&cfg, "cell-x", None, Some("w-123"), None);
         // shell_escape wraps the value in single quotes; assert on the
         // escaped form we'll actually see in the printed banner.
         assert!(
@@ -1473,10 +1556,31 @@ mod tests {
             "expected worker id in: {with_id}",
         );
 
-        let without_id = build_agent_command(&cfg, "cell-x", None, None);
+        let without_id = build_agent_command(&cfg, "cell-x", None, None, None);
         assert!(
             !without_id.contains("DISPATCH_WORKER_ID"),
             "legacy path must not emit worker id: {without_id}",
+        );
+    }
+
+    /// `build_agent_command` emits `DISPATCH_CONFIG_PATH=<shell-escaped>`
+    /// when a path is supplied, right alongside `DISPATCH_CELL_ID` so the
+    /// printed banner lets the pasted command resolve the same config from
+    /// any cwd. Unset → omitted, byte-identical to the previous banner.
+    #[test]
+    fn build_agent_command_includes_config_path_when_some() {
+        let cfg = test_config("alice", "echo hi");
+        let cfg_path = std::path::PathBuf::from("/tmp/ex/dispatch.config.toml");
+        let with_path = build_agent_command(&cfg, "cell-x", None, None, Some(cfg_path.as_path()));
+        assert!(
+            with_path.contains("DISPATCH_CONFIG_PATH='/tmp/ex/dispatch.config.toml'"),
+            "expected config path in: {with_path}"
+        );
+
+        let without = build_agent_command(&cfg, "cell-x", None, None, None);
+        assert!(
+            !without.contains("DISPATCH_CONFIG_PATH"),
+            "unset path must not appear: {without}"
         );
     }
 
@@ -1498,6 +1602,7 @@ mod tests {
             tmp.path().join("logs"),
             vec![bad_cfg],
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
         );
 
         // Build fails because the prompt file doesn't exist.
@@ -1531,6 +1636,7 @@ mod tests {
             tmp.path().join("logs"),
             vec![cfg.clone()],
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
         );
 
         // First reservation succeeds.
@@ -1591,6 +1697,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
         );
         let cfg = test_config("alice", "sleep 30");
         orch.spawn_agent(&cfg).await.expect("spawn");
@@ -1619,6 +1726,7 @@ mod tests {
             tmp.path().join("logs"),
             Vec::new(),
             Arc::new(Mutex::new(super::super::local::BrokerState::new())),
+            None,
         );
         let cfg = test_config("flaky", "exit 1");
         orch.spawn_agent(&cfg).await.expect("spawn");

--- a/src/backend/orchestrator.rs
+++ b/src/backend/orchestrator.rs
@@ -664,6 +664,75 @@ pub async fn build_pending_agent(
     })
 }
 
+/// Pre-register an unmanaged (`launch = false`) agent with a
+/// `prompt_file` so the copy-paste command printed at serve startup can
+/// use the same boot-prompt bootstrap as supervised agents. Returns
+/// `(worker_id, boot_prompt_path)`: the caller emits
+/// `DISPATCH_WORKER_ID=<id>` in the printed env and substitutes
+/// `boot_prompt_path` for `config.prompt_file_path` so the adapter's
+/// stdin redirect points at the one-line boot prompt instead of the full
+/// role prompt body.
+///
+/// No supervisor, no re-register hook, no spawn — this is only the
+/// broker-side setup. If the user waits longer than `ttl` to paste the
+/// command, the worker expires and the agent's `--for-agent` claim will
+/// fall through to the insert path with `role_prompt: None` (the same
+/// deterministic failure mode as a supervised agent whose TTL elapses
+/// during downtime). In practice the user pastes the command seconds
+/// after serve startup, so this is a non-issue; bumping `ttl` covers
+/// longer windows.
+pub async fn pre_register_unmanaged(
+    ctx: &SpawnContext,
+    config: &ResolvedAgentConfig,
+) -> Result<(String, PathBuf), DispatchError> {
+    let prompt_path =
+        config
+            .prompt_file_path
+            .as_ref()
+            .ok_or_else(|| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: "pre_register_unmanaged requires prompt_file_path".into(),
+            })?;
+    let prompt_content = tokio::fs::read_to_string(prompt_path).await.map_err(|_| {
+        DispatchError::PromptFileNotFound {
+            name: config.name.clone(),
+            path: prompt_path.clone(),
+        }
+    })?;
+
+    // Write boot prompt BEFORE register_worker so a write failure can't
+    // leave an orphan broker entry — same ordering invariant as the
+    // managed path in `build_pending_agent`.
+    let boot_path = write_boot_prompt(&ctx.log_dir, config).await.map_err(|e| {
+        DispatchError::AgentLaunchFailed {
+            name: config.name.clone(),
+            reason: format!("write boot prompt: {e}"),
+        }
+    })?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    {
+        let mut broker = ctx.broker.lock().await;
+        broker
+            .register_worker(
+                config.name.clone(),
+                config.role.clone(),
+                config.description.clone(),
+                Vec::new(),
+                config.ttl,
+                true, // evict any stale same-name worker from a prior session
+                Some(id.clone()),
+                Some(prompt_content),
+            )
+            .map_err(|e| DispatchError::AgentLaunchFailed {
+                name: config.name.clone(),
+                reason: format!("pre-register failed: {e}"),
+            })?;
+    }
+
+    Ok((id, boot_path))
+}
+
 /// Write the issue-#43 one-line boot prompt to a stable per-agent file
 /// under the log dir. The boot prompt forces the model's first observable
 /// action to be a real `dispatch register --for-agent` tool call, which
@@ -953,17 +1022,24 @@ async fn supervise_agent(
 /// Build an agent command string for the user to paste.
 ///
 /// Includes the dispatch env vars (shell-escaped) and the adapter-assembled
-/// launch string. Used by the monitor dashboard's sidebar and by the
-/// serve-time "Unmanaged agents" banner — both are copy-paste paths where
-/// the agent runs its own `dispatch register` and receives a broker-assigned
-/// id. The managed-spawn flow (issue #43, `launch = true` + `prompt_file`)
-/// goes through `build_pending_agent` / `spawn_child_process`, which assembles
-/// the command via `build_launch` directly and injects `DISPATCH_WORKER_ID`
-/// via the env snapshot rather than the command string.
+/// launch string. When `worker_id` is `Some`, emits
+/// `DISPATCH_WORKER_ID=<id>` so the agent's first
+/// `dispatch register --for-agent` call idempotently claims a worker
+/// pre-registered via `pre_register_unmanaged` and retrieves its stored
+/// role prompt. When `None`, the legacy unmanaged path applies: the
+/// agent calls `dispatch register` without a supplied id and gets a
+/// broker-assigned one back.
+///
+/// Used by the monitor dashboard's sidebar and by the serve-time
+/// "Unmanaged agents" banner. The managed-spawn flow (`launch = true` +
+/// `prompt_file`) goes through `build_pending_agent` /
+/// `spawn_child_process`, which assembles the argv directly and injects
+/// `DISPATCH_WORKER_ID` via the env snapshot rather than this helper.
 pub fn build_agent_command(
     config: &ResolvedAgentConfig,
     cell_id: &str,
     monitor_url: Option<&str>,
+    worker_id: Option<&str>,
 ) -> String {
     let mut parts = vec![
         format!("DISPATCH_CELL_ID={}", shell_escape(cell_id)),
@@ -973,6 +1049,10 @@ pub fn build_agent_command(
 
     if let Some(url) = monitor_url {
         parts.push(format!("DISPATCH_MONITOR_URL={}", shell_escape(url)));
+    }
+
+    if let Some(id) = worker_id {
+        parts.push(format!("DISPATCH_WORKER_ID={}", shell_escape(id)));
     }
 
     let cmd_str = AgentOrchestrator::build_launch(config)
@@ -1004,36 +1084,6 @@ fn launch_to_shell_string(launch: &Launch) -> String {
         ));
     }
     s
-}
-
-/// Build the main agent command string for the user to paste.
-pub fn build_main_agent_command(
-    main: &crate::config::MainAgentConfig,
-    cell_id: &str,
-    monitor_url: Option<&str>,
-) -> String {
-    let mut parts = vec![format!("DISPATCH_CELL_ID={}", shell_escape(cell_id))];
-
-    if let Some(url) = monitor_url {
-        parts.push(format!("DISPATCH_MONITOR_URL={}", shell_escape(url)));
-    }
-
-    let mut cmd = main.command.clone();
-
-    if let Some(ref model) = main.model {
-        cmd.push_str(&format!(" --model {model}"));
-    }
-
-    if let Some(ref prompt_file) = main.prompt_file {
-        // Tell the agent to read the prompt file rather than inlining it.
-        let msg = format!("Read and follow the instructions in {prompt_file}");
-        cmd.push_str(&format!(" {}", shell_escape(&msg)));
-    } else if let Some(ref prompt) = main.prompt {
-        cmd.push_str(&format!(" {}", shell_escape(prompt)));
-    }
-
-    parts.push(cmd);
-    parts.join(" ")
 }
 
 /// Whether `s` is safe to use as a single filename component on disk and as
@@ -1321,6 +1371,109 @@ mod tests {
         assert!(
             b.notifiers.is_empty(),
             "spawn failure must not leave an orphan notifier",
+        );
+    }
+
+    /// Issue #45: `pre_register_unmanaged` mirrors the managed-agent
+    /// pre-register flow without spawning. The unmanaged serve-time banner
+    /// calls this so the printed copy-paste command can include a
+    /// `DISPATCH_WORKER_ID` that the agent's first
+    /// `dispatch register --for-agent` call can idempotently claim.
+    #[tokio::test]
+    async fn pre_register_unmanaged_stores_worker_and_role_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prompt_path = tmp.path().join("coord.md");
+        let prompt_body = "Run: dispatch listen --timeout 270\nCoordinator instructions.";
+        tokio::fs::write(&prompt_path, prompt_body).await.unwrap();
+
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+        let mut cfg = managed_test_config("coordinator", "true", prompt_path);
+        cfg.launch = false;
+
+        let ctx = orch.snapshot_spawn_context();
+        let (worker_id, boot_path) = pre_register_unmanaged(&ctx, &cfg)
+            .await
+            .expect("pre_register_unmanaged must succeed");
+
+        let b = broker.lock().await;
+        assert_eq!(b.workers.len(), 1);
+        let worker = b
+            .workers
+            .get(&worker_id)
+            .expect("worker must be stored under returned id");
+        assert_eq!(worker.name, "coordinator");
+        assert_eq!(worker.role, "test-runner");
+        assert_eq!(
+            b.role_prompts.get(&worker_id).map(String::as_str),
+            Some(prompt_body),
+        );
+        assert!(
+            boot_path.exists(),
+            "boot prompt file must be written: {}",
+            boot_path.display()
+        );
+    }
+
+    /// Issue #45: `pre_register_unmanaged` refuses a config without a
+    /// `prompt_file_path` — the caller should only reach this path for
+    /// unmanaged agents that actually need the boot-prompt bootstrap.
+    #[tokio::test]
+    async fn pre_register_unmanaged_rejects_config_without_prompt_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let broker = Arc::new(Mutex::new(super::super::local::BrokerState::new()));
+        let orch = AgentOrchestrator::new(
+            "test-cell",
+            &tmp.path().join("broker.sock"),
+            None,
+            tmp.path(),
+            tmp.path().join("logs"),
+            Vec::new(),
+            Arc::clone(&broker),
+        );
+        let mut cfg = test_config("bare", "true");
+        cfg.launch = false;
+
+        let ctx = orch.snapshot_spawn_context();
+        let err = pre_register_unmanaged(&ctx, &cfg)
+            .await
+            .expect_err("must fail without prompt_file_path");
+        assert!(
+            matches!(err, DispatchError::AgentLaunchFailed { .. }),
+            "expected AgentLaunchFailed, got: {err:?}",
+        );
+        assert!(
+            broker.lock().await.workers.is_empty(),
+            "failed pre-register must not leave a worker behind",
+        );
+    }
+
+    /// Issue #45: `build_agent_command` emits `DISPATCH_WORKER_ID=<id>`
+    /// only when the id is supplied — the legacy bare-register path
+    /// (no prompt_file → no pre-register) keeps its previous output.
+    #[test]
+    fn build_agent_command_includes_worker_id_when_some() {
+        let cfg = test_config("alice", "echo hi");
+        let with_id = build_agent_command(&cfg, "cell-x", None, Some("w-123"));
+        // shell_escape wraps the value in single quotes; assert on the
+        // escaped form we'll actually see in the printed banner.
+        assert!(
+            with_id.contains("DISPATCH_WORKER_ID='w-123'"),
+            "expected worker id in: {with_id}",
+        );
+
+        let without_id = build_agent_command(&cfg, "cell-x", None, None);
+        assert!(
+            !without_id.contains("DISPATCH_WORKER_ID"),
+            "legacy path must not emit worker id: {without_id}",
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,10 @@ Exit codes:
 Docs: https://github.com/codesoda/dispatch"
 )]
 pub struct Cli {
-    /// Path to dispatch.config.toml (default: ./dispatch.config.toml)
+    /// Path to dispatch.config.toml (default: ./dispatch.config.toml).
+    /// Falls back to the `DISPATCH_CONFIG_PATH` env var when unset — the
+    /// orchestrator injects that var into spawned agents so child
+    /// `dispatch` calls resolve the same config from any cwd.
     #[arg(long, global = true)]
     pub config: Option<std::path::PathBuf>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,10 +41,6 @@ pub enum Commands {
         /// Start an HTTP monitor dashboard on this port
         #[arg(long)]
         monitor: Option<u16>,
-
-        /// Auto-launch configured agents (default: print commands only)
-        #[arg(long)]
-        launch: bool,
     },
 
     /// Register a worker with the broker

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,11 @@ pub struct ResolvedAgentConfig {
     pub stream_json: bool,
     /// Whether `dispatch serve` should auto-launch and supervise this agent.
     pub launch: bool,
+    /// When true, the adapter omits its headless flag (`-p` for claude,
+    /// `exec` for codex) so the agent opens in REPL / interactive mode.
+    /// Mutually exclusive with `launch = true` (an interactive REPL can't
+    /// be supervised); when both are set, `launch` wins with a warning.
+    pub interactive: bool,
 }
 
 /// On-disk config file shape.
@@ -137,6 +142,12 @@ pub struct AgentConfig {
     /// in the log. Default off so logs stay quiet for normal use.
     #[serde(default)]
     pub stream_json: bool,
+    /// When true, the adapter omits its headless flag (`-p` for claude,
+    /// `exec` for codex) so the agent opens in REPL / interactive mode.
+    /// Mutually exclusive with `launch = true`; resolution emits a warning
+    /// and falls back to non-interactive + launch when both are set.
+    #[serde(default)]
+    pub interactive: bool,
 }
 
 /// Resolve an agent config by reading prompt_file if specified and validating
@@ -209,6 +220,23 @@ fn resolve_agent_config(
         (None, None) => (None, None),
     };
 
+    // An interactive REPL can't run under the supervisor — the supervisor
+    // owns stdin/stdout and the whole point of interactive mode is a TTY.
+    // Rather than fail the whole config, warn loudly and keep `launch = true`
+    // (the more useful default for an auto-start workflow). The user's
+    // original intent — "run this agent interactively" — would have
+    // required them to drop `launch = true` anyway.
+    let interactive = if agent.interactive && agent.launch {
+        eprintln!(
+            "dispatch: warning: agent '{}' has both `interactive = true` and `launch = true`; \
+             these are mutually exclusive — keeping `launch = true` (headless) and ignoring `interactive`.",
+            agent.name
+        );
+        false
+    } else {
+        agent.interactive
+    };
+
     Ok(ResolvedAgentConfig {
         name: agent.name.clone(),
         role: agent.role.clone(),
@@ -221,6 +249,7 @@ fn resolve_agent_config(
         ttl: agent.ttl,
         stream_json: agent.stream_json,
         launch: agent.launch,
+        interactive,
     })
 }
 
@@ -330,6 +359,12 @@ const CONFIG_TEMPLATE: &str = "\
 # extra_args = [\"--dangerously-skip-permissions\", \"--model\", \"sonnet\"]
 # prompt_file = \"prompts/coordinator.md\"
 # launch = false
+# interactive = true                            # drops the headless flag
+#                                                # (`-p` for claude, `exec` for
+#                                                # codex) so the printed
+#                                                # copy-paste command opens the
+#                                                # vendor CLI's REPL. Mutually
+#                                                # exclusive with launch = true.
 # ttl = 7200
 
 # Scheduled heartbeats — commands run on a timer while the broker is running
@@ -854,6 +889,96 @@ command = "./run.sh"
             msg.contains("alice/foo") && msg.contains("ASCII"),
             "expected safe-name rejection for 'alice/foo', got: {msg}"
         );
+    }
+
+    /// `interactive = true` on a `launch = false` agent round-trips
+    /// through TOML unchanged. The adapter uses this to drop `-p` (claude)
+    /// / `exec` (codex) so the printed copy-paste command opens the vendor
+    /// CLI in its REPL instead of headless mode.
+    #[test]
+    fn agent_config_parses_interactive_flag() {
+        let tmp = TempDir::new().unwrap();
+        let prompt_path = tmp.path().join("coord.md");
+        fs::write(&prompt_path, "you are the coordinator").unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "coordinator"
+role = "coordinator"
+description = "the human-run coordinator"
+adapter = "claude"
+prompt_file = "coord.md"
+launch = false
+interactive = true
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        assert_eq!(resolved.agents.len(), 1);
+        let a = &resolved.agents[0];
+        assert!(a.interactive, "interactive = true must round-trip");
+        assert!(!a.launch);
+    }
+
+    /// `interactive = true + launch = true` is contradictory (the
+    /// supervisor owns stdin/stdout, so there's no TTY for a REPL). We
+    /// warn and prefer `launch = true` (headless), keeping the config
+    /// loadable rather than forcing a hard failure that would strand a
+    /// user who typed the wrong combo.
+    #[test]
+    fn agent_config_warns_and_prefers_launch_when_both_set() {
+        let tmp = TempDir::new().unwrap();
+        let prompt_path = tmp.path().join("r.md");
+        fs::write(&prompt_path, "role").unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "reviewer"
+role = "reviewer"
+description = "reviews"
+adapter = "claude"
+prompt_file = "r.md"
+launch = true
+interactive = true
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        let a = &resolved.agents[0];
+        assert!(a.launch, "launch must win when both are set");
+        assert!(
+            !a.interactive,
+            "interactive must be forced off when launch is on",
+        );
+    }
+
+    /// `interactive` defaults to false so existing configs see no
+    /// behavior change after the new field is introduced.
+    #[test]
+    fn agent_config_interactive_defaults_false() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[agents]]
+name = "worker"
+role = "worker"
+description = "d"
+adapter = "command"
+command = "./run.sh"
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        assert!(!resolved.agents[0].interactive);
     }
 
     /// Issue #45: `[main_agent]` has been removed in favor of a regular

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,8 +28,6 @@ pub struct ResolvedConfig {
     pub default_ttl: Option<u64>,
     /// Agent definitions to launch on serve.
     pub agents: Vec<ResolvedAgentConfig>,
-    /// Main interactive agent (printed as a command, not auto-launched).
-    pub main_agent: Option<MainAgentConfig>,
     /// Scheduled heartbeat commands.
     pub heartbeats: Vec<HeartbeatConfig>,
 }
@@ -80,8 +78,6 @@ pub struct ConfigFile {
     /// Agent definitions to launch on serve.
     #[serde(default)]
     pub agents: Vec<AgentConfig>,
-    /// Main interactive agent configuration.
-    pub main_agent: Option<MainAgentConfig>,
     /// Scheduled heartbeat commands.
     #[serde(default)]
     pub heartbeats: Vec<HeartbeatConfig>,
@@ -139,16 +135,6 @@ pub struct AgentConfig {
     /// in the log. Default off so logs stay quiet for normal use.
     #[serde(default)]
     pub stream_json: bool,
-}
-
-/// On-disk main agent definition.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct MainAgentConfig {
-    pub command: String,
-    pub model: Option<String>,
-    pub prompt: Option<String>,
-    pub prompt_file: Option<String>,
 }
 
 /// Resolve an agent config by reading prompt_file if specified and validating
@@ -327,11 +313,22 @@ const CONFIG_TEMPLATE: &str = "\
 # command = \"scripts/worker.sh --verbose\"
 # launch = true
 
-# Main interactive agent — printed as a ready-to-paste command
-# [main_agent]
-# command = \"claude\"
-# model = \"opus\"
-# prompt = \"You are the lead agent for this project...\"
+# Interactive coordinator agent — printed as a ready-to-paste command at
+# serve startup. `launch = false` (the default) keeps the orchestrator out
+# of its lifecycle; you run it yourself in a terminal. If a `prompt_file`
+# is set, dispatch pre-registers a worker server-side and the printed
+# command uses the issue-#43 boot-prompt bootstrap — the agent's first
+# tool call is `dispatch register --for-agent`, which returns the prompt
+# body from the broker rather than embedding it in a multi-kB shell string.
+# [[agents]]
+# name = \"coordinator\"
+# role = \"coordinator\"
+# description = \"Coordinates chat between the user and other agents\"
+# adapter = \"claude\"
+# extra_args = [\"--dangerously-skip-permissions\", \"--model\", \"sonnet\"]
+# prompt_file = \"prompts/coordinator.md\"
+# launch = false
+# ttl = 7200
 
 # Scheduled heartbeats — commands run on a timer while the broker is running
 # [[heartbeats]]
@@ -406,28 +403,19 @@ fn resolve_config_inner(
     };
 
     // Extract fields from config file
-    let (
-        name,
-        backend,
-        default_ttl,
-        config_cwd,
-        monitor_config,
-        raw_agents,
-        main_agent_config,
-        heartbeats,
-    ) = match config_file {
-        Some(c) => (
-            c.name,
-            c.backend,
-            c.default_ttl,
-            c.cwd,
-            c.monitor,
-            c.agents,
-            c.main_agent,
-            c.heartbeats,
-        ),
-        None => (None, None, None, None, None, vec![], None, vec![]),
-    };
+    let (name, backend, default_ttl, config_cwd, monitor_config, raw_agents, heartbeats) =
+        match config_file {
+            Some(c) => (
+                c.name,
+                c.backend,
+                c.default_ttl,
+                c.cwd,
+                c.monitor,
+                c.agents,
+                c.heartbeats,
+            ),
+            None => (None, None, None, None, None, vec![], vec![]),
+        };
 
     // Resolve agent working directory: config cwd (relative to project_root) or project_root
     let agent_cwd = if let Some(ref cwd_path) = config_cwd {
@@ -445,28 +433,6 @@ fn resolve_config_inner(
         .map(|a| resolve_agent_config(a, &project_root))
         .collect::<Result<_, _>>()?;
 
-    // Validate main agent config (check prompt_file exists if specified, but don't read it).
-    let main_agent = if let Some(ref ma) = main_agent_config {
-        if ma.prompt.is_some() && ma.prompt_file.is_some() {
-            return Err(DispatchError::AgentConfigError {
-                name: "main_agent".into(),
-                reason: "cannot specify both 'prompt' and 'prompt_file'".into(),
-            });
-        }
-        if let Some(ref path) = ma.prompt_file {
-            let full_path = project_root.join(path);
-            if !full_path.exists() {
-                return Err(DispatchError::PromptFileNotFound {
-                    name: "main_agent".into(),
-                    path: full_path,
-                });
-            }
-        }
-        Some(ma.clone())
-    } else {
-        None
-    };
-
     Ok(ResolvedConfig {
         name,
         cell_id,
@@ -477,7 +443,6 @@ fn resolve_config_inner(
         monitor_open,
         default_ttl,
         agents,
-        main_agent,
         heartbeats,
     })
 }
@@ -886,6 +851,33 @@ command = "./run.sh"
         assert!(
             msg.contains("alice/foo") && msg.contains("ASCII"),
             "expected safe-name rejection for 'alice/foo', got: {msg}"
+        );
+    }
+
+    /// Issue #45: `[main_agent]` has been removed in favor of a regular
+    /// `[[agents]] launch = false + prompt_file` entry. `ConfigFile`'s
+    /// `deny_unknown_fields` means a legacy config with `[main_agent]`
+    /// fails parse with a clear pointer rather than silently ignoring
+    /// the section.
+    #[test]
+    fn config_rejects_legacy_main_agent_table() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[main_agent]
+command = "claude"
+model = "opus"
+"#,
+        )
+        .unwrap();
+
+        let err = resolve_config_inner(None, None, None, tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("main_agent"),
+            "expected error to reference main_agent, got: {msg}"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,9 @@ pub struct AgentConfig {
     pub prompt: Option<String>,
     pub prompt_file: Option<String>,
     pub ttl: Option<u64>,
-    /// Whether `dispatch serve --launch` should auto-start this agent.
+    /// Whether `dispatch serve` should auto-start this agent under the
+    /// supervisor. `false` (the default) prints a copy-paste command at
+    /// startup instead so you can run the agent yourself.
     #[serde(default)]
     pub launch: bool,
     /// Issue #43: when true, the claude adapter is launched with
@@ -276,7 +278,7 @@ const CONFIG_TEMPLATE: &str = "\
 # port = 8384
 # open = true  # open the dashboard in your default browser
 
-# Agent definitions — auto-started by `dispatch serve --launch` when launch = true.
+# Agent definitions — auto-started by `dispatch serve` when launch = true.
 #
 # When `launch = true` AND `prompt_file` is set (the managed-agent flow),
 # dispatch pre-registers the worker server-side at spawn time, injects
@@ -828,7 +830,7 @@ adapter = "gpt"
 
     /// Agent names must pass `is_safe_name` at resolve time so the
     /// boot-prompt filename (derived via lossy `sanitize_name`) cannot
-    /// collide across distinct raw names under `dispatch serve --launch`.
+    /// collide across distinct raw names under `dispatch serve`.
     #[test]
     fn agent_config_rejects_name_with_unsafe_characters() {
         let tmp = TempDir::new().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,11 @@ pub struct ResolvedConfig {
     pub backend: Option<String>,
     /// The project root (directory containing dispatch.config.toml, or cwd).
     pub project_root: PathBuf,
+    /// Absolute path of the `dispatch.config.toml` that produced this
+    /// resolution, or `None` when no config file was found. Propagated to
+    /// spawned agents via `DISPATCH_CONFIG_PATH` so child `dispatch` calls
+    /// resolve the same config even when their cwd doesn't contain it.
+    pub config_file_path: Option<PathBuf>,
     /// Working directory for agents. Defaults to project_root, overridden by `cwd` in config.
     pub agent_cwd: PathBuf,
     /// Monitor dashboard port (from config or CLI flag).
@@ -403,7 +408,44 @@ pub fn resolve_config(
     cwd: &Path,
 ) -> Result<ResolvedConfig, DispatchError> {
     let env_cell_id = env::var("DISPATCH_CELL_ID").ok();
-    resolve_config_inner(cli_cell_id, env_cell_id.as_deref(), cli_config_path, cwd)
+    let env_config_path = env::var("DISPATCH_CONFIG_PATH").ok();
+    resolve_config_with_env(
+        cli_cell_id,
+        env_cell_id.as_deref(),
+        cli_config_path,
+        env_config_path.as_deref(),
+        cwd,
+    )
+}
+
+/// Env-parameterized entry point. Keeps `std::env::set_var` out of tests —
+/// see `hooks::resolve_socket_path_with_env` (src/hooks/mod.rs) for the
+/// same pattern.
+fn resolve_config_with_env(
+    cli_cell_id: Option<&str>,
+    env_cell_id: Option<&str>,
+    cli_config_path: Option<&Path>,
+    env_config_path: Option<&str>,
+    cwd: &Path,
+) -> Result<ResolvedConfig, DispatchError> {
+    // Treat an empty env value the same as unset (matches
+    // resolve_socket_path_with_env).  `cell_id` handling below does NOT
+    // currently filter empty; leaving that unchanged in this change to
+    // keep scope tight.
+    let env_config_path = env_config_path.filter(|s| !s.is_empty()).map(Path::new);
+    let effective_config_path = cli_config_path.or(env_config_path);
+    resolve_config_inner(cli_cell_id, env_cell_id, effective_config_path, cwd)
+}
+
+/// Absolutize `path` against `cwd` without touching the filesystem. Used as
+/// a fallback when `canonicalize()` fails on a path that nonetheless loaded
+/// successfully (rare — permissions on an ancestor dir).
+fn absolutize(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
 }
 
 fn resolve_config_inner(
@@ -413,15 +455,24 @@ fn resolve_config_inner(
     cwd: &Path,
 ) -> Result<ResolvedConfig, DispatchError> {
     // Locate config: explicit --config path, or dispatch.config.toml in cwd.
-    let (config_file, project_root) = if let Some(path) = cli_config_path {
+    // Canonicalize only AFTER load succeeds so we never propagate a garbage
+    // relative path via DISPATCH_CONFIG_PATH. `project_root` stays derived
+    // from the raw (non-canonicalized) path so downstream path-joins match
+    // the pre-change behavior bit-for-bit (canonicalize resolves symlinks
+    // like `/var` → `/private/var` on macOS and would surprise callers).
+    let (config_file, project_root, config_file_path) = if let Some(path) = cli_config_path {
         let config = load_config_file(path)?;
+        let abs = path
+            .canonicalize()
+            .unwrap_or_else(|_| absolutize(cwd, path));
         let root = path.parent().unwrap_or(cwd).to_path_buf();
-        (Some(config), root)
+        (Some(config), root, Some(abs))
     } else if let Some((config_path, root)) = find_config_file(cwd) {
         let config = load_config_file(&config_path)?;
-        (Some(config), root)
+        let abs = config_path.canonicalize().unwrap_or(config_path);
+        (Some(config), root, Some(abs))
     } else {
-        (None, cwd.to_path_buf())
+        (None, cwd.to_path_buf(), None)
     };
 
     // Resolve cell_id with precedence: CLI > env > config > derived
@@ -475,6 +526,7 @@ fn resolve_config_inner(
         cell_id,
         backend,
         project_root,
+        config_file_path,
         agent_cwd,
         monitor_port,
         monitor_open,
@@ -1005,6 +1057,175 @@ model = "opus"
         assert!(
             msg.contains("main_agent"),
             "expected error to reference main_agent, got: {msg}"
+        );
+    }
+
+    /// `config_file_path` carries the discovered file path as an absolute
+    /// canonical path, so agents spawned by `dispatch serve` can propagate
+    /// it via `DISPATCH_CONFIG_PATH` regardless of their working directory.
+    #[test]
+    fn resolved_config_carries_path_when_discovered() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        let expected = config_path.canonicalize().unwrap();
+        assert_eq!(
+            resolved.config_file_path.as_deref(),
+            Some(expected.as_path())
+        );
+    }
+
+    /// Explicit `--config <path>` flow: the absolute path threads through
+    /// to `ResolvedConfig` so the injected env var points at the right file.
+    #[test]
+    fn resolved_config_carries_path_when_flag_given() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("other");
+        fs::create_dir(&config_dir).unwrap();
+        let config_path = config_dir.join("dispatch.config.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let resolved = resolve_config_inner(None, None, Some(&config_path), tmp.path()).unwrap();
+        let expected = config_path.canonicalize().unwrap();
+        assert_eq!(
+            resolved.config_file_path.as_deref(),
+            Some(expected.as_path())
+        );
+    }
+
+    /// Cwd without a config file: `config_file_path` stays `None` so the
+    /// orchestrator emits no `DISPATCH_CONFIG_PATH` env var (regression
+    /// guard — existing configs see byte-identical env).
+    #[test]
+    fn resolved_config_none_when_no_config_file() {
+        let tmp = TempDir::new().unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        assert!(resolved.config_file_path.is_none());
+    }
+
+    /// `DISPATCH_CONFIG_PATH` acts as a fallback to `--config`, mirroring how
+    /// `DISPATCH_SOCKET_PATH` already works for the broker socket.
+    #[test]
+    fn resolve_config_with_env_honors_dispatch_config_path() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("elsewhere");
+        fs::create_dir(&config_dir).unwrap();
+        let config_path = config_dir.join("dispatch.config.toml");
+        fs::write(&config_path, r#"cell_id = "from-env-path""#).unwrap();
+
+        let resolved = resolve_config_with_env(
+            None,
+            None,
+            None,
+            Some(config_path.to_str().unwrap()),
+            tmp.path(),
+        )
+        .unwrap();
+        assert_eq!(resolved.cell_id, "from-env-path");
+    }
+
+    /// CLI flag beats env var — matches the stated precedence order
+    /// (CLI > env > discovery) from the config docs.
+    #[test]
+    fn resolve_config_with_env_prefers_cli_flag_over_env() {
+        let tmp = TempDir::new().unwrap();
+        let cli_dir = tmp.path().join("cli");
+        fs::create_dir(&cli_dir).unwrap();
+        let cli_config = cli_dir.join("dispatch.config.toml");
+        fs::write(&cli_config, r#"cell_id = "from-cli""#).unwrap();
+
+        let env_dir = tmp.path().join("env");
+        fs::create_dir(&env_dir).unwrap();
+        let env_config = env_dir.join("dispatch.config.toml");
+        fs::write(&env_config, r#"cell_id = "from-env""#).unwrap();
+
+        let resolved = resolve_config_with_env(
+            None,
+            None,
+            Some(&cli_config),
+            Some(env_config.to_str().unwrap()),
+            tmp.path(),
+        )
+        .unwrap();
+        assert_eq!(resolved.cell_id, "from-cli");
+    }
+
+    /// Empty `DISPATCH_CONFIG_PATH` is treated as unset — matches the
+    /// `resolve_socket_path_with_env` idiom and avoids a hard error when
+    /// a parent shell exports the var blank.
+    #[test]
+    fn resolve_config_with_env_treats_empty_string_as_unset() {
+        let tmp = TempDir::new().unwrap();
+
+        let resolved = resolve_config_with_env(None, None, None, Some(""), tmp.path()).unwrap();
+        assert!(resolved.config_file_path.is_none());
+    }
+
+    /// `DISPATCH_CONFIG_PATH` pointing at a missing file errors out — same
+    /// failure mode as `--config nonexistent.toml`, documented as a
+    /// breaking-change surface.
+    #[test]
+    fn resolve_config_with_env_hard_errors_on_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist.toml");
+
+        let err = resolve_config_with_env(
+            None,
+            None,
+            None,
+            Some(missing.to_str().unwrap()),
+            tmp.path(),
+        )
+        .unwrap_err();
+        // ConfigNotFound — exactly what `--config <missing>` emits today.
+        assert!(
+            err.to_string().to_lowercase().contains("not found")
+                || err.to_string().to_lowercase().contains("no such"),
+            "expected not-found error, got: {err}"
+        );
+    }
+
+    /// Regression guard for the `absolutize` fallback: when canonicalize
+    /// fails (e.g. permission denied on an ancestor dir), we must still
+    /// produce an absolute path, not echo the raw relative input. The
+    /// fallback is what stands between `DISPATCH_CONFIG_PATH` and a
+    /// worthless value in rare failure modes.
+    #[test]
+    fn absolutize_joins_relative_paths_against_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let relative = Path::new("foo/bar.toml");
+        let joined = absolutize(tmp.path(), relative);
+        assert!(joined.is_absolute());
+        assert_eq!(joined, tmp.path().join("foo/bar.toml"));
+    }
+
+    /// `absolutize` leaves already-absolute paths untouched.
+    #[test]
+    fn absolutize_passes_absolute_paths_through() {
+        let tmp = TempDir::new().unwrap();
+        let already_abs = tmp.path().join("x.toml");
+        assert_eq!(absolutize(tmp.path(), &already_abs), already_abs);
+    }
+
+    /// Discovered path is always absolute — even a `TempDir` root (already
+    /// absolute) gets canonicalized to resolve `/tmp` → `/private/tmp` on
+    /// macOS, guaranteeing the stored path is what downstream code can
+    /// stat regardless of how the test env was configured.
+    #[test]
+    fn discovered_config_path_is_absolute() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("dispatch.config.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let resolved = resolve_config_inner(None, None, None, tmp.path()).unwrap();
+        let stored = resolved.config_file_path.expect("path must be set");
+        assert!(
+            stored.is_absolute(),
+            "discovered path must be absolute, got: {}",
+            stored.display()
         );
     }
 }

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -4,6 +4,22 @@
 //! is set in `<repo>/.codex/config.toml`. The Stop hook we register runs
 //! `dispatch codex-hook stop` which prints a block decision — keeping the
 //! agent alive for the next dispatch message.
+//!
+//! # Schema
+//!
+//! Codex (and claude) expects hooks wrapped in a top-level `"hooks"` object
+//! with categories as keys. Each category is an array of matcher blocks, and
+//! each matcher has an inner `"hooks"` array of actual command entries:
+//!
+//! ```json
+//! {"hooks": {"Stop": [{"hooks": [{"type":"command","command":"…","timeout":10}]}]}}
+//! ```
+//!
+//! We originally emitted a flatter `{"Stop":[{"command":["dispatch","codex-hook","stop"]}]}`
+//! which codex silently dropped — the `install` path below writes the nested
+//! shape matching what claude's vendor config uses, and `uninstall` /
+//! idempotency checks tolerate the legacy shape so an upgrade cleanup step
+//! (or re-running `install`) rewrites old files in place.
 
 use std::path::{Path, PathBuf};
 
@@ -11,7 +27,11 @@ use serde_json::{Map, Value};
 
 use crate::errors::DispatchError;
 
-const HOOK_COMMAND: [&str; 3] = ["dispatch", "codex-hook", "stop"];
+const HOOK_COMMAND: &str = "dispatch codex-hook stop";
+/// Stop hook timeout in seconds. The hook probes the broker socket
+/// (`PROBE_TIMEOUT = 250ms` in `hooks::mod`) so 10s is comfortably more
+/// headroom than we need.
+const HOOK_TIMEOUT_SECS: u64 = 10;
 
 /// Location of the hooks manifest relative to the project root.
 fn hooks_path(cwd: &Path) -> PathBuf {
@@ -24,12 +44,15 @@ fn config_path(cwd: &Path) -> PathBuf {
 }
 
 /// Merge the dispatch Stop hook into `.codex/hooks.json` (preserving any
-/// other Stop entries and any other top-level hook categories the user has
-/// registered) and enable `features.codex_hooks = true` in
-/// `.codex/config.toml`. Creates `.codex/` if it doesn't exist.
+/// other Stop entries and any other hook categories the user has registered)
+/// and enable `features.codex_hooks = true` in `.codex/config.toml`. Creates
+/// `.codex/` if it doesn't exist.
 ///
-/// Idempotent: re-running does not duplicate our Stop entry and does not
-/// duplicate the `codex_hooks = true` line.
+/// Idempotent: re-running does not duplicate our Stop entry. If a legacy
+/// flat-schema entry from an older dispatch install is present
+/// (`{"Stop":[{"command":["dispatch","codex-hook","stop"]}]}` written without
+/// the `hooks` wrapper), it's removed and replaced with the nested form so
+/// codex actually loads it.
 pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
     let codex_dir = cwd.join(".codex");
     tokio::fs::create_dir_all(&codex_dir).await?;
@@ -43,18 +66,42 @@ pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
             reason: "expected a JSON object at the top level".into(),
         })?;
 
-    let stop = obj
+    // Legacy cleanup: a pre-0.5.2 install wrote Stop entries at the top level
+    // (no `hooks` wrapper). Those are dead weight under the real codex
+    // schema, so strip them before we insert the correct shape.
+    if let Some(legacy_stop) = obj.get_mut("Stop").and_then(Value::as_array_mut) {
+        legacy_stop.retain(|e| !entry_is_legacy_dispatch_hook(e));
+        if legacy_stop.is_empty() {
+            obj.remove("Stop");
+        }
+    }
+
+    let hooks_obj = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| DispatchError::ConfigInvalid {
+            path: hooks_path.clone(),
+            reason: "expected \"hooks\" to be a JSON object".into(),
+        })?;
+
+    let stop_arr = hooks_obj
         .entry("Stop".to_string())
-        .or_insert_with(|| Value::Array(Vec::new()));
-    let stop_arr = stop
+        .or_insert_with(|| Value::Array(Vec::new()))
         .as_array_mut()
         .ok_or_else(|| DispatchError::ConfigInvalid {
             path: hooks_path.clone(),
-            reason: "expected \"Stop\" to be an array".into(),
+            reason: "expected \"hooks.Stop\" to be an array".into(),
         })?;
 
-    if !stop_arr.iter().any(entry_is_dispatch_hook) {
-        stop_arr.push(serde_json::json!({ "command": HOOK_COMMAND }));
+    if !stop_arr.iter().any(entry_has_dispatch_hook) {
+        stop_arr.push(serde_json::json!({
+            "hooks": [{
+                "type": "command",
+                "command": HOOK_COMMAND,
+                "timeout": HOOK_TIMEOUT_SECS,
+            }],
+        }));
     }
 
     tokio::fs::write(&hooks_path, serde_json::to_string_pretty(&root)? + "\n").await?;
@@ -73,11 +120,13 @@ pub async fn install(cwd: &Path) -> Result<PathBuf, DispatchError> {
     Ok(hooks_path)
 }
 
-/// Remove the dispatch Stop entry from `.codex/hooks.json`. If that leaves
-/// the Stop array empty, drop the key; if the file is empty afterwards,
-/// delete it. Leaves `config.toml` alone so the user can keep the feature
-/// flag enabled for their own hooks. Returns `Ok(None)` when nothing
-/// dispatch-owned was present.
+/// Remove the dispatch Stop entry from `.codex/hooks.json` — both from the
+/// real nested-schema location (`hooks.Stop[].hooks[]`) and from any legacy
+/// flat-schema location (`Stop[]`) left by a pre-0.5.2 install that codex
+/// couldn't load. If that leaves containers empty, collapse them on the way
+/// out; if the file is empty afterwards, delete it. Leaves `config.toml`
+/// alone so the user can keep the feature flag enabled for their own hooks.
+/// Returns `Ok(None)` when nothing dispatch-owned was present.
 pub async fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     let path = hooks_path(cwd);
     if !tokio_file_exists(&path).await {
@@ -88,16 +137,36 @@ pub async fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     let Some(obj) = root.as_object_mut() else {
         return Ok(None);
     };
-    let Some(stop) = obj.get_mut("Stop").and_then(Value::as_array_mut) else {
-        return Ok(None);
-    };
 
-    let before = stop.len();
-    stop.retain(|entry| !entry_is_dispatch_hook(entry));
-    let removed = stop.len() != before;
+    let mut removed = false;
 
-    if stop.is_empty() {
-        obj.remove("Stop");
+    // Nested-schema path (the one codex actually reads).
+    if let Some(hooks_obj) = obj.get_mut("hooks").and_then(Value::as_object_mut) {
+        if let Some(stop) = hooks_obj.get_mut("Stop").and_then(Value::as_array_mut) {
+            let before = stop.len();
+            stop.retain(|entry| !entry_has_dispatch_hook(entry));
+            if stop.len() != before {
+                removed = true;
+            }
+            if stop.is_empty() {
+                hooks_obj.remove("Stop");
+            }
+        }
+        if hooks_obj.is_empty() {
+            obj.remove("hooks");
+        }
+    }
+
+    // Legacy flat-schema path.
+    if let Some(stop) = obj.get_mut("Stop").and_then(Value::as_array_mut) {
+        let before = stop.len();
+        stop.retain(|entry| !entry_is_legacy_dispatch_hook(entry));
+        if stop.len() != before {
+            removed = true;
+        }
+        if stop.is_empty() {
+            obj.remove("Stop");
+        }
     }
 
     if !removed {
@@ -112,24 +181,32 @@ pub async fn uninstall(cwd: &Path) -> Result<Option<PathBuf>, DispatchError> {
     Ok(Some(path))
 }
 
-/// Whether a hook entry is the one dispatch owns. Tolerates alternate
-/// representations: `command` as an array (the shape we write) or as the
-/// single-string form some examples in codex docs use.
-fn entry_is_dispatch_hook(entry: &Value) -> bool {
+/// Whether a matcher block at `hooks.Stop[]` carries our inner command —
+/// `{"hooks": [{"type":"command","command":"dispatch codex-hook stop", ...}]}`.
+fn entry_has_dispatch_hook(entry: &Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|arr| {
+            arr.iter()
+                .any(|h| h.get("command").and_then(Value::as_str) == Some(HOOK_COMMAND))
+        })
+}
+
+/// Whether a top-level `Stop[]` entry is a legacy pre-0.5.2 dispatch entry:
+/// `{"command": ["dispatch","codex-hook","stop"]}` (or the string form
+/// `"dispatch codex-hook stop"`). Used by `install` to sweep old entries out
+/// before writing the nested form, and by `uninstall` for idempotent removal.
+fn entry_is_legacy_dispatch_hook(entry: &Value) -> bool {
     let Some(cmd) = entry.get("command") else {
         return false;
     };
     if let Some(arr) = cmd.as_array() {
-        if arr.len() != HOOK_COMMAND.len() {
-            return false;
-        }
-        return arr
-            .iter()
-            .zip(HOOK_COMMAND.iter())
-            .all(|(a, b)| a.as_str() == Some(*b));
+        let parts: Vec<_> = arr.iter().filter_map(Value::as_str).collect();
+        return parts.join(" ") == HOOK_COMMAND;
     }
     if let Some(s) = cmd.as_str() {
-        return s == HOOK_COMMAND.join(" ");
+        return s == HOOK_COMMAND;
     }
     false
 }
@@ -314,8 +391,29 @@ mod tests {
         assert_eq!(cfg.matches("codex_hooks").count(), 1);
     }
 
-    /// Pre-existing Stop entries (different command) and other top-level
-    /// hook categories must survive a dispatch install.
+    /// Fresh install writes the nested schema codex actually loads —
+    /// top-level `"hooks"` object, Stop matcher with inner `"hooks"` array
+    /// containing `type:"command"` and our command string.
+    #[tokio::test]
+    async fn install_writes_nested_schema() {
+        let dir = tempdir().unwrap();
+        install(dir.path()).await.unwrap();
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+
+        let stops = value["hooks"]["Stop"].as_array().expect("hooks.Stop array");
+        assert_eq!(stops.len(), 1);
+        let inner = stops[0]["hooks"].as_array().expect("inner hooks array");
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0]["type"], "command");
+        assert_eq!(inner[0]["command"], HOOK_COMMAND);
+        assert_eq!(inner[0]["timeout"], HOOK_TIMEOUT_SECS);
+    }
+
+    /// Pre-existing hooks in other categories and other Stop matchers must
+    /// survive a dispatch install.
     #[tokio::test]
     async fn install_preserves_unrelated_hook_entries() {
         let dir = tempdir().unwrap();
@@ -323,12 +421,14 @@ mod tests {
             .await
             .unwrap();
         let pre = serde_json::json!({
-            "PreCompact": [
-                { "command": ["echo", "user-hook"] }
-            ],
-            "Stop": [
-                { "command": ["echo", "existing-stop"] }
-            ]
+            "hooks": {
+                "PreToolUse": [
+                    { "hooks": [{ "type": "command", "command": "echo user-pre" }] }
+                ],
+                "Stop": [
+                    { "hooks": [{ "type": "command", "command": "echo existing-stop" }] }
+                ]
+            }
         });
         tokio::fs::write(
             dir.path().join(".codex/hooks.json"),
@@ -342,12 +442,15 @@ mod tests {
             .await
             .unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
-        // User's PreCompact hook intact.
-        assert_eq!(value["PreCompact"][0]["command"][0], "echo");
+        // User's PreToolUse hook intact.
+        assert_eq!(
+            value["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "echo user-pre"
+        );
         // User's existing Stop entry still present, ours appended.
-        let stops = value["Stop"].as_array().unwrap();
+        let stops = value["hooks"]["Stop"].as_array().unwrap();
         assert_eq!(stops.len(), 2);
-        assert!(stops.iter().any(entry_is_dispatch_hook));
+        assert!(stops.iter().any(entry_has_dispatch_hook));
     }
 
     #[tokio::test]
@@ -359,7 +462,78 @@ mod tests {
             .await
             .unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
-        assert_eq!(value["Stop"].as_array().unwrap().len(), 1);
+        assert_eq!(value["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    /// A legacy flat-schema entry left by pre-0.5.2 install should be
+    /// rewritten in place when `install` runs again: legacy entry removed,
+    /// nested entry added under `hooks.Stop`.
+    #[tokio::test]
+    async fn install_migrates_legacy_flat_schema() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        let legacy = serde_json::json!({
+            "Stop": [
+                { "command": ["dispatch", "codex-hook", "stop"] }
+            ]
+        });
+        tokio::fs::write(
+            dir.path().join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&legacy).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        install(dir.path()).await.unwrap();
+
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        // Legacy flat Stop removed (it was the only entry, so the key is gone).
+        assert!(value.get("Stop").is_none(), "legacy Stop should be gone");
+        // Nested shape present with our command.
+        let stops = value["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stops.len(), 1);
+        assert_eq!(stops[0]["hooks"][0]["command"].as_str(), Some(HOOK_COMMAND));
+    }
+
+    /// A legacy flat Stop entry from a different command (user-owned, not
+    /// dispatch) must be preserved through `install` — we only strip our
+    /// own legacy records.
+    #[tokio::test]
+    async fn install_keeps_legacy_stop_entries_from_other_owners() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        let pre = serde_json::json!({
+            "Stop": [
+                { "command": ["echo", "user-legacy-stop"] }
+            ]
+        });
+        tokio::fs::write(
+            dir.path().join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&pre).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        install(dir.path()).await.unwrap();
+
+        let content = tokio::fs::read_to_string(dir.path().join(".codex/hooks.json"))
+            .await
+            .unwrap();
+        let value: Value = serde_json::from_str(&content).unwrap();
+        // User's legacy entry still there.
+        let legacy = value["Stop"].as_array().expect("user legacy Stop survives");
+        assert_eq!(legacy.len(), 1);
+        assert_eq!(legacy[0]["command"][0], "echo");
+        // Ours is in the nested location.
+        let nested = value["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(nested.len(), 1);
     }
 
     #[tokio::test]
@@ -369,9 +543,11 @@ mod tests {
             .await
             .unwrap();
         let pre = serde_json::json!({
-            "Stop": [
-                { "command": ["echo", "user-stop"] }
-            ]
+            "hooks": {
+                "Stop": [
+                    { "hooks": [{ "type": "command", "command": "echo user-stop" }] }
+                ]
+            }
         });
         tokio::fs::write(
             dir.path().join(".codex/hooks.json"),
@@ -387,9 +563,37 @@ mod tests {
             .await
             .unwrap();
         let value: Value = serde_json::from_str(&content).unwrap();
-        let stops = value["Stop"].as_array().unwrap();
+        let stops = value["hooks"]["Stop"].as_array().unwrap();
         assert_eq!(stops.len(), 1);
-        assert_eq!(stops[0]["command"][0], "echo");
+        assert_eq!(stops[0]["hooks"][0]["command"], "echo user-stop");
+    }
+
+    /// Uninstall removes legacy flat-schema entries too, so a user upgrading
+    /// from pre-0.5.2 gets a clean file without having to hand-edit.
+    #[tokio::test]
+    async fn uninstall_removes_legacy_flat_entry() {
+        let dir = tempdir().unwrap();
+        tokio::fs::create_dir_all(dir.path().join(".codex"))
+            .await
+            .unwrap();
+        let legacy = serde_json::json!({
+            "Stop": [
+                { "command": ["dispatch", "codex-hook", "stop"] }
+            ]
+        });
+        tokio::fs::write(
+            dir.path().join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&legacy).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let removed = uninstall(dir.path()).await.unwrap();
+        assert!(removed.is_some(), "uninstall should report removal");
+        assert!(
+            !dir.path().join(".codex/hooks.json").exists(),
+            "file should be gone when nothing else is left",
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,13 +82,13 @@ async fn run(cli: Cli) -> Result<(), dispatch::errors::DispatchError> {
     tracing::debug!(cell_id = %config.cell_id, project_root = %config.project_root.display(), "resolved config");
 
     // Extract monitor port: CLI flag takes precedence over config.
-    let (monitor_port, launch_agents) = if let Commands::Serve { monitor, launch } = &cli.command {
-        (monitor.or(config.monitor_port), *launch)
+    let monitor_port = if let Commands::Serve { monitor } = &cli.command {
+        monitor.or(config.monitor_port)
     } else {
-        (None, false)
+        None
     };
 
-    let backend = create_backend(&config, monitor_port, launch_agents)?;
+    let backend = create_backend(&config, monitor_port)?;
 
     match cli.command {
         Commands::Serve { .. } => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -195,6 +195,17 @@ pub struct Worker {
     /// own field. Skipped when empty so older clients see the same shape.
     #[serde(default, skip_serializing_if = "VecDeque::is_empty")]
     pub status_history: VecDeque<StatusEntry>,
+    /// True once the worker has been "claimed" by an actual process:
+    /// either the agent ran `dispatch register` with the supplied id
+    /// (idempotent-claim path), sent a heartbeat, or reported a status.
+    /// False for freshly-inserted records — including the issue-#43
+    /// pre-register path where the orchestrator creates the worker
+    /// server-side before the agent starts. The monitor uses this to
+    /// distinguish "reserved, waiting for the agent to attach" from
+    /// "alive and reporting in." `#[serde(default)]` so responses from
+    /// older brokers (no field present) decode as `false`.
+    #[serde(default)]
+    pub claimed: bool,
 }
 
 /// The payload inside a successful response, varies by request type.
@@ -378,6 +389,7 @@ mod tests {
                     last_status: None,
                     last_status_at: None,
                     status_history: VecDeque::new(),
+                    claimed: false,
                 }],
             },
             ResponsePayload::HeartbeatAck {
@@ -436,6 +448,7 @@ mod tests {
             last_status: Some("waiting on review".into()),
             last_status_at: Some(110),
             status_history: history.clone(),
+            claimed: true,
         };
         let json = serde_json::to_string(&worker).unwrap();
         assert!(json.contains("status_history"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -946,3 +946,64 @@ fn stdout_is_json_stderr_is_empty_on_success() {
         "stderr should be empty on success, got: {stderr}"
     );
 }
+
+// ── Spawned-agent env propagation ─────────────────────────────────────
+
+/// Regression guard for the `DISPATCH_CONFIG_PATH` injection wire: a
+/// `launch = true` command-adapter agent must receive the env var pointing
+/// at the canonicalized config file path, so child `dispatch` calls from
+/// any cwd in the agent tree resolve the orchestrator's config rather than
+/// falling back to a cwd-derived `cell-<hash>`.
+#[test]
+fn serve_spawns_agent_with_dispatch_config_path_in_env() {
+    let dir = TempDir::new().unwrap();
+    let cell_id = "test-dispatch-config-path-env";
+
+    // Dump the DISPATCH_* env seen by the spawned agent to a sibling file,
+    // then sleep so the supervisor doesn't enter its restart loop and
+    // stomp on the file before we can read it.
+    let envfile = dir.path().join("agent.env");
+    let command = format!("env | grep ^DISPATCH_ > {} && sleep 60", envfile.display());
+    let config_path = dir.path().join("dispatch.config.toml");
+    let config = format!(
+        r#"
+[[agents]]
+name = "dumper"
+role = "worker"
+description = "dumps env"
+adapter = "command"
+command = {command:?}
+launch = true
+"#
+    );
+    std::fs::write(&config_path, config).unwrap();
+
+    let _broker = start_broker(&dir, cell_id);
+
+    // Poll up to ~5s for the env dump. The supervisor launches agents
+    // sequentially with a 500ms pause, so even on a cold machine the dump
+    // should land well under the budget.
+    let mut contents = String::new();
+    for _ in 0..100 {
+        if envfile.exists() {
+            contents = std::fs::read_to_string(&envfile).unwrap_or_default();
+            if !contents.is_empty() {
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    assert!(
+        !contents.is_empty(),
+        "agent env dump did not appear within 5s; file: {}",
+        envfile.display()
+    );
+
+    let expected = config_path.canonicalize().unwrap();
+    let needle = format!("DISPATCH_CONFIG_PATH={}", expected.display());
+    assert!(
+        contents.contains(&needle),
+        "env dump missing {needle:?}; got:\n{contents}"
+    );
+}


### PR DESCRIPTION
## Summary

- Deletes `[main_agent]` / `MainAgentConfig` — the schema was a pre-adapter-abstraction leftover that couldn't use `adapter`, `extra_args`, `role`, `description`, or the issue-#43 register-prompt-bootstrap flow. Any agent you want to run interactively is now just an `[[agents]]` entry with `launch = false`.
- Extends the issue-#43 bootstrap (introduced in #43, hardened in #44) to cover `launch = false + prompt_file` agents. At serve startup, dispatch pre-registers a worker server-side and prints a pasteable command that includes `DISPATCH_WORKER_ID=<uuid>` and redirects stdin from the one-line boot prompt. When you paste and run, the agent's first tool call is `dispatch register --for-agent`, which idempotently claims the pre-registered worker and returns the role prompt — same mechanism as supervised agents, just with you launching the process instead of the orchestrator.

## Why

Before: configs with a coordinator-style interactive agent had to choose between `[main_agent]` (can't use adapter abstraction, raw shell strings only) or `[[agents]] launch = false` (no bootstrap, full role prompt embedded in a multi-kB shell string printed at startup). Neither was good.

After: one schema, one bootstrap flow, two launch modes (supervisor vs. human) differentiated solely by `launch: bool`.

## Example banner

```
dispatch serve: ready. Unmanaged agents — run these in separate terminals:

  # coordinator (coordinator)
  DISPATCH_CELL_ID='seams' DISPATCH_AGENT_NAME='coordinator' DISPATCH_AGENT_ROLE='coordinator' \
    DISPATCH_WORKER_ID='11132e60-ae06-4116-8881-dc202aeba90f' \
    claude --dangerously-skip-permissions --model sonnet -p \
    < /path/to/logs/coordinator.boot.prompt
```

## Breaking change — migration

Configs using `[main_agent]` now fail parse under `deny_unknown_fields` with:

```
Error: invalid config at ...: TOML parse error at line N, column M
  | [main_agent]
  |  ^^^^^^^^^^
unknown field \`main_agent\`, expected one of \`name\`, \`cell_id\`, \`backend\`, \`cwd\`, \`default_ttl\`, \`monitor\`, \`agents\`, \`heartbeats\`
```

Migration: replace the `[main_agent]` table with a regular `[[agents]]` entry. Example:

```toml
# Before
[main_agent]
command = \"claude\"
model = \"opus\"
prompt_file = \"prompts/coordinator.md\"

# After
[[agents]]
name = \"coordinator\"
role = \"coordinator\"
description = \"Coordinates chat between the user and other agents\"
adapter = \"claude\"
extra_args = [\"--model\", \"opus\"]
prompt_file = \"prompts/coordinator.md\"
launch = false
ttl = 7200
```

## Changes

- `src/backend/orchestrator.rs` — add `pre_register_unmanaged(ctx, config) -> (worker_id, boot_path)`; restore `worker_id: Option<&str>` param on `build_agent_command`; delete `build_main_agent_command`.
- `src/config.rs` — delete `MainAgentConfig` struct + all resolution/validation; update init-config template with a commented unmanaged-coordinator example.
- `src/backend/local.rs` — collapse the "Unmanaged agents" + "main session" banners into a single loop that pre-registers each `launch = false + prompt_file` agent and renders the bootstrap command.
- `src/backend/monitor.rs` — delete `main_agent` field from `MonitorState` and `/api/agents` response.
- `src/backend/monitor.html` — delete `_isMain` JS branches (pinned slot, synthesized role, card-grid filter).

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` — all green (159 + 3 + 24 tests pass, +4 new regression tests).
- [x] New tests: `pre_register_unmanaged_stores_worker_and_role_prompt`, `pre_register_unmanaged_rejects_config_without_prompt_file`, `build_agent_command_includes_worker_id_when_some`, `config_rejects_legacy_main_agent_table`.
- [x] Manual smoke: `dispatch init` writes the new template; `dispatch serve` on a `launch = false + prompt_file` agent with `adapter = \"claude\"` prints `DISPATCH_WORKER_ID=<uuid> … claude [args] -p < <log_dir>/<name>.boot.prompt`; the boot prompt file contains the one-line `Run: dispatch register --worker-id … --for-agent` instruction; `dispatch team` shows the pre-registered worker immediately.
- [x] Manual migration smoke: a config with `[main_agent]` fails serve with the expected `unknown field` error and exit code 2.
- [ ] User-owned follow-up: migrate `~/projects/ai-barometer/.seams/dispatch.config.toml` off `[main_agent]`.

Related: #43 (original bootstrap), #44 (three-phase unlocked-spawn pattern this builds on).